### PR TITLE
Update TKP percent fields and DOCX formatting

### DIFF
--- a/core/static/core/css/site.css
+++ b/core/static/core/css/site.css
@@ -2598,6 +2598,32 @@ html.proposal-progress-cursor * {
   color: #6c757d;
 }
 
+#proposals-pane .proposal-inline-percent {
+  position: relative;
+}
+
+#proposals-pane .proposal-inline-percent input {
+  appearance: textfield;
+  -moz-appearance: textfield;
+  padding-right: 2rem;
+}
+
+#proposals-pane .proposal-inline-percent input::-webkit-outer-spin-button,
+#proposals-pane .proposal-inline-percent input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+#proposals-pane .proposal-inline-percent__suffix {
+  position: absolute;
+  top: 50%;
+  right: 0.75rem;
+  transform: translateY(-50%);
+  color: #6c757d;
+  pointer-events: none;
+  z-index: 2;
+}
+
 #proposals-pane .proposal-customer-meta-grid {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));

--- a/core/static/core/js/proposals-panels.js
+++ b/core/static/core/js/proposals-panels.js
@@ -1470,15 +1470,6 @@
         if (input.value) input.value = formatMoneyWithPrecision(input.value, precision);
       });
     });
-
-    var form = root.closest('form[data-proposal-form]') || root;
-    if (form.dataset.moneySubmitBound === '1') return;
-    form.dataset.moneySubmitBound = '1';
-    form.addEventListener('submit', function () {
-      form.querySelectorAll('.js-money-input').forEach(function (input) {
-        input.value = rawMoney(input.value);
-      });
-    });
   }
 
   function initProposalDateInput(input) {
@@ -5079,8 +5070,19 @@
       const finalWeeks = parseProposalDecimal(finalReportWeeksInput.value);
       if (preliminaryMonths === null || finalWeeks === null) return;
 
-      if (!force && String(preliminaryDateInput.value || '').trim() && String(finalDateInput.value || '').trim()) {
-        return;
+      const preliminaryDateValue = String(preliminaryDateInput.value || '').trim();
+      const finalDateValue = String(finalDateInput.value || '').trim();
+      if (!force) {
+        if (preliminaryDateValue && finalDateValue) {
+          return;
+        }
+        if (preliminaryDateValue && !finalDateValue) {
+          syncProposalFinalDateFromPreliminary();
+          return;
+        }
+        if (!preliminaryDateValue && finalDateValue) {
+          return;
+        }
       }
 
       const baseStartDate = getNearestMonday(addDays(new Date(), 14));

--- a/proposals_app/migrations/0034_seed_tkp_preliminary_variable.py
+++ b/proposals_app/migrations/0034_seed_tkp_preliminary_variable.py
@@ -20,8 +20,9 @@ def seed_tkp_preliminary_variable(apps, schema_editor):
 
 
 def remove_tkp_preliminary_variable(apps, schema_editor):
-    ProposalVariable = apps.get_model("proposals_app", "ProposalVariable")
-    ProposalVariable.objects.filter(key="{{tkp_preliminary}}").delete()
+    # Keep rollback safe: this migration may have been applied on a database
+    # where the variable already existed, so we must not delete pre-existing data.
+    return
 
 
 class Migration(migrations.Migration):

--- a/proposals_app/migrations/0035_seed_preliminary_payment_percentage_full_variable.py
+++ b/proposals_app/migrations/0035_seed_preliminary_payment_percentage_full_variable.py
@@ -1,0 +1,37 @@
+from django.db import migrations
+from django.db.models import Max
+
+
+def seed_preliminary_payment_percentage_full_variable(apps, schema_editor):
+    ProposalVariable = apps.get_model("proposals_app", "ProposalVariable")
+    if ProposalVariable.objects.filter(key="{{preliminary_payment_percentage_full}}").exists():
+        return
+
+    max_position = ProposalVariable.objects.aggregate(m=Max("position"))["m"] or 0
+    ProposalVariable.objects.create(
+        key="{{preliminary_payment_percentage_full}}",
+        description="Размер оплаты Предварительного отчёта в процентах (с учетом предоплаты)",
+        is_computed=True,
+        position=max_position + 1,
+        source_section="",
+        source_table="",
+        source_column="",
+    )
+
+
+def remove_preliminary_payment_percentage_full_variable(apps, schema_editor):
+    # Safe rollback: avoid deleting a variable that may have existed before this migration.
+    return
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("proposals_app", "0034_seed_tkp_preliminary_variable"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            seed_preliminary_payment_percentage_full_variable,
+            remove_preliminary_payment_percentage_full_variable,
+        ),
+    ]

--- a/proposals_app/templates/proposals_app/proposal_form_page.html
+++ b/proposals_app/templates/proposals_app/proposal_form_page.html
@@ -541,9 +541,9 @@
 
       <div class="col-4">
         <label class="form-label">{{ form.advance_percent.label }}</label>
-        <div class="input-group">
+        <div class="proposal-inline-percent">
           {{ form.advance_percent }}
-          <span class="input-group-text">%</span>
+          <span class="proposal-inline-percent__suffix" aria-hidden="true">%</span>
         </div>
       </div>
       <div class="col-4">
@@ -553,9 +553,9 @@
       <div class="w-100"></div>
       <div class="col-4">
         <label class="form-label">{{ form.preliminary_report_percent.label }}</label>
-        <div class="input-group">
+        <div class="proposal-inline-percent">
           {{ form.preliminary_report_percent }}
-          <span class="input-group-text">%</span>
+          <span class="proposal-inline-percent__suffix" aria-hidden="true">%</span>
         </div>
       </div>
       <div class="col-4">
@@ -566,9 +566,9 @@
 
       <div class="col-4">
         <label class="form-label">{{ form.final_report_percent.label }}</label>
-        <div class="input-group">
+        <div class="proposal-inline-percent">
           {{ form.final_report_percent }}
-          <span class="input-group-text">%</span>
+          <span class="proposal-inline-percent__suffix" aria-hidden="true">%</span>
         </div>
       </div>
       <div class="col-4">

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -116,6 +116,8 @@ class ProposalDocumentGenerationTests(TestCase):
             asset_owner_matches_customer=True,
             country=self.country,
             proposal_project_name='Due Diligence ООО "Приморское"',
+            advance_percent="50",
+            preliminary_report_percent="20",
             identifier="ОГРН",
             registration_number="1174910001683",
             proposal_workspace_disk_path="/Corporate Root/ТКП/2026/33330RU DD Приморское",
@@ -136,6 +138,7 @@ class ProposalDocumentGenerationTests(TestCase):
         template_doc.add_paragraph("Краткое название: {{service_type_short}}")
         template_doc.add_paragraph("Цель в родительном: {{service_goal_genitive}}")
         template_doc.add_paragraph("Титул ТКП: {{tkp_preliminary}}")
+        template_doc.add_paragraph("Предварительная оплата всего: {{preliminary_payment_percentage_full}}")
         template_doc.add_paragraph("Активы:")
         template_doc.add_paragraph("[[actives_name]]")
         buffer = BytesIO()
@@ -194,10 +197,16 @@ class ProposalDocumentGenerationTests(TestCase):
             position=6,
         )
         ProposalVariable.objects.create(
+            key="{{preliminary_payment_percentage_full}}",
+            description="Размер оплаты Предварительного отчёта в процентах (с учетом предоплаты)",
+            is_computed=True,
+            position=7,
+        )
+        ProposalVariable.objects.create(
             key="[[actives_name]]",
             description="Список наименований активов",
             is_computed=True,
-            position=7,
+            position=8,
         )
         ProposalAsset.objects.create(
             proposal=self.proposal,
@@ -256,6 +265,7 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertIn("Краткое название: Due Diligence", full_text)
         self.assertIn("Цель в родительном: Проведения due diligence", full_text)
         self.assertIn("Титул ТКП: (предварительное)", full_text)
+        self.assertIn("Предварительная оплата всего: 70", full_text)
         self.assertIn("Месторождение Приморское", full_text)
         self.assertIn("Фабрика Приморская", full_text)
         asset_paragraphs = [
@@ -1388,6 +1398,14 @@ class ProposalRegistrationFormTests(TestCase):
         self.assertTrue(form.is_valid(), form.errors)
         self.assertEqual(form.cleaned_data["final_report_term_weeks"], Decimal("2.5"))
 
+    def test_form_accepts_formatted_service_cost_without_js_raw_submit(self):
+        form = ProposalRegistrationForm(
+            data=self._base_form_payload(service_cost="1 250 000,50")
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["service_cost"], Decimal("1250000.50"))
+
     def test_invalid_bound_percent_does_not_raise_during_init(self):
         form = ProposalRegistrationForm(
             data={
@@ -1756,6 +1774,18 @@ class ProposalRegistrationFormTests(TestCase):
                 source_column="advance_percent",
             ),
             ProposalVariable(
+                key="{{preliminary_report_percent}}",
+                source_section="proposals",
+                source_table="registry",
+                source_column="preliminary_report_percent",
+            ),
+            ProposalVariable(
+                key="{{final_report_percent}}",
+                source_section="proposals",
+                source_table="registry",
+                source_column="final_report_percent",
+            ),
+            ProposalVariable(
                 key="{{currency}}",
                 source_section="proposals",
                 source_table="registry",
@@ -1800,6 +1830,10 @@ class ProposalRegistrationFormTests(TestCase):
                 is_computed=True,
             ),
             ProposalVariable(
+                key="{{preliminary_payment_percentage_full}}",
+                is_computed=True,
+            ),
+            ProposalVariable(
                 key="[[actives_name]]",
                 is_computed=True,
             ),
@@ -1821,7 +1855,9 @@ class ProposalRegistrationFormTests(TestCase):
         self.assertEqual(replacements["{{evaluation_date}}"], "01.04.2026")
         self.assertEqual(replacements["{{final_report_term_weeks}}"], "2,0")
         self.assertEqual(replacements["{{status}}"], "Предварительное")
-        self.assertEqual(replacements["{{advance_percent}}"], "50")
+        self.assertEqual(replacements["{{advance_percent}}"], "50%")
+        self.assertEqual(replacements["{{preliminary_report_percent}}"], "20%")
+        self.assertEqual(replacements["{{final_report_percent}}"], "30%")
         self.assertEqual(replacements["{{currency}}"], "RUB")
         self.assertEqual(replacements["{{country}}"], "Россия")
         self.assertEqual(replacements["{{registration_region}}"], "Тюменская область")
@@ -1832,6 +1868,7 @@ class ProposalRegistrationFormTests(TestCase):
         self.assertEqual(replacements["{{service_type_short}}"], "Due Diligence")
         self.assertEqual(replacements["{{service_goal_genitive}}"], "Подготовки коммерческого предложения")
         self.assertEqual(replacements["{{tkp_preliminary}}"], "(предварительное)")
+        self.assertEqual(replacements["{{preliminary_payment_percentage_full}}"], "70")
         self.assertEqual(replacements["{{owner_country_full_name}}"], "Российская Федерация")
         self.assertEqual(replacements["{{year}}"], "2026")
         self.assertEqual(replacements["{{day}}"], "09")
@@ -1912,6 +1949,15 @@ class ProposalRegistrationFormTests(TestCase):
             [ProposalVariable(key="{{tkp_preliminary}}", is_computed=True)],
         )
         self.assertEqual(replacements["{{tkp_preliminary}}"], "")
+
+    def test_resolve_preliminary_payment_percentage_full_sums_existing_percent_fields(self):
+        proposal = ProposalRegistration(advance_percent="50", preliminary_report_percent="20")
+
+        replacements, _ = resolve_variables(
+            proposal,
+            [ProposalVariable(key="{{preliminary_payment_percentage_full}}", is_computed=True)],
+        )
+        self.assertEqual(replacements["{{preliminary_payment_percentage_full}}"], "70")
 
     def test_form_saves_assets_from_payload(self):
         country = OKSMCountry.objects.create(

--- a/proposals_app/variable_resolver.py
+++ b/proposals_app/variable_resolver.py
@@ -180,6 +180,11 @@ def _format_decimal(value, precision=2, *, strip_trailing_zeros=False) -> str:
     return text
 
 
+def _format_percent(value, precision=2, *, strip_trailing_zeros=False) -> str:
+    text = _format_decimal(value, precision=precision, strip_trailing_zeros=strip_trailing_zeros)
+    return f"{text}%" if text else ""
+
+
 def _format_money(value) -> str:
     if value in (None, ""):
         return ""
@@ -264,7 +269,7 @@ def _proposal_currency(proposal) -> str:
 
 
 def _proposal_advance_percent(proposal) -> str:
-    return _format_decimal(proposal.advance_percent, strip_trailing_zeros=True)
+    return _format_percent(proposal.advance_percent, strip_trailing_zeros=True)
 
 
 def _proposal_advance_term_days(proposal) -> str:
@@ -272,7 +277,19 @@ def _proposal_advance_term_days(proposal) -> str:
 
 
 def _proposal_preliminary_report_percent(proposal) -> str:
-    return _format_decimal(proposal.preliminary_report_percent, strip_trailing_zeros=True)
+    return _format_percent(proposal.preliminary_report_percent, strip_trailing_zeros=True)
+
+
+def _proposal_preliminary_payment_percentage_full(proposal) -> str:
+    try:
+        advance = Decimal(str(getattr(proposal, "advance_percent", "") or "0"))
+    except (InvalidOperation, TypeError, ValueError):
+        advance = Decimal("0")
+    try:
+        preliminary = Decimal(str(getattr(proposal, "preliminary_report_percent", "") or "0"))
+    except (InvalidOperation, TypeError, ValueError):
+        preliminary = Decimal("0")
+    return _format_decimal(advance + preliminary, strip_trailing_zeros=True)
 
 
 def _proposal_preliminary_report_term_days(proposal) -> str:
@@ -280,7 +297,7 @@ def _proposal_preliminary_report_term_days(proposal) -> str:
 
 
 def _proposal_final_report_percent(proposal) -> str:
-    return _format_decimal(proposal.final_report_percent, strip_trailing_zeros=True)
+    return _format_percent(proposal.final_report_percent, strip_trailing_zeros=True)
 
 
 def _proposal_final_report_term_days(proposal) -> str:
@@ -352,6 +369,7 @@ COMPUTED_MAP = {
     "{{service_type_short}}": _proposal_service_type_short,
     "{{service_goal_genitive}}": _proposal_service_goal_genitive,
     "{{tkp_preliminary}}": _proposal_tkp_preliminary,
+    "{{preliminary_payment_percentage_full}}": _proposal_preliminary_payment_percentage_full,
     "{{owner_country_full_name}}": _proposal_asset_owner_country_full_name,
     "{{country_full_name}}": _proposal_country_full_name,
 }

--- a/worktime_app/tests.py
+++ b/worktime_app/tests.py
@@ -17,6 +17,8 @@ class WorktimeViewsTests(TestCase):
             username="worktime-user",
             password="secret",
             is_staff=True,
+            first_name="Иван",
+            last_name="Иванов",
         )
         self.client.force_login(self.user)
         self.employee = Employee.objects.create(user=self.user, patronymic="Иванович")
@@ -74,6 +76,33 @@ class WorktimeViewsTests(TestCase):
         self.assertNotContains(response, "Сотрудник")
         self.assertContains(response, ">8<", html=False)
         self.assertNotContains(response, ">5<", html=False)
+
+    def test_personal_partial_name_fallback_ignores_rows_linked_to_homonym(self):
+        Performer.objects.create(
+            registration=self.registration,
+            executor="Иванов Иван Иванович",
+            work_hours=3,
+        )
+        homonym_user = get_user_model().objects.create_user(
+            username="worktime-homonym-user",
+            password="secret",
+            first_name="Иван",
+            last_name="Иванов",
+        )
+        homonym_employee = Employee.objects.create(user=homonym_user, patronymic="Иванович")
+        homonym_performer = Performer.objects.create(
+            registration=self.registration,
+            executor="Иванов Иван Иванович",
+            work_hours=13,
+        )
+        Performer.objects.filter(pk=homonym_performer.pk).update(employee=homonym_employee)
+
+        response = self.client.get(reverse("personal_worktime_partial"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, ">8<", html=False)
+        self.assertContains(response, ">3<", html=False)
+        self.assertNotContains(response, ">13<", html=False)
 
     def test_edit_updates_work_hours_and_triggers_refresh(self):
         response = self.client.post(

--- a/worktime_app/views.py
+++ b/worktime_app/views.py
@@ -27,7 +27,7 @@ def _worktime_queryset(user, personal_only=False):
         employee = getattr(user, "employee_profile", None)
         employee_name = Performer.employee_full_name(employee)
         if employee_name:
-            filters |= Q(executor=employee_name)
+            filters |= Q(employee__isnull=True, executor=employee_name)
         items = items.filter(filters)
     return items
 


### PR DESCRIPTION
## Summary
- show percent sign inside TKP percent inputs in edit form
- remove separate percent addon next to those fields
- keep percent sign in DOCX variable replacements
## Test plan
- open TKP edit form and verify % is shown inside the three fields
- generate DOCX and verify percent fields are rendered with %