### PR TITLE
Refine proposal DOCX budget table layout

### DIFF
--- a/contracts_app/docx_processor.py
+++ b/contracts_app/docx_processor.py
@@ -643,6 +643,7 @@ def _normalize_table_cell_spec(value) -> dict[str, object]:
             "header": bool(value.get("header")),
             "vertical_align": str(value.get("vertical_align") or "").strip().lower() or "top",
             "margins_cm": value.get("margins_cm") or {},
+            "no_wrap": bool(value.get("no_wrap")),
         }
     return {
         "text": str(value or ""),
@@ -653,6 +654,7 @@ def _normalize_table_cell_spec(value) -> dict[str, object]:
         "header": False,
         "vertical_align": "top",
         "margins_cm": {},
+        "no_wrap": False,
     }
 
 
@@ -697,22 +699,29 @@ def _apply_cell_text(cell, spec: dict[str, object], font_size_pt: int | float | 
     paragraph.paragraph_format.space_before = Pt(0)
     paragraph.paragraph_format.space_after = Pt(0)
     text_parts = str(spec.get("text") or "").split("\n")
-    run = paragraph.add_run(text_parts[0] if text_parts else "")
+    runs = list(paragraph.runs)
+    if runs:
+        run = runs[0]
+        run.text = text_parts[0] if text_parts else ""
+        for extra_run in runs[1:]:
+            extra_run.text = ""
+    else:
+        run = paragraph.add_run(text_parts[0] if text_parts else "")
     for text_part in text_parts[1:]:
         run.add_break()
         run.add_text(text_part)
-    if spec.get("bold"):
-        run.bold = True
-    if font_size_pt:
-        run.font.size = Pt(font_size_pt)
-    if language_code:
-        r_pr = run._element.find(qn("w:rPr"))
-        if r_pr is None:
-            from docx.oxml import OxmlElement
+    for paragraph_run in paragraph.runs:
+        paragraph_run.bold = bool(spec.get("bold"))
+        if font_size_pt:
+            paragraph_run.font.size = Pt(font_size_pt)
+        if language_code:
+            r_pr = paragraph_run._element.find(qn("w:rPr"))
+            if r_pr is None:
+                from docx.oxml import OxmlElement
 
-            r_pr = OxmlElement("w:rPr")
-            run._element.insert(0, r_pr)
-        _set_language_property(r_pr, language_code)
+                r_pr = OxmlElement("w:rPr")
+                paragraph_run._element.insert(0, r_pr)
+            _set_language_property(r_pr, language_code)
     vertical_align = str(spec.get("vertical_align") or "top").strip().lower()
     cell.vertical_alignment = (
         WD_CELL_VERTICAL_ALIGNMENT.CENTER
@@ -741,6 +750,20 @@ def _set_cell_margins(cell, *, top_cm=0, right_cm=0.1, bottom_cm=0, left_cm=0.1)
             tc_mar.append(node)
         node.set(qn("w:w"), str(int(round(Cm(value_cm).twips))))
         node.set(qn("w:type"), "dxa")
+
+
+def _set_cell_no_wrap(cell, enabled: bool) -> None:
+    from docx.oxml import OxmlElement
+
+    tc_pr = cell._tc.get_or_add_tcPr()
+    existing = tc_pr.find(qn("w:noWrap"))
+    if enabled:
+        if existing is None:
+            existing = OxmlElement("w:noWrap")
+            tc_pr.append(existing)
+        existing.set(qn("w:val"), "1")
+    elif existing is not None:
+        tc_pr.remove(existing)
 
 
 def _set_table_autofit(table) -> None:
@@ -827,6 +850,7 @@ def _insert_table_after_paragraph(paragraph, table_spec: dict, language_code: st
                 bottom_cm=float((margins or {}).get("bottom", 0)),
                 left_cm=float((margins or {}).get("left", 0.1)),
             )
+            _set_cell_no_wrap(start_cell, bool(spec.get("no_wrap")))
             _apply_cell_text(start_cell, spec, font_size_pt, language_code)
             col_idx += colspan
 

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -401,6 +401,10 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertIn("900\u00a0000,00", budget_rows[7][-1])
         self.assertIn('w:tblLayout w:type="autofit"', budget_table._tbl.xml)
         self.assertIn('w:tblW w:type="auto" w:w="0"', budget_table._tbl.xml)
+        empty_fixed_cell = budget_table.rows[5].cells[3]
+        self.assertTrue(empty_fixed_cell.paragraphs)
+        self.assertTrue(empty_fixed_cell.paragraphs[0].runs)
+        self.assertEqual(empty_fixed_cell.paragraphs[0].runs[0].font.size.pt, 7)
         budget_run_sizes = [
             run.font.size.pt
             for row in budget_table.rows
@@ -456,6 +460,41 @@ class ProposalDocumentGenerationTests(TestCase):
             self.assertTrue(
                 "w:numPr" in paragraph._element.xml or "w:pStyle" in paragraph._element.xml
             )
+            self.assertIn('w:lang w:val="ru-RU"', paragraph._element.xml)
+
+    def test_scope_of_work_plain_text_fallback_remains_plain_paragraphs(self):
+        proposal = ProposalRegistration(
+            service_composition_mode="sections",
+            service_composition="Первый абзац\n\nВторой абзац",
+        )
+        template_doc = Document()
+        template_doc.add_paragraph("[[scope_of_work]]")
+        buffer = BytesIO()
+        template_doc.save(buffer)
+
+        replacements, lists, _ = resolve_variables(
+            proposal,
+            [ProposalVariable(key="[[scope_of_work]]", is_computed=True)],
+        )
+
+        generated_bytes = process_template(
+            buffer.getvalue(),
+            replacements,
+            list_replacements=lists,
+            default_language_code="ru-RU",
+        )
+
+        generated_doc = Document(BytesIO(generated_bytes))
+        scope_paragraphs = [
+            paragraph
+            for paragraph in generated_doc.paragraphs
+            if paragraph.text in {"Первый абзац", "Второй абзац"}
+        ]
+
+        self.assertEqual(len(scope_paragraphs), 2)
+        for paragraph in scope_paragraphs:
+            self.assertNotIn("w:numPr", paragraph._element.xml)
+            self.assertNotIn("w:pStyle", paragraph._element.xml)
             self.assertIn('w:lang w:val="ru-RU"', paragraph._element.xml)
 
     def test_process_template_applies_default_language_to_scalar_replacements(self):
@@ -520,10 +559,60 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertEqual(table_spec["rows"][0][-2]["text"], "Кол-во\nдней")
         self.assertEqual(table_spec["rows"][0][-1]["text"], "Итого,\n€ без НДС")
         self.assertEqual(table_spec["rows"][0][3]["text"], "Месторождение Приморское")
+        self.assertTrue(table_spec["rows"][0][1]["no_wrap"])
         self.assertEqual(table_spec["rows"][1][0]["text"], "Иванов И.И.")
         self.assertEqual(table_spec["rows"][1][1]["text"], "Геолог, Партнер")
+        self.assertTrue(table_spec["rows"][1][1]["no_wrap"])
         self.assertEqual(table_spec["rows"][1][-2]["text"], "6")
         self.assertEqual(table_spec["rows"][7][0]["text"], "ИТОГО в договор, рубли без НДС с учётом доп. скидки")
+
+    def test_resolve_budget_table_omits_total_days_column_for_single_asset(self):
+        proposal = ProposalRegistration.objects.create(
+            number=4444,
+            group_member=self.group_member,
+            type=self.product,
+            name="Один актив",
+            year=2026,
+            status=ProposalRegistration.ProposalStatus.PRELIMINARY,
+            customer='ООО "Приморское"',
+        )
+        ProposalAsset.objects.create(
+            proposal=proposal,
+            short_name="Единственный актив",
+            position=1,
+        )
+        ProposalCommercialOffer.objects.create(
+            proposal=proposal,
+            specialist="Иванов И.И.",
+            job_title="Геолог",
+            professional_status="Партнер",
+            service_name="Раздел 1",
+            rate_eur_per_day="1200",
+            asset_day_counts=[2],
+            total_eur_without_vat="2400",
+            position=1,
+        )
+
+        _, _, tables = resolve_variables(
+            proposal,
+            [ProposalVariable(key="[[budget_table]]", is_computed=True)],
+        )
+
+        header_row = tables["[[budget_table]]"]["rows"][0]
+        header_texts = [cell["text"] for cell in header_row]
+        self.assertEqual(
+            header_texts,
+            [
+                "Специалист",
+                "Должность/направление",
+                "Ставка,\n€/дн",
+                "Единственный актив",
+                "Итого,\n€ без НДС",
+            ],
+        )
+        data_row = tables["[[budget_table]]"]["rows"][1]
+        self.assertEqual(len(data_row), 5)
+        self.assertEqual(data_row[3]["text"], "2")
 
     def test_process_template_inserts_budget_table(self):
         template_doc = Document()

--- a/proposals_app/variable_resolver.py
+++ b/proposals_app/variable_resolver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from html import escape
 
 from datetime import date
 from decimal import Decimal, InvalidOperation
@@ -235,6 +236,18 @@ def _proposal_service_composition(proposal) -> str:
 
 
 def _proposal_scope_of_work(proposal) -> list[dict[str, str] | str]:
+    def plain_text_to_html(value):
+        text = str(value or "").strip()
+        if not text:
+            return ""
+        paragraphs = []
+        for chunk in text.split("\n\n"):
+            chunk = chunk.strip()
+            if not chunk:
+                continue
+            paragraphs.append("<p>" + escape(chunk).replace("\n", "<br>") + "</p>")
+        return "".join(paragraphs)
+
     def build_item(html_value, plain_text_value):
         html = str(html_value or "").strip()
         plain_text = str(plain_text_value or "").strip()
@@ -242,10 +255,7 @@ def _proposal_scope_of_work(proposal) -> list[dict[str, str] | str]:
             return {"html": html}
         if not plain_text:
             return None
-        chunks = [chunk.strip() for chunk in plain_text.split("\n\n") if chunk.strip()]
-        if len(chunks) <= 1:
-            return plain_text
-        return chunks
+        return {"html": plain_text_to_html(plain_text)}
 
     mode = str(getattr(proposal, "service_composition_mode", "") or "sections").strip()
     if mode == "customer_tz":
@@ -340,6 +350,7 @@ def _proposal_budget_table(proposal) -> dict:
         default=0,
     )
     asset_count = max(len(asset_labels), max_asset_count, 1)
+    show_total_days_column = asset_count > 1
     while len(asset_labels) < asset_count:
         asset_labels.append(f"Актив {len(asset_labels) + 1}")
     asset_labels = [label or f"Актив {index + 1}" for index, label in enumerate(asset_labels)]
@@ -347,7 +358,7 @@ def _proposal_budget_table(proposal) -> dict:
     rows: list[list[dict[str, object]]] = [
         [
             {"text": "Специалист", "bold": True, "align": "left", "header": True, "vertical_align": "center"},
-            {"text": "Должность/направление", "bold": True, "align": "left", "header": True, "vertical_align": "center"},
+            {"text": "Должность/направление", "bold": True, "align": "left", "header": True, "vertical_align": "center", "no_wrap": True},
             {"text": "Ставка,\n€/дн", "bold": True, "align": "right", "header": True, "vertical_align": "center"},
             *[
                 {
@@ -365,7 +376,11 @@ def _proposal_budget_table(proposal) -> dict:
                 }
                 for label in asset_labels
             ],
-            {"text": "Кол-во\nдней", "bold": True, "align": "right", "header": True, "vertical_align": "center"},
+            *(
+                [{"text": "Кол-во\nдней", "bold": True, "align": "right", "header": True, "vertical_align": "center"}]
+                if show_total_days_column
+                else []
+            ),
             {"text": "Итого,\n€ без НДС", "bold": True, "align": "right", "header": True, "vertical_align": "center"},
         ],
     ]
@@ -391,13 +406,17 @@ def _proposal_budget_table(proposal) -> dict:
         rows.append(
             [
                 {"text": str(getattr(item, "specialist", "") or "").strip()},
-                {"text": direction},
+                {"text": direction, "no_wrap": True},
                 {"text": _format_money(getattr(item, "rate_eur_per_day", None)), "align": "right"},
                 *[
                     {"text": value, "align": "right"}
                     for value in day_values
                 ],
-                {"text": str(_sum_day_counts(day_values)) if _sum_day_counts(day_values) else "", "align": "right"},
+                *(
+                    [{"text": str(_sum_day_counts(day_values)) if _sum_day_counts(day_values) else "", "align": "right"}]
+                    if show_total_days_column
+                    else []
+                ),
                 {"text": _format_money(getattr(item, "total_eur_without_vat", None)), "align": "right"},
             ]
         )
@@ -447,7 +466,11 @@ def _proposal_budget_table(proposal) -> dict:
                     {"text": str(value or ""), "align": "right"}
                     for value in current_day_values
                 ],
-                {"text": str(_sum_day_counts(current_day_values)) if _sum_day_counts(current_day_values) else "", "align": "right"},
+                *(
+                    [{"text": str(_sum_day_counts(current_day_values)) if _sum_day_counts(current_day_values) else "", "align": "right"}]
+                    if show_total_days_column
+                    else []
+                ),
                 {"text": str(total or ""), "align": "right"},
             ]
         )


### PR DESCRIPTION
## Summary
- refine generated `[[budget_table]]` layout, spacing, wrapping behavior, and single-asset column rules
- preserve correct `[[scope_of_work]]` behavior for both rich lists and plain-text fallback content
- add regression coverage for DOCX table rendering and scope-of-work formatting behavior
## Test plan
- [x] run targeted Django tests for `[[budget_table]]`
- [x] run targeted Django tests for `[[scope_of_work]]` rich-list and plain-text fallback behavior
- [x] verify DOCX table autofit and formatting-related regression coverage