### PR TITLE
Refine proposal DOCX budget table formatting

### DIFF
--- a/contracts_app/docx_processor.py
+++ b/contracts_app/docx_processor.py
@@ -20,7 +20,7 @@ from docx import Document
 from docx.enum.table import WD_CELL_VERTICAL_ALIGNMENT, WD_TABLE_ALIGNMENT
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.oxml.ns import qn
-from docx.shared import Pt
+from docx.shared import Cm, Pt
 
 
 _PLACEHOLDER_RE = re.compile(r"\{\{[a-zA-Z][a-zA-Z0-9_]*\}\}")
@@ -284,17 +284,16 @@ def _set_font_property(r_pr, font_name: str | None) -> None:
 
 
 def _set_language_property(r_pr, language_code: str | None) -> None:
+    if not language_code:
+        return
     existing = r_pr.find(qn("w:lang"))
-    if language_code:
-        if existing is None:
-            from docx.oxml import OxmlElement
+    if existing is None:
+        from docx.oxml import OxmlElement
 
-            existing = OxmlElement("w:lang")
-            r_pr.append(existing)
-        for attr_name in ("val", "bidi", "eastAsia"):
-            existing.set(qn(f"w:{attr_name}"), language_code)
-    elif existing is not None:
-        r_pr.remove(existing)
+        existing = OxmlElement("w:lang")
+        r_pr.append(existing)
+    for attr_name in ("val", "bidi", "eastAsia"):
+        existing.set(qn(f"w:{attr_name}"), language_code)
 
 
 def _append_text_segments(run_element, text: str) -> None:
@@ -641,6 +640,9 @@ def _normalize_table_cell_spec(value) -> dict[str, object]:
             "rowspan": max(1, int(value.get("rowspan") or 1)),
             "bold": bool(value.get("bold")),
             "align": str(value.get("align") or "").strip().lower() or "left",
+            "header": bool(value.get("header")),
+            "vertical_align": str(value.get("vertical_align") or "").strip().lower() or "top",
+            "margins_cm": value.get("margins_cm") or {},
         }
     return {
         "text": str(value or ""),
@@ -648,6 +650,9 @@ def _normalize_table_cell_spec(value) -> dict[str, object]:
         "rowspan": 1,
         "bold": False,
         "align": "left",
+        "header": False,
+        "vertical_align": "top",
+        "margins_cm": {},
     }
 
 
@@ -689,7 +694,13 @@ def _apply_cell_text(cell, spec: dict[str, object], font_size_pt: int | float | 
     cell.text = ""
     paragraph = cell.paragraphs[0]
     paragraph.alignment = _table_alignment(str(spec.get("align") or "left"))
-    run = paragraph.add_run(str(spec.get("text") or ""))
+    paragraph.paragraph_format.space_before = Pt(0)
+    paragraph.paragraph_format.space_after = Pt(0)
+    text_parts = str(spec.get("text") or "").split("\n")
+    run = paragraph.add_run(text_parts[0] if text_parts else "")
+    for text_part in text_parts[1:]:
+        run.add_break()
+        run.add_text(text_part)
     if spec.get("bold"):
         run.bold = True
     if font_size_pt:
@@ -702,7 +713,34 @@ def _apply_cell_text(cell, spec: dict[str, object], font_size_pt: int | float | 
             r_pr = OxmlElement("w:rPr")
             run._element.insert(0, r_pr)
         _set_language_property(r_pr, language_code)
-    cell.vertical_alignment = WD_CELL_VERTICAL_ALIGNMENT.CENTER
+    vertical_align = str(spec.get("vertical_align") or "top").strip().lower()
+    cell.vertical_alignment = (
+        WD_CELL_VERTICAL_ALIGNMENT.CENTER
+        if vertical_align == "center"
+        else WD_CELL_VERTICAL_ALIGNMENT.TOP
+    )
+
+
+def _set_cell_margins(cell, *, top_cm=0, right_cm=0.1, bottom_cm=0, left_cm=0.1) -> None:
+    from docx.oxml import OxmlElement
+
+    tc_pr = cell._tc.get_or_add_tcPr()
+    tc_mar = tc_pr.find(qn("w:tcMar"))
+    if tc_mar is None:
+        tc_mar = OxmlElement("w:tcMar")
+        tc_pr.append(tc_mar)
+    for side, value_cm in (
+        ("top", top_cm),
+        ("right", right_cm),
+        ("bottom", bottom_cm),
+        ("left", left_cm),
+    ):
+        node = tc_mar.find(qn(f"w:{side}"))
+        if node is None:
+            node = OxmlElement(f"w:{side}")
+            tc_mar.append(node)
+        node.set(qn("w:w"), str(int(round(Cm(value_cm).twips))))
+        node.set(qn("w:type"), "dxa")
 
 
 def _set_table_autofit(table) -> None:
@@ -781,6 +819,14 @@ def _insert_table_after_paragraph(paragraph, table_spec: dict, language_code: st
                     occupied[rr][cc] = True
             if rowspan > 1 or colspan > 1:
                 start_cell = start_cell.merge(table.cell(row_idx + rowspan - 1, col_idx + colspan - 1))
+            margins = spec.get("margins_cm") if isinstance(spec, dict) else {}
+            _set_cell_margins(
+                start_cell,
+                top_cm=float((margins or {}).get("top", 0)),
+                right_cm=float((margins or {}).get("right", 0.1)),
+                bottom_cm=float((margins or {}).get("bottom", 0)),
+                left_cm=float((margins or {}).get("left", 0.1)),
+            )
             _apply_cell_text(start_cell, spec, font_size_pt, language_code)
             col_idx += colspan
 

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -15,6 +15,8 @@ from django.urls import reverse
 from django.utils import timezone
 
 from docx import Document
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
 
 from classifiers_app.models import BusinessEntityRecord, BusinessEntityIdentifierRecord, LegalEntityRecord, OKSMCountry, OKVCurrency
 from contacts_app.models import PersonRecord
@@ -377,23 +379,26 @@ class ProposalDocumentGenerationTests(TestCase):
             if any("Специалист" in cell.text for cell in table.rows[0].cells)
         )
         budget_rows = [[cell.text.strip() for cell in row.cells] for row in budget_table.rows]
-        self.assertIn("Месторождение Приморское", budget_rows[1])
-        self.assertIn("Фабрика Приморская", budget_rows[1])
-        self.assertIn("Иванов И.И.", budget_rows[2])
-        self.assertIn("Геолог, Партнер", budget_rows[2])
-        self.assertIn("6", budget_rows[2])
-        self.assertIn("7\u00a0200,00", budget_rows[2])
-        self.assertIn("Командировочные расходы", budget_rows[4][0])
-        self.assertIn("ИТОГО, по расчёту", budget_rows[5][0])
-        self.assertIn("10\u00a0400,00", budget_rows[5][-1])
-        self.assertIn("ИТОГО, рубли без НДС", budget_rows[6][0])
-        self.assertIn("96,5", budget_rows[6][2])
-        self.assertIn("1\u00a0003\u00a0600,00", budget_rows[6][-1])
-        self.assertIn("ИТОГО, рубли без НДС с учетом скидки", budget_rows[7][0])
-        self.assertIn("7,5%", budget_rows[7][2])
-        self.assertIn("928\u00a0330,00", budget_rows[7][-1])
-        self.assertIn("ИТОГО в договор, рубли без НДС с учётом дополнительной скидки", budget_rows[8][0])
-        self.assertIn("900\u00a0000,00", budget_rows[8][-1])
+        self.assertIn("Месторождение Приморское", budget_rows[0])
+        self.assertIn("Фабрика Приморская", budget_rows[0])
+        self.assertIn("Ставка,\n€/дн", budget_rows[0])
+        self.assertIn("Кол-во\nдней", budget_rows[0])
+        self.assertIn("Итого,\n€ без НДС", budget_rows[0])
+        self.assertIn("Иванов И.И.", budget_rows[1])
+        self.assertIn("Геолог, Партнер", budget_rows[1])
+        self.assertIn("6", budget_rows[1])
+        self.assertIn("7\u00a0200,00", budget_rows[1])
+        self.assertIn("Командировочные расходы", budget_rows[3][0])
+        self.assertIn("ИТОГО, по расчёту", budget_rows[4][0])
+        self.assertIn("10\u00a0400,00", budget_rows[4][-1])
+        self.assertIn("ИТОГО, рубли без НДС", budget_rows[5][0])
+        self.assertIn("96,5", budget_rows[5][2])
+        self.assertIn("1\u00a0003\u00a0600,00", budget_rows[5][-1])
+        self.assertIn("ИТОГО, рубли без НДС с учетом скидки", budget_rows[6][0])
+        self.assertIn("7,5%", budget_rows[6][2])
+        self.assertIn("928\u00a0330,00", budget_rows[6][-1])
+        self.assertIn("ИТОГО в договор, рубли без НДС с учётом доп. скидки", budget_rows[7][0])
+        self.assertIn("900\u00a0000,00", budget_rows[7][-1])
         self.assertIn('w:tblLayout w:type="autofit"', budget_table._tbl.xml)
         self.assertIn('w:tblW w:type="auto" w:w="0"', budget_table._tbl.xml)
         budget_run_sizes = [
@@ -405,7 +410,7 @@ class ProposalDocumentGenerationTests(TestCase):
             if run.text.strip()
         ]
         self.assertTrue(budget_run_sizes)
-        self.assertTrue(all(size == 8 for size in budget_run_sizes))
+        self.assertTrue(all(size == 7 for size in budget_run_sizes))
 
     @patch("ai_app.proposals_app.document_generation._get_cloud_upload_user")
     @patch("ai_app.proposals_app.document_generation.cloud_upload_file", return_value=True)
@@ -426,7 +431,7 @@ class ProposalDocumentGenerationTests(TestCase):
         mocked_cloud_upload.assert_called_once()
         self.assertEqual(mocked_cloud_upload.call_args.args[0], connected_user)
 
-    def test_scope_of_work_plain_list_key_strips_rich_list_markers(self):
+    def test_scope_of_work_preserves_rich_list_markers(self):
         template_doc = Document()
         template_doc.add_paragraph("[[scope_of_work]]")
         buffer = BytesIO()
@@ -440,7 +445,6 @@ class ProposalDocumentGenerationTests(TestCase):
                     {"html": "<ul><li>Первый пункт</li><li>Второй пункт</li></ul>"}
                 ]
             },
-            plain_list_keys={"[[scope_of_work]]"},
             default_language_code="ru-RU",
         )
 
@@ -449,8 +453,9 @@ class ProposalDocumentGenerationTests(TestCase):
 
         self.assertEqual(len(scope_paragraphs), 2)
         for paragraph in scope_paragraphs:
-            self.assertNotIn("w:numPr", paragraph._element.xml)
-            self.assertNotIn("w:pStyle", paragraph._element.xml)
+            self.assertTrue(
+                "w:numPr" in paragraph._element.xml or "w:pStyle" in paragraph._element.xml
+            )
             self.assertIn('w:lang w:val="ru-RU"', paragraph._element.xml)
 
     def test_process_template_applies_default_language_to_scalar_replacements(self):
@@ -470,6 +475,35 @@ class ProposalDocumentGenerationTests(TestCase):
 
         self.assertIn('w:lang w:val="ru-RU"', paragraph._element.xml)
 
+    def test_process_template_preserves_existing_language_when_default_not_provided(self):
+        template_doc = Document()
+        paragraph = template_doc.add_paragraph()
+        run = paragraph.add_run("Заказчик: {{name}}")
+        r_pr = run._element.find(qn("w:rPr"))
+        if r_pr is None:
+            r_pr = OxmlElement("w:rPr")
+            run._element.insert(0, r_pr)
+        lang = OxmlElement("w:lang")
+        lang.set(qn("w:val"), "en-US")
+        lang.set(qn("w:bidi"), "en-US")
+        lang.set(qn("w:eastAsia"), "en-US")
+        r_pr.append(lang)
+
+        buffer = BytesIO()
+        template_doc.save(buffer)
+
+        generated_bytes = process_template(
+            buffer.getvalue(),
+            {"{{name}}": 'ООО "Приморское"'},
+        )
+
+        generated_doc = Document(BytesIO(generated_bytes))
+        generated_paragraph = next(
+            item for item in generated_doc.paragraphs if 'ООО "Приморское"' in item.text
+        )
+
+        self.assertIn('w:lang w:val="en-US"', generated_paragraph._element.xml)
+
     def test_resolve_budget_table_returns_table_spec(self):
         _, lists, tables = resolve_variables(
             self.proposal,
@@ -479,14 +513,17 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertEqual(lists, {})
         self.assertIn("[[budget_table]]", tables)
         table_spec = tables["[[budget_table]]"]
-        self.assertEqual(table_spec["font_size_pt"], 8)
+        self.assertEqual(table_spec["font_size_pt"], 7)
         self.assertEqual(table_spec["style"], "Table Grid")
         self.assertEqual(table_spec["rows"][0][0]["text"], "Специалист")
-        self.assertEqual(table_spec["rows"][1][0]["text"], "Месторождение Приморское")
-        self.assertEqual(table_spec["rows"][2][0]["text"], "Иванов И.И.")
-        self.assertEqual(table_spec["rows"][2][1]["text"], "Геолог, Партнер")
-        self.assertEqual(table_spec["rows"][2][-2]["text"], "6")
-        self.assertEqual(table_spec["rows"][5][0]["text"], "ИТОГО, по расчёту")
+        self.assertEqual(table_spec["rows"][0][2]["text"], "Ставка,\n€/дн")
+        self.assertEqual(table_spec["rows"][0][-2]["text"], "Кол-во\nдней")
+        self.assertEqual(table_spec["rows"][0][-1]["text"], "Итого,\n€ без НДС")
+        self.assertEqual(table_spec["rows"][0][3]["text"], "Месторождение Приморское")
+        self.assertEqual(table_spec["rows"][1][0]["text"], "Иванов И.И.")
+        self.assertEqual(table_spec["rows"][1][1]["text"], "Геолог, Партнер")
+        self.assertEqual(table_spec["rows"][1][-2]["text"], "6")
+        self.assertEqual(table_spec["rows"][7][0]["text"], "ИТОГО в договор, рубли без НДС с учётом доп. скидки")
 
     def test_process_template_inserts_budget_table(self):
         template_doc = Document()
@@ -512,23 +549,28 @@ class ProposalDocumentGenerationTests(TestCase):
         budget_table = generated_doc.tables[0]
         budget_rows = [[cell.text.strip() for cell in row.cells] for row in budget_table.rows]
 
-        self.assertIn("Месторождение Приморское", budget_rows[1])
-        self.assertIn("Фабрика Приморская", budget_rows[1])
-        self.assertIn("Иванов И.И.", budget_rows[2])
-        self.assertIn("Геолог, Партнер", budget_rows[2])
-        self.assertIn("6", budget_rows[2])
-        self.assertIn("7\u00a0200,00", budget_rows[2])
-        self.assertIn("Командировочные расходы", budget_rows[4][0])
-        self.assertIn("ИТОГО, по расчёту", budget_rows[5][0])
-        self.assertIn("10\u00a0400,00", budget_rows[5][-1])
-        self.assertIn("ИТОГО, рубли без НДС", budget_rows[6][0])
-        self.assertIn("96,5", budget_rows[6][2])
-        self.assertIn("1\u00a0003\u00a0600,00", budget_rows[6][-1])
-        self.assertIn("ИТОГО, рубли без НДС с учетом скидки", budget_rows[7][0])
-        self.assertIn("7,5%", budget_rows[7][2])
-        self.assertIn("928\u00a0330,00", budget_rows[7][-1])
-        self.assertIn("ИТОГО в договор, рубли без НДС с учётом дополнительной скидки", budget_rows[8][0])
-        self.assertIn("900\u00a0000,00", budget_rows[8][-1])
+        self.assertIn("Месторождение Приморское", budget_rows[0])
+        self.assertIn("Фабрика Приморская", budget_rows[0])
+        self.assertIn("Ставка,\n€/дн", budget_rows[0])
+        self.assertIn("Кол-во\nдней", budget_rows[0])
+        self.assertIn("Итого,\n€ без НДС", budget_rows[0])
+        self.assertIn("Иванов И.И.", budget_rows[1])
+        self.assertIn("Геолог, Партнер", budget_rows[1])
+        self.assertIn("6", budget_rows[1])
+        self.assertIn("7\u00a0200,00", budget_rows[1])
+        self.assertIn("Командировочные расходы", budget_rows[3][0])
+        self.assertIn("ИТОГО, по расчёту", budget_rows[4][0])
+        self.assertIn("10\u00a0400,00", budget_rows[4][-1])
+        self.assertIn("ИТОГО, рубли без НДС", budget_rows[5][0])
+        self.assertIn("96,5", budget_rows[5][2])
+        self.assertIn("1\u00a0003\u00a0600,00", budget_rows[5][-1])
+        self.assertIn("ИТОГО, рубли без НДС с учетом скидки", budget_rows[6][0])
+        self.assertIn("7,5%", budget_rows[6][2])
+        self.assertIn("928\u00a0330,00", budget_rows[6][-1])
+        self.assertIn("ИТОГО в договор, рубли без НДС с учётом доп. скидки", budget_rows[7][0])
+        self.assertIn("900\u00a0000,00", budget_rows[7][-1])
+        self.assertIn('w:tblLayout w:type="autofit"', budget_table._tbl.xml)
+        self.assertIn('w:tblW w:type="auto" w:w="0"', budget_table._tbl.xml)
         budget_run_sizes = [
             run.font.size.pt
             for row in budget_table.rows
@@ -538,7 +580,7 @@ class ProposalDocumentGenerationTests(TestCase):
             if run.text.strip()
         ]
         self.assertTrue(budget_run_sizes)
-        self.assertTrue(all(size == 8 for size in budget_run_sizes))
+        self.assertTrue(all(size == 7 for size in budget_run_sizes))
 
     @patch("ai_app.proposals_app.document_generation.get_any_connected_service_user")
     @patch("ai_app.proposals_app.document_generation.is_nextcloud_primary", return_value=False)

--- a/proposals_app/variable_resolver.py
+++ b/proposals_app/variable_resolver.py
@@ -287,7 +287,7 @@ PROPOSAL_TRAVEL_EXPENSES_LABEL = "Командировочные расходы"
 PROPOSAL_SUMMARY_TOTAL_LABEL = "ИТОГО, по расчёту"
 PROPOSAL_RUB_TOTAL_LABEL = "ИТОГО, рубли без НДС"
 PROPOSAL_RUB_DISCOUNTED_LABEL = "ИТОГО, рубли без НДС с учетом скидки"
-PROPOSAL_CONTRACT_TOTAL_LABEL = "ИТОГО в договор, рубли без НДС с учётом дополнительной скидки"
+PROPOSAL_CONTRACT_TOTAL_LABEL = "ИТОГО в договор, рубли без НДС с учётом доп. скидки"
 
 
 def _parse_decimal(value) -> Decimal | None:
@@ -346,23 +346,27 @@ def _proposal_budget_table(proposal) -> dict:
 
     rows: list[list[dict[str, object]]] = [
         [
-            {"text": "Специалист", "rowspan": 2, "bold": True, "align": "center"},
-            {"text": "Должность/направление", "rowspan": 2, "bold": True, "align": "center"},
-            {"text": "Ставка, евро / день", "rowspan": 2, "bold": True, "align": "center"},
-            {
-                "text": "Количество дней",
-                "colspan": max(asset_count, 1),
-                "bold": True,
-                "align": "center",
-            },
-            {"text": "Количество дней", "rowspan": 2, "bold": True, "align": "center"},
-            {"text": "Итого, евро без НДС", "rowspan": 2, "bold": True, "align": "center"},
-        ],
-        [
+            {"text": "Специалист", "bold": True, "align": "left", "header": True, "vertical_align": "center"},
+            {"text": "Должность/направление", "bold": True, "align": "left", "header": True, "vertical_align": "center"},
+            {"text": "Ставка,\n€/дн", "bold": True, "align": "right", "header": True, "vertical_align": "center"},
             *[
-                {"text": label, "bold": True, "align": "center"}
-                for label in (asset_labels or ["Количество дней"])
-            ]
+                {
+                    "text": label,
+                    "bold": True,
+                    "align": "center",
+                    "header": True,
+                    "vertical_align": "center",
+                    "margins_cm": {
+                        "top": 0,
+                        "right": 0,
+                        "bottom": 0,
+                        "left": 0,
+                    },
+                }
+                for label in asset_labels
+            ],
+            {"text": "Кол-во\nдней", "bold": True, "align": "right", "header": True, "vertical_align": "center"},
+            {"text": "Итого,\n€ без НДС", "bold": True, "align": "right", "header": True, "vertical_align": "center"},
         ],
     ]
 
@@ -484,7 +488,7 @@ def _proposal_budget_table(proposal) -> dict:
 
     return {
         "rows": rows,
-        "font_size_pt": 8,
+        "font_size_pt": 7,
         "style": "Table Grid",
     }
 

--- a/proposals_app/views.py
+++ b/proposals_app/views.py
@@ -1781,7 +1781,6 @@ def proposal_dispatch_create_documents(request):
                 replacements,
                 table_replacements=table_replacements or None,
                 list_replacements=list_replacements or None,
-                plain_list_keys={"[[scope_of_work]]"},
                 default_language_code="ru-RU",
             )
             stored = store_generated_documents(request.user, proposal, docx_bytes, None)


### PR DESCRIPTION
## Summary
- refine the generated `[[budget_table]]` DOCX table layout, labels, spacing, and sizing
- preserve bullet list formatting for `[[scope_of_work]]` instead of flattening it into plain paragraphs
- keep DOCX table autofit behavior and formatting-related regression coverage in tests
## Test plan
- [x] run targeted Django tests for budget table generation
- [x] run targeted Django test for preserving rich list markers in `[[scope_of_work]]`
- [x] verify generated budget table keeps DOCX autofit settings