### PR TITLE
Refine proposal registry editing and budget table behavior

### DIFF
--- a/contracts_app/docx_processor.py
+++ b/contracts_app/docx_processor.py
@@ -693,11 +693,31 @@ def _measure_table_columns(rows: list[list[dict[str, object]]]) -> int:
 
 
 def _apply_cell_text(cell, spec: dict[str, object], font_size_pt: int | float | None, language_code: str | None) -> None:
+    from docx.oxml import OxmlElement
+
     cell.text = ""
     paragraph = cell.paragraphs[0]
     paragraph.alignment = _table_alignment(str(spec.get("align") or "left"))
     paragraph.paragraph_format.space_before = Pt(0)
     paragraph.paragraph_format.space_after = Pt(0)
+    p_pr = paragraph._element.find(qn("w:pPr"))
+    if p_pr is None:
+        p_pr = OxmlElement("w:pPr")
+        paragraph._element.insert(0, p_pr)
+    paragraph_r_pr = p_pr.find(qn("w:rPr"))
+    if paragraph_r_pr is None:
+        paragraph_r_pr = OxmlElement("w:rPr")
+        p_pr.append(paragraph_r_pr)
+    if font_size_pt:
+        half_points = str(int(round(float(font_size_pt) * 2)))
+        for tag_name in ("w:sz", "w:szCs"):
+            existing = paragraph_r_pr.find(qn(tag_name))
+            if existing is None:
+                existing = OxmlElement(tag_name)
+                paragraph_r_pr.append(existing)
+            existing.set(qn("w:val"), half_points)
+    if language_code:
+        _set_language_property(paragraph_r_pr, language_code)
     text_parts = str(spec.get("text") or "").split("\n")
     runs = list(paragraph.runs)
     if runs:
@@ -717,8 +737,6 @@ def _apply_cell_text(cell, spec: dict[str, object], font_size_pt: int | float | 
         if language_code:
             r_pr = paragraph_run._element.find(qn("w:rPr"))
             if r_pr is None:
-                from docx.oxml import OxmlElement
-
                 r_pr = OxmlElement("w:rPr")
                 paragraph_run._element.insert(0, r_pr)
             _set_language_property(r_pr, language_code)
@@ -798,6 +816,48 @@ def _set_table_autofit(table) -> None:
     tbl_w.set(qn("w:w"), "0")
 
 
+def _set_table_fixed_pct_widths(table, column_widths_pct: list[float]) -> None:
+    from docx.oxml import OxmlElement
+
+    tbl_pr = table._tbl.tblPr
+    if tbl_pr is None:
+        return
+
+    try:
+        table.autofit = False
+    except Exception:
+        pass
+    try:
+        table.allow_autofit = False
+    except Exception:
+        pass
+
+    tbl_layout = tbl_pr.find(qn("w:tblLayout"))
+    if tbl_layout is None:
+        tbl_layout = OxmlElement("w:tblLayout")
+        tbl_pr.append(tbl_layout)
+    tbl_layout.set(qn("w:type"), "fixed")
+
+    tbl_w = tbl_pr.find(qn("w:tblW"))
+    if tbl_w is None:
+        tbl_w = OxmlElement("w:tblW")
+        tbl_pr.insert(0, tbl_w)
+    tbl_w.set(qn("w:type"), "pct")
+    tbl_w.set(qn("w:w"), "5000")
+
+
+def _set_cell_width_pct(cell, width_pct: float) -> None:
+    from docx.oxml import OxmlElement
+
+    tc_pr = cell._tc.get_or_add_tcPr()
+    tc_w = tc_pr.find(qn("w:tcW"))
+    if tc_w is None:
+        tc_w = OxmlElement("w:tcW")
+        tc_pr.append(tc_w)
+    tc_w.set(qn("w:type"), "pct")
+    tc_w.set(qn("w:w"), str(int(round(float(width_pct) * 50))))
+
+
 def _insert_table_after_paragraph(paragraph, table_spec: dict, language_code: str | None = None) -> bool:
     rows = table_spec.get("rows") if isinstance(table_spec, dict) else None
     if not isinstance(rows, list) or not rows:
@@ -823,7 +883,11 @@ def _insert_table_after_paragraph(paragraph, table_spec: dict, language_code: st
             table.style = str(table_spec.get("style"))
     except Exception:
         pass
-    _set_table_autofit(table)
+    column_widths_pct = list(table_spec.get("column_widths_pct") or []) if isinstance(table_spec, dict) else []
+    if column_widths_pct and len(column_widths_pct) == column_count:
+        _set_table_fixed_pct_widths(table, column_widths_pct)
+    else:
+        _set_table_autofit(table)
     table.alignment = WD_TABLE_ALIGNMENT.CENTER
 
     font_size_pt = table_spec.get("font_size_pt") if isinstance(table_spec, dict) else None
@@ -850,6 +914,8 @@ def _insert_table_after_paragraph(paragraph, table_spec: dict, language_code: st
                 bottom_cm=float((margins or {}).get("bottom", 0)),
                 left_cm=float((margins or {}).get("left", 0.1)),
             )
+            if column_widths_pct and len(column_widths_pct) == column_count:
+                _set_cell_width_pct(start_cell, sum(column_widths_pct[col_idx:col_idx + colspan]))
             _set_cell_no_wrap(start_cell, bool(spec.get("no_wrap")))
             _apply_cell_text(start_cell, spec, font_size_pt, language_code)
             col_idx += colspan

--- a/core/static/core/css/site.css
+++ b/core/static/core/css/site.css
@@ -1791,6 +1791,8 @@ section#templates .alert.alert-info .text-muted {
 #proposals-pane .proposal-assets-table th {
   white-space: nowrap;
   font-weight: 400;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #proposals-pane .proposal-assets-table td {
@@ -1848,6 +1850,9 @@ section#templates .alert.alert-info .text-muted {
 #proposals-pane .proposal-commercial-table th[rowspan="2"] {
   vertical-align: bottom;
   padding-bottom: var(--bs-table-cell-padding-y, .5rem);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #proposals-pane .proposal-commercial-table .proposal-commercial-days-group,
@@ -1858,8 +1863,10 @@ section#templates .alert.alert-info .text-muted {
 #proposals-pane .proposal-commercial-table .proposal-commercial-rate-header,
 #proposals-pane .proposal-commercial-table .proposal-commercial-total-header,
 #proposals-pane .proposal-commercial-table .proposal-commercial-days-header {
-  white-space: normal;
+  white-space: nowrap;
   line-height: 1.15;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #proposals-pane .proposal-commercial-table .proposal-commercial-days-group {
@@ -1935,6 +1942,8 @@ section#templates .alert.alert-info .text-muted {
   max-width: none;
   white-space: nowrap;
   word-break: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #proposals-pane .proposal-commercial-table .proposal-commercial-day-cell-single {
@@ -2043,6 +2052,15 @@ section#templates .alert.alert-info .text-muted {
   white-space: nowrap;
 }
 
+#proposals-pane .proposal-commercial-table .proposal-commercial-row-label {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 #proposals-pane .proposal-commercial-table > tbody > tr.proposal-commercial-travel-row > td,
 #proposals-pane .proposal-commercial-table > tbody > tr.proposal-commercial-summary-row > td,
 #proposals-pane .proposal-commercial-table > tbody > tr.proposal-commercial-financial-row > td {
@@ -2059,9 +2077,9 @@ section#templates .alert.alert-info .text-muted {
 }
 
 #proposals-pane .proposal-commercial-table .proposal-commercial-financial-service-cell {
-  width: 13rem !important;
+  width: auto !important;
   min-width: 13rem !important;
-  max-width: 13rem !important;
+  max-width: none !important;
 }
 
 #proposals-pane .proposal-commercial-table .proposal-commercial-financial-rate-cell,
@@ -2596,6 +2614,25 @@ html.proposal-progress-cursor * {
 #proposals-pane .readonly-field {
   background-color: #f8f9fa;
   color: #6c757d;
+}
+
+#proposals-pane .form-label {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#proposals-pane .js-proposal-report-terms-lock {
+  cursor: pointer;
+  font-size: .85em;
+  vertical-align: baseline;
+  color: #6c757d;
+  transition: color .15s;
+}
+
+#proposals-pane .js-proposal-report-terms-lock:hover {
+  color: #0d6efd;
 }
 
 #proposals-pane .proposal-inline-percent {

--- a/core/static/core/js/proposals-panels.js
+++ b/core/static/core/js/proposals-panels.js
@@ -1555,6 +1555,13 @@
     return td;
   }
 
+  function createProposalEllipsisLabel(text, className) {
+    const span = document.createElement('span');
+    span.className = className || 'proposal-commercial-row-label';
+    span.textContent = text || '';
+    return span;
+  }
+
   function bindProposalEntityAutocomplete(input, list, row, updatePayload, searchUrl, selectors, getRowIndex) {
     let debounce = null;
     let results = [];
@@ -2022,15 +2029,20 @@
     return syncOptionsSelect(select, getProposalTypicalSectionNames(form), selectedValue);
   }
 
-  const PROPOSAL_TRAVEL_EXPENSES_LABEL = 'Командировочные расходы';
+  const PROPOSAL_TRAVEL_EXPENSES_LABEL = 'Командировочные расходы, евро';
+  const PROPOSAL_TRAVEL_EXPENSES_LABEL_LEGACY = 'Командировочные расходы';
+  const PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL = 'actual';
+  const PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION = 'calculation';
   const PROPOSAL_SUMMARY_TOTAL_LABEL = 'ИТОГО, по расчёту';
+  const PROPOSAL_SUMMARY_WITH_TRAVEL_TOTAL_LABEL = 'ИТОГО, евро с командировочными по расчёту';
   const PROPOSAL_RUB_TOTAL_LABEL = 'ИТОГО, рубли без НДС';
   const PROPOSAL_RUB_DISCOUNTED_LABEL = 'ИТОГО, рубли без НДС с учетом скидки';
   const PROPOSAL_CONTRACT_TOTAL_LABEL = 'ИТОГО в договор, рубли без НДС с учётом дополнительной скидки';
   const PROPOSAL_CBR_EUR_DAILY_URL = 'https://www.cbr.ru/currency_base/daily/';
 
   function isProposalTravelExpensesRow(row) {
-    return String(row?.service_name || '').trim() === PROPOSAL_TRAVEL_EXPENSES_LABEL;
+    const serviceName = String(row?.service_name || '').trim();
+    return serviceName === PROPOSAL_TRAVEL_EXPENSES_LABEL || serviceName === PROPOSAL_TRAVEL_EXPENSES_LABEL_LEGACY;
   }
 
   function normalizeProposalTravelExpensesRow(row) {
@@ -2047,6 +2059,23 @@
       asset_day_counts: dayCounts,
       total_eur_without_vat: String(row?.total_eur_without_vat || '').trim(),
     };
+  }
+
+  function normalizeProposalTravelExpensesMode(value) {
+    const mode = String(value || '').trim();
+    if (mode === PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL || mode === PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION) {
+      return mode;
+    }
+    return '';
+  }
+
+  function inferProposalTravelExpensesMode(row, fallbackValue) {
+    const explicitMode = normalizeProposalTravelExpensesMode(fallbackValue);
+    if (explicitMode) return explicitMode;
+    const assetValues = Array.isArray(row?.asset_day_counts) ? row.asset_day_counts : [];
+    const hasSavedValues = assetValues.some(function (value) { return String(value ?? '').trim(); })
+      || String(row?.total_eur_without_vat || '').trim();
+    return hasSavedValues ? PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION : PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL;
   }
 
   function parseProposalPercent(value) {
@@ -2070,6 +2099,7 @@
       contract_total_auto: String(source.contract_total_auto || '').trim(),
       rub_total_service_text: String(source.rub_total_service_text || 'Курс евро Банка России на текущую дату:').trim(),
       discounted_total_service_text: String(source.discounted_total_service_text || 'Размер скидки:').trim(),
+      travel_expenses_mode: normalizeProposalTravelExpensesMode(source.travel_expenses_mode),
     };
   }
 
@@ -2244,8 +2274,9 @@
       setDateFieldValue(regDateInput, data.registration_date || '');
     }
 
-    function createRow(data) {
+    function createRow(data, options) {
       const sourceData = data && typeof data === 'object' ? data : {};
+      const skipDefaultPrefill = options?.skipDefaultPrefill === true;
       const hasExplicitSourceData = Boolean(
         (sourceData.short_name || '').trim()
         || (sourceData.country_id || '').trim()
@@ -2256,7 +2287,7 @@
         || (sourceData.region || '').trim()
         || (sourceData.selected_identifier_record_id || '').trim()
       );
-      data = mergeWithDefaultRowData(sourceData);
+      data = skipDefaultPrefill ? { ...sourceData } : mergeWithDefaultRowData(sourceData);
       const row = document.createElement('tr');
       row.dataset.countryId = data.country_id || '';
       row.dataset.countryName = data.country_name || '';
@@ -2434,7 +2465,7 @@
     }
 
     addBtn.addEventListener('click', function () {
-      const row = createRow({});
+      const row = createRow({}, { skipDefaultPrefill: config.skipDefaultPrefillOnManualAdd === true });
       tbody.appendChild(row);
       activateRow(row);
       updatePayload({ reason: 'row-add', rowIndex: getRows().length - 1 });
@@ -2594,6 +2625,7 @@
         };
       },
       rowsChangedEvent: 'proposal-assets-changed',
+      skipDefaultPrefillOnManualAdd: true,
       withAssetSelect: false,
       apiKey: '__proposalAssetsTableApi',
     });
@@ -3182,6 +3214,10 @@
       return row?.dataset?.summaryRow === '1';
     }
 
+    function isSummaryWithTravelRow(row) {
+      return row?.dataset?.summaryWithTravelRow === '1';
+    }
+
     function isRubTotalRow(row) {
       return row?.dataset?.rubTotalRow === '1';
     }
@@ -3199,7 +3235,11 @@
     }
 
     function isFixedRow(row) {
-      return isTravelRow(row) || isSummaryRow(row) || isRubTotalRow(row) || isDiscountedTotalRow(row) || isContractTotalRow(row);
+      return isTravelRow(row) || isSummaryRow(row) || isSummaryWithTravelRow(row) || isRubTotalRow(row) || isDiscountedTotalRow(row) || isContractTotalRow(row);
+    }
+
+    function getTravelExpensesMode(row) {
+      return normalizeProposalTravelExpensesMode(row?.dataset?.travelExpensesMode) || PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL;
     }
 
     function parseTotalsPayload() {
@@ -3322,8 +3362,8 @@
           + '<tr>'
           + '<th class="proposal-assets-check-col"></th>'
           + '<th>Специалист</th>'
-          + '<th>Профессиональный статус</th>'
           + '<th>Специальность</th>'
+          + '<th>Профессиональный статус</th>'
           + '<th>Услуги</th>'
           + '<th class="proposal-commercial-rate-header">Ставка, евро / день</th>'
           + '<th class="proposal-commercial-days-group proposal-commercial-days-header proposal-commercial-days-header-single">Количество дней</th>'
@@ -3336,8 +3376,8 @@
         + '<tr>'
         + '<th class="proposal-assets-check-col" rowspan="2"></th>'
         + '<th rowspan="2">Специалист</th>'
-        + '<th rowspan="2">Профессиональный статус</th>'
         + '<th rowspan="2">Специальность</th>'
+        + '<th rowspan="2">Профессиональный статус</th>'
         + '<th rowspan="2">Услуги</th>'
         + '<th class="proposal-commercial-rate-header" rowspan="2">Ставка, евро / день</th>'
         + '<th class="proposal-commercial-days-group proposal-commercial-days-group-subheaders proposal-commercial-days-header proposal-commercial-days-header-multi" colspan="' + labels.length + '">Количество дней</th>'
@@ -3386,9 +3426,30 @@
       totalInput.value = fmtMoney((rate * totalDays).toFixed(2));
     }
 
+    function recalcTravelRowTotal(row) {
+      if (!row || !isTravelRow(row)) return;
+      const totalInput = row.querySelector('.proposal-commercial-total');
+      if (!totalInput) return;
+      const total = getDayInputs(row).reduce(function (sum, input) {
+        const value = parseFloat(rawMoney(input.value || ''));
+        return sum + (Number.isFinite(value) ? value : 0);
+      }, 0);
+      totalInput.value = total > 0 ? fmtMoney(total.toFixed(2)) : '';
+    }
+
+    function syncCalculatedRowTotal(row) {
+      if (isTravelRow(row)) {
+        recalcTravelRowTotal(row);
+        return;
+      }
+      recalcRowTotal(row);
+    }
+
     function syncDayCells(row, assetRows, values, options) {
-      const isReadOnly = options?.readOnly === true;
-      const sourceValues = Array.isArray(values) ? values : getDayInputs(row).map(function (input) { return input.value || ''; });
+      const isTravelExpenses = isTravelRow(row);
+      const isReadOnly = options?.readOnly === true
+        || (isTravelExpenses && getTravelExpensesMode(row) !== PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION);
+      let sourceValues = Array.isArray(values) ? values : getDayInputs(row).map(function (input) { return input.value || ''; });
       const dayColumnWidths = getCommercialDayColumnWidths(assetRows);
       row.querySelectorAll('.proposal-commercial-day-cell, .proposal-commercial-day-placeholder-cell').forEach(function (cell) {
         cell.remove();
@@ -3401,8 +3462,12 @@
         const placeholderCell = createProposalTableCell('proposal-commercial-day-placeholder-cell');
         placeholderCell.textContent = '—';
         row.insertBefore(placeholderCell, totalCell);
-        recalcRowTotal(row);
+        syncCalculatedRowTotal(row);
         return;
+      }
+
+      if (isTravelExpenses && isReadOnly) {
+        sourceValues = Array.from({ length: assetRows.length }, function () { return ''; });
       }
 
       assetRows.forEach(function (_assetRow, index) {
@@ -3411,10 +3476,17 @@
         );
         applyCommercialDayColumnWidth(dayCell, dayColumnWidths[index]);
         const input = document.createElement('input');
-        input.type = 'number';
-        input.min = '0';
-        input.step = '1';
-        input.className = 'form-control proposal-commercial-day-count';
+        if (isTravelExpenses) {
+          input.type = 'text';
+          input.inputMode = 'decimal';
+          input.dataset.moneyPrecision = '2';
+          input.className = 'form-control js-money-input proposal-commercial-day-count proposal-commercial-travel-amount';
+        } else {
+          input.type = 'number';
+          input.min = '0';
+          input.step = '1';
+          input.className = 'form-control proposal-commercial-day-count';
+        }
         input.value = sourceValues[index] ?? '';
         if (isReadOnly) {
           input.readOnly = true;
@@ -3434,11 +3506,11 @@
         }
         if (!isReadOnly) {
           input.addEventListener('change', function () {
-            recalcRowTotal(row);
+            syncCalculatedRowTotal(row);
             updatePayload();
           });
           input.addEventListener('input', function () {
-            recalcRowTotal(row);
+            syncCalculatedRowTotal(row);
             updatePayload();
           });
         }
@@ -3446,11 +3518,12 @@
         row.insertBefore(dayCell, totalCell);
       });
 
-      if (!isReadOnly) recalcRowTotal(row);
+      if (isTravelExpenses) attachMoneyInputs(row);
+      if (!isReadOnly) syncCalculatedRowTotal(row);
     }
 
     function serializeRow(row) {
-      if (isSummaryRow(row) || isRubTotalRow(row) || isDiscountedTotalRow(row) || isContractTotalRow(row)) {
+      if (isSummaryRow(row) || isSummaryWithTravelRow(row) || isRubTotalRow(row) || isDiscountedTotalRow(row) || isContractTotalRow(row)) {
         return null;
       }
       if (isTravelRow(row)) {
@@ -3496,6 +3569,15 @@
       };
     }
 
+    function computeTravelRowTotalValue() {
+      const travelRow = tbody.querySelector('tr[data-travel-expenses-row="1"]');
+      if (!travelRow) return 0;
+      return getDayInputs(travelRow).reduce(function (sum, input) {
+        const value = parseFloat(rawMoney(input.value || ''));
+        return sum + (Number.isFinite(value) ? value : 0);
+      }, 0);
+    }
+
     function findFixedRow(selector) {
       return tbody.querySelector(selector);
     }
@@ -3504,8 +3586,42 @@
       return Array.from({ length: Math.max(getAssetRows().length, 1) }, function () { return ''; });
     }
 
+    function syncFinancialServiceCellExpansion(row) {
+      const labelCell = row?.querySelector('.proposal-commercial-financial-label-cell');
+      const serviceCell = row?.querySelector('.proposal-commercial-financial-service-cell');
+      const serviceInput = row?.querySelector('.proposal-commercial-service-text');
+      if (!labelCell || !serviceCell || !serviceInput) return;
+
+      const spanVariants = [
+        { labelColSpan: 4, serviceColSpan: 1 },
+        { labelColSpan: 3, serviceColSpan: 2 },
+        { labelColSpan: 2, serviceColSpan: 3 },
+      ];
+
+      for (let index = 0; index < spanVariants.length; index += 1) {
+        const variant = spanVariants[index];
+        labelCell.colSpan = variant.labelColSpan;
+        serviceCell.colSpan = variant.serviceColSpan;
+        row.dataset.financialServiceExpansionLevel = String(index);
+        const hasOverflow = (serviceInput.scrollWidth - serviceInput.clientWidth) > 1;
+        if (!hasOverflow || index === spanVariants.length - 1) {
+          break;
+        }
+      }
+    }
+
+    function syncAllFinancialServiceCellExpansions() {
+      tbody.querySelectorAll('tr.proposal-commercial-financial-row').forEach(function (row) {
+        syncFinancialServiceCellExpansion(row);
+      });
+    }
+
     function computeCommercialFinancialTotals() {
-      const summaryTotal = parseFloat(rawMoney(findFixedRow('tr[data-summary-row="1"]')?.querySelector('.proposal-commercial-total')?.value || ''));
+      const summaryTotal = parseFloat(rawMoney(
+        findFixedRow('tr[data-summary-with-travel-row="1"]')?.querySelector('.proposal-commercial-total')?.value
+        || findFixedRow('tr[data-summary-row="1"]')?.querySelector('.proposal-commercial-total')?.value
+        || ''
+      ));
       const totalsState = parseTotalsPayload();
       const exchangeRate = parseFloat(rawMoney(findFixedRow('tr[data-rub-total-row="1"]')?.querySelector('.proposal-commercial-rate')?.value || totalsState.exchange_rate || ''));
       const discountPercent = parseProposalPercent(findFixedRow('tr[data-discounted-total-row="1"]')?.querySelector('.proposal-commercial-rate')?.value || totalsState.discount_percent || '');
@@ -3535,6 +3651,17 @@
       syncDayCells(summaryRow, getAssetRows(), summary.asset_day_counts, { readOnly: true });
       const totalInput = summaryRow.querySelector('.proposal-commercial-total');
       if (totalInput) totalInput.value = summary.total_eur_without_vat;
+    }
+
+    function syncSummaryWithTravelRowValues() {
+      const summaryWithTravelRow = tbody.querySelector('tr[data-summary-with-travel-row="1"]');
+      if (!summaryWithTravelRow) return;
+      const summaryTotal = parseFloat(rawMoney(computeSummaryValues().total_eur_without_vat || ''));
+      const travelTotal = computeTravelRowTotalValue();
+      const total = (Number.isFinite(summaryTotal) ? summaryTotal : 0) + travelTotal;
+      syncDayCells(summaryWithTravelRow, getAssetRows(), createReadOnlyDayValues(), { readOnly: true });
+      const totalInput = summaryWithTravelRow.querySelector('.proposal-commercial-total');
+      if (totalInput) totalInput.value = total > 0 ? fmtMoney(total.toFixed(2)) : '';
     }
 
     function syncServiceCostValue(valueRaw) {
@@ -3591,12 +3718,16 @@
         contract_total_auto: nextAutoRaw,
         rub_total_service_text: totals.rub_total_service_text,
         discounted_total_service_text: totals.discounted_total_service_text,
+        travel_expenses_mode: getTravelExpensesMode(findFixedRow('tr[data-travel-expenses-row="1"]')),
       });
+      syncAllFinancialServiceCellExpansions();
     }
 
     function updatePayload(meta) {
+      recalcTravelRowTotal(tbody.querySelector('tr[data-travel-expenses-row="1"]'));
       const rows = getRows().map(serializeRow).filter(Boolean);
       syncSummaryRowValues();
+      syncSummaryWithTravelRowValues();
       syncCommercialFinancialRows();
       syncActions();
       if (servicesStore) {
@@ -3661,6 +3792,16 @@
       specialistTd.appendChild(specialistSelect);
       row.appendChild(specialistTd);
 
+      const titleTd = createProposalTableCell();
+      const titleInput = document.createElement('input');
+      titleInput.type = 'text';
+      titleInput.className = 'form-control proposal-commercial-job-title readonly-field';
+      titleInput.readOnly = true;
+      titleInput.tabIndex = -1;
+      titleInput.value = data.job_title || autofill.jobTitle || '';
+      titleTd.appendChild(titleInput);
+      row.appendChild(titleTd);
+
       const statusTd = createProposalTableCell();
       const statusInput = document.createElement('input');
       statusInput.type = 'text';
@@ -3675,16 +3816,6 @@
         || '';
       statusTd.appendChild(statusInput);
       row.appendChild(statusTd);
-
-      const titleTd = createProposalTableCell();
-      const titleInput = document.createElement('input');
-      titleInput.type = 'text';
-      titleInput.className = 'form-control proposal-commercial-job-title readonly-field';
-      titleInput.readOnly = true;
-      titleInput.tabIndex = -1;
-      titleInput.value = data.job_title || autofill.jobTitle || '';
-      titleTd.appendChild(titleInput);
-      row.appendChild(titleTd);
 
       const serviceTd = createProposalTableCell();
       const serviceSelect = document.createElement('select');
@@ -3800,45 +3931,57 @@
       return row;
     }
 
-    function createTravelExpensesRow(data) {
+    function createTravelExpensesRow(data, mode) {
       const row = document.createElement('tr');
       row.dataset.travelExpensesRow = '1';
+      row.dataset.travelExpensesMode = normalizeProposalTravelExpensesMode(mode) || PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL;
       row.className = 'proposal-commercial-travel-row';
 
       const labelTd = createProposalTableCell('proposal-commercial-travel-label-cell');
       labelTd.colSpan = 5;
-      labelTd.textContent = PROPOSAL_TRAVEL_EXPENSES_LABEL;
+      labelTd.appendChild(createProposalEllipsisLabel(PROPOSAL_TRAVEL_EXPENSES_LABEL));
       row.appendChild(labelTd);
 
       const rateTd = createProposalTableCell('proposal-commercial-rate-cell proposal-commercial-travel-rate-cell');
-      const rateInput = document.createElement('input');
-      rateInput.type = 'text';
-      rateInput.className = 'form-control proposal-commercial-rate proposal-commercial-travel-rate readonly-field';
-      rateInput.value = 'по факту';
-      rateInput.readOnly = true;
-      rateInput.tabIndex = -1;
-      rateTd.appendChild(rateInput);
+      const rateSelect = document.createElement('select');
+      rateSelect.className = 'form-select proposal-commercial-rate proposal-commercial-travel-mode';
+      [
+        { value: PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL, label: 'по факту' },
+        { value: PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION, label: 'расчёт' },
+      ].forEach(function (optionConfig) {
+        const option = document.createElement('option');
+        option.value = optionConfig.value;
+        option.textContent = optionConfig.label;
+        rateSelect.appendChild(option);
+      });
+      rateSelect.value = getTravelExpensesMode(row);
+      rateTd.appendChild(rateSelect);
       row.appendChild(rateTd);
 
       const totalTd = createProposalTableCell('proposal-commercial-total-cell proposal-commercial-total-value-cell');
       const totalInput = document.createElement('input');
       totalInput.type = 'text';
-      totalInput.className = 'form-control js-money-input proposal-commercial-total';
+      totalInput.className = 'form-control proposal-commercial-total readonly-field';
       totalInput.inputMode = 'decimal';
-      totalInput.value = data.total_eur_without_vat ? fmtMoney(data.total_eur_without_vat) : '';
+      totalInput.readOnly = true;
+      totalInput.tabIndex = -1;
       totalTd.appendChild(totalInput);
       row.appendChild(totalTd);
 
       syncDayCells(row, getAssetRows(), data.asset_day_counts || []);
 
-      totalInput.addEventListener('change', function () {
-        updatePayload({ reason: 'travel-expenses-edit' });
-      });
-      totalInput.addEventListener('input', function () {
-        updatePayload({ reason: 'travel-expenses-edit' });
+      rateSelect.addEventListener('change', function () {
+        row.dataset.travelExpensesMode = normalizeProposalTravelExpensesMode(rateSelect.value) || PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL;
+        const nextValues = getTravelExpensesMode(row) === PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION
+          ? getDayInputs(row).map(function (input) { return input.value || ''; })
+          : [];
+        syncDayCells(row, getAssetRows(), nextValues);
+        recalcTravelRowTotal(row);
+        updatePayload({ reason: 'travel-expenses-mode-change' });
       });
 
       attachMoneyInputs(row);
+      recalcTravelRowTotal(row);
       return row;
     }
 
@@ -3849,7 +3992,7 @@
 
       const labelTd = createProposalTableCell('proposal-commercial-summary-label-cell');
       labelTd.colSpan = 5;
-      labelTd.textContent = PROPOSAL_SUMMARY_TOTAL_LABEL;
+      labelTd.appendChild(createProposalEllipsisLabel(PROPOSAL_SUMMARY_TOTAL_LABEL));
       row.appendChild(labelTd);
 
       const rateTd = createProposalTableCell('proposal-commercial-rate-cell proposal-commercial-summary-rate-cell');
@@ -3875,6 +4018,39 @@
       return row;
     }
 
+    function createSummaryWithTravelRow() {
+      const row = document.createElement('tr');
+      row.dataset.summaryWithTravelRow = '1';
+      row.className = 'proposal-commercial-travel-row proposal-commercial-summary-with-travel-row';
+
+      const labelTd = createProposalTableCell('proposal-commercial-travel-label-cell');
+      labelTd.colSpan = 5;
+      labelTd.appendChild(createProposalEllipsisLabel(PROPOSAL_SUMMARY_WITH_TRAVEL_TOTAL_LABEL));
+      row.appendChild(labelTd);
+
+      const rateTd = createProposalTableCell('proposal-commercial-rate-cell proposal-commercial-travel-rate-cell');
+      const rateInput = document.createElement('input');
+      rateInput.type = 'text';
+      rateInput.className = 'form-control proposal-commercial-rate readonly-field';
+      rateInput.value = '';
+      rateInput.readOnly = true;
+      rateInput.tabIndex = -1;
+      rateTd.appendChild(rateInput);
+      row.appendChild(rateTd);
+
+      const totalTd = createProposalTableCell('proposal-commercial-total-cell proposal-commercial-total-value-cell');
+      const totalInput = document.createElement('input');
+      totalInput.type = 'text';
+      totalInput.className = 'form-control proposal-commercial-total readonly-field';
+      totalInput.readOnly = true;
+      totalInput.tabIndex = -1;
+      totalTd.appendChild(totalInput);
+      row.appendChild(totalTd);
+
+      syncDayCells(row, getAssetRows(), createReadOnlyDayValues(), { readOnly: true });
+      return row;
+    }
+
     function createFinancialTotalRow(config, state) {
       const row = document.createElement('tr');
       row.className = config.rowClass;
@@ -3882,11 +4058,12 @@
 
       const labelTd = createProposalTableCell('proposal-commercial-financial-label-cell');
       labelTd.colSpan = config.serviceEditable ? 4 : 5;
-      labelTd.textContent = config.label;
+      labelTd.appendChild(createProposalEllipsisLabel(config.label));
       row.appendChild(labelTd);
 
       if (config.serviceEditable) {
         const serviceTd = createProposalTableCell('proposal-commercial-financial-service-cell');
+        serviceTd.colSpan = 1;
         const serviceWrap = document.createElement('div');
         serviceWrap.className = 'proposal-commercial-financial-service-wrap';
         if (config.showCbrLink) {
@@ -4030,6 +4207,7 @@
 
       syncDayCells(row, getAssetRows(), createReadOnlyDayValues(), { readOnly: true });
       attachMoneyInputs(row);
+      if (config.serviceEditable) syncFinancialServiceCellExpansion(row);
       return row;
     }
 
@@ -4043,11 +4221,13 @@
         rowsList.find(isProposalTravelExpensesRow) || {}
       );
       const totalsState = parseTotalsPayload();
+      const travelExpensesMode = inferProposalTravelExpensesMode(travelRow, totalsState.travel_expenses_mode);
       regularRows.forEach(function (item) {
         tbody.appendChild(createRow(item || {}));
       });
-      tbody.appendChild(createTravelExpensesRow(travelRow));
       tbody.appendChild(createSummaryRow());
+      tbody.appendChild(createTravelExpensesRow(travelRow, travelExpensesMode));
+      tbody.appendChild(createSummaryWithTravelRow());
       tbody.appendChild(createFinancialTotalRow({
         label: PROPOSAL_RUB_TOTAL_LABEL,
         rowClass: 'proposal-commercial-financial-row proposal-commercial-financial-row--first',
@@ -4076,6 +4256,7 @@
         serviceEditable: false,
       }, totalsState));
       syncSummaryRowValues();
+      syncSummaryWithTravelRowValues();
       syncCommercialFinancialRows();
       syncActions();
     }
@@ -4143,6 +4324,10 @@
           syncSummaryRowValues();
           return;
         }
+        if (isSummaryWithTravelRow(row)) {
+          syncSummaryWithTravelRowValues();
+          return;
+        }
         syncDayCells(row, rows, undefined, { readOnly: isFixedRow(row) && !isTravelRow(row) });
       });
       updatePayload({ reason: 'sync-asset-columns' });
@@ -4155,6 +4340,7 @@
 
     renderHeader(getAssetRows());
     renderRows(parsePayload());
+    window.addEventListener('resize', syncAllFinancialServiceCellExpansions);
 
     const api = {
       getSerializedRows: function () {
@@ -5127,6 +5313,65 @@
       return addDays(date, Math.round(safeWeeks * 7));
     }
 
+    function subtractDecimalWeeks(date, weeks) {
+      const safeWeeks = Number.isFinite(weeks) ? Math.max(weeks, 0) : 0;
+      return addDays(date, -Math.round(safeWeeks * 7));
+    }
+
+    function diffProposalDays(start, end) {
+      const safeStart = startOfDay(start);
+      const safeEnd = startOfDay(end);
+      return Math.round((safeEnd.getTime() - safeStart.getTime()) / 86400000);
+    }
+
+    function roundProposalDecimal(value) {
+      return Math.round(value * 10) / 10;
+    }
+
+    function formatProposalDecimal(value) {
+      return Number.isFinite(value) ? roundProposalDecimal(value).toFixed(1) : '';
+    }
+
+    function getProposalBaseStartDate() {
+      return getNearestMonday(addDays(new Date(), 14));
+    }
+
+    function decimalMonthsBetween(start, end) {
+      const safeStart = startOfDay(start);
+      const safeEnd = startOfDay(end);
+      if (safeEnd.getTime() <= safeStart.getTime()) return 0;
+
+      let wholeMonths = (safeEnd.getFullYear() - safeStart.getFullYear()) * 12
+        + (safeEnd.getMonth() - safeStart.getMonth());
+      let wholeDate = addDecimalMonths(safeStart, wholeMonths);
+      while (wholeMonths > 0 && wholeDate.getTime() > safeEnd.getTime()) {
+        wholeMonths -= 1;
+        wholeDate = addDecimalMonths(safeStart, wholeMonths);
+      }
+
+      const remainderDays = Math.max(0, diffProposalDays(wholeDate, safeEnd));
+      return wholeMonths + (remainderDays / 30);
+    }
+
+    function setProposalReadonly(input, locked, options) {
+      if (!input) return;
+      input.readOnly = locked;
+      input.classList.toggle('readonly-field', locked);
+      if (locked) {
+        input.setAttribute('readonly', '');
+        input.tabIndex = -1;
+      } else {
+        input.removeAttribute('readonly');
+        input.removeAttribute('tabindex');
+      }
+      if (options?.lockPicker) {
+        if (input._flatpickr) {
+          input._flatpickr.set('clickOpens', !locked);
+        }
+        input.style.pointerEvents = locked ? 'none' : '';
+      }
+    }
+
     function formatProposalDateIso(date) {
       const year = String(date.getFullYear()).padStart(4, '0');
       const month = String(date.getMonth() + 1).padStart(2, '0');
@@ -5156,6 +5401,7 @@
           return;
         }
         if (!preliminaryDateValue && finalDateValue) {
+          syncProposalPreliminaryDateFromFinal();
           return;
         }
       }
@@ -5177,6 +5423,70 @@
       const finalWeeks = parseProposalDecimal(finalReportWeeksInput.value);
       if (!preliminaryDate || finalWeeks === null) return;
       setDateFieldValue(finalDateInput, formatProposalDateIso(addDecimalWeeks(preliminaryDate, finalWeeks)));
+    }
+
+    function syncProposalPreliminaryDateFromFinal() {
+      const preliminaryDateInput = form.querySelector('input[name="preliminary_report_date"]');
+      const finalDateInput = form.querySelector('input[name="final_report_date"]');
+      const finalReportWeeksInput = form.querySelector('[name="final_report_term_weeks"]');
+      if (!preliminaryDateInput || !finalDateInput || !finalReportWeeksInput) return;
+
+      const finalDate = parseProposalDate(finalDateInput.value);
+      const finalWeeks = parseProposalDecimal(finalReportWeeksInput.value);
+      if (!finalDate || finalWeeks === null) return;
+      setDateFieldValue(preliminaryDateInput, formatProposalDateIso(subtractDecimalWeeks(finalDate, finalWeeks)));
+    }
+
+    function syncProposalTermsFromDates() {
+      const preliminaryDateInput = form.querySelector('input[name="preliminary_report_date"]');
+      const finalDateInput = form.querySelector('input[name="final_report_date"]');
+      const serviceTermInput = form.querySelector('[name="service_term_months"]');
+      const finalReportWeeksInput = form.querySelector('[name="final_report_term_weeks"]');
+      if (!preliminaryDateInput || !finalDateInput || !serviceTermInput || !finalReportWeeksInput) return;
+
+      const preliminaryDate = parseProposalDate(preliminaryDateInput.value);
+      const finalDate = parseProposalDate(finalDateInput.value);
+      if (preliminaryDate) {
+        const months = decimalMonthsBetween(getProposalBaseStartDate(), preliminaryDate);
+        serviceTermInput.value = formatProposalDecimal(months);
+      } else {
+        serviceTermInput.value = '';
+      }
+
+      if (preliminaryDate && finalDate) {
+        const weeks = Math.max(0, diffProposalDays(preliminaryDate, finalDate) / 7);
+        finalReportWeeksInput.value = formatProposalDecimal(weeks);
+      } else {
+        finalReportWeeksInput.value = '';
+      }
+    }
+
+    let proposalReportTermsEditMode = false;
+
+    function applyProposalReportTermsLockState() {
+      const preliminaryDateInput = form.querySelector('input[name="preliminary_report_date"]');
+      const finalDateInput = form.querySelector('input[name="final_report_date"]');
+      const serviceTermInput = form.querySelector('[name="service_term_months"]');
+      const finalReportWeeksInput = form.querySelector('[name="final_report_term_weeks"]');
+      const lockIcons = qa('.js-proposal-report-terms-lock', form);
+      if (!preliminaryDateInput || !finalDateInput || !serviceTermInput || !finalReportWeeksInput) return;
+
+      if (proposalReportTermsEditMode) {
+        syncProposalTermsFromDates();
+      }
+
+      setProposalReadonly(preliminaryDateInput, proposalReportTermsEditMode, { lockPicker: true });
+      setProposalReadonly(finalDateInput, proposalReportTermsEditMode, { lockPicker: true });
+      setProposalReadonly(serviceTermInput, !proposalReportTermsEditMode);
+      setProposalReadonly(finalReportWeeksInput, !proposalReportTermsEditMode);
+
+      lockIcons.forEach(function (icon) {
+        icon.classList.toggle('bi-lock-fill', !proposalReportTermsEditMode);
+        icon.classList.toggle('bi-unlock-fill', proposalReportTermsEditMode);
+        icon.title = proposalReportTermsEditMode
+          ? 'Заблокировать ввод сроков'
+          : 'Разблокировать ввод сроков';
+      });
     }
 
     function initCompositeProposalField(options) {
@@ -5305,6 +5615,12 @@
     attachProposalLegalEntitiesToObjectsSync(form, legalEntitiesApi, objectsApi);
     form.querySelector('[name="advance_percent"]')?.addEventListener('input', syncFinalReportPercent);
     form.querySelector('[name="preliminary_report_percent"]')?.addEventListener('input', syncFinalReportPercent);
+    qa('.js-proposal-report-terms-lock', form).forEach(function (icon) {
+      icon.addEventListener('click', function () {
+        proposalReportTermsEditMode = !proposalReportTermsEditMode;
+        applyProposalReportTermsLockState();
+      });
+    });
     form.querySelector('select[name="type"]')?.addEventListener('change', function () {
       syncProposalServiceTermMonths(true);
       syncProposalReportDates(true);
@@ -5322,10 +5638,16 @@
       syncProposalReportDates(true);
     });
     form.querySelector('input[name="preliminary_report_date"]')?.addEventListener('input', function () {
-      syncProposalFinalDateFromPreliminary();
+      if (!proposalReportTermsEditMode) syncProposalFinalDateFromPreliminary();
     });
     form.querySelector('input[name="preliminary_report_date"]')?.addEventListener('change', function () {
-      syncProposalFinalDateFromPreliminary();
+      if (!proposalReportTermsEditMode) syncProposalFinalDateFromPreliminary();
+    });
+    form.querySelector('input[name="final_report_date"]')?.addEventListener('input', function () {
+      if (!proposalReportTermsEditMode) syncProposalPreliminaryDateFromFinal();
+    });
+    form.querySelector('input[name="final_report_date"]')?.addEventListener('change', function () {
+      if (!proposalReportTermsEditMode) syncProposalPreliminaryDateFromFinal();
     });
     form.querySelector('[name="asset_owner_matches_customer"]')?.addEventListener('change', function () {
       syncAssetOwnerFromCustomer('customer-sync');
@@ -5354,6 +5676,7 @@
       }
     });
     syncProposalServiceTermMonths(false);
+    applyProposalReportTermsLockState();
     syncProposalReportDates(false);
     ['asset_owner', 'asset_owner_registration_number', 'asset_owner_registration_date'].forEach(function (fieldName) {
       form.querySelector('[name="' + fieldName + '"]')?.addEventListener('change', function () {

--- a/core/static/core/js/proposals-panels.js
+++ b/core/static/core/js/proposals-panels.js
@@ -2073,9 +2073,8 @@
     const explicitMode = normalizeProposalTravelExpensesMode(fallbackValue);
     if (explicitMode) return explicitMode;
     const assetValues = Array.isArray(row?.asset_day_counts) ? row.asset_day_counts : [];
-    const hasSavedValues = assetValues.some(function (value) { return String(value ?? '').trim(); })
-      || String(row?.total_eur_without_vat || '').trim();
-    return hasSavedValues ? PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION : PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL;
+    const hasSavedAssetValues = assetValues.some(function (value) { return String(value ?? '').trim(); });
+    return hasSavedAssetValues ? PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION : PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL;
   }
 
   function parseProposalPercent(value) {
@@ -3430,6 +3429,11 @@
       if (!row || !isTravelRow(row)) return;
       const totalInput = row.querySelector('.proposal-commercial-total');
       if (!totalInput) return;
+      if (getTravelExpensesMode(row) !== PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION) {
+        const preservedRaw = rawMoney(row.dataset.preservedActualTotalRaw || '');
+        totalInput.value = preservedRaw ? fmtMoney(preservedRaw) : '';
+        return;
+      }
       const total = getDayInputs(row).reduce(function (sum, input) {
         const value = parseFloat(rawMoney(input.value || ''));
         return sum + (Number.isFinite(value) ? value : 0);
@@ -3935,6 +3939,7 @@
       const row = document.createElement('tr');
       row.dataset.travelExpensesRow = '1';
       row.dataset.travelExpensesMode = normalizeProposalTravelExpensesMode(mode) || PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL;
+      row.dataset.preservedActualTotalRaw = rawMoney(data?.total_eur_without_vat || '');
       row.className = 'proposal-commercial-travel-row';
 
       const labelTd = createProposalTableCell('proposal-commercial-travel-label-cell');
@@ -3972,6 +3977,9 @@
 
       rateSelect.addEventListener('change', function () {
         row.dataset.travelExpensesMode = normalizeProposalTravelExpensesMode(rateSelect.value) || PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL;
+        if (getTravelExpensesMode(row) === PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL) {
+          row.dataset.preservedActualTotalRaw = '';
+        }
         const nextValues = getTravelExpensesMode(row) === PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION
           ? getDayInputs(row).map(function (input) { return input.value || ''; })
           : [];

--- a/proposals_app/forms.py
+++ b/proposals_app/forms.py
@@ -1333,7 +1333,6 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
                     )
                 else:
                     asset_day_counts = ["" for _ in asset_day_counts]
-                    total_value = None
 
             cleaned_rows.append(
                 {

--- a/proposals_app/forms.py
+++ b/proposals_app/forms.py
@@ -30,6 +30,10 @@ from .cbr import get_cbr_eur_rate_for_today, get_cbr_eur_rate_text
 
 DATE_INPUT_ATTRS = {"class": "js-date", "autocomplete": "off"}
 DATE_INPUT_FORMATS = ["%Y-%m-%d", "%d.%m.%Y", "%d.%m.%y"]
+PROPOSAL_TRAVEL_EXPENSES_LABEL = "Командировочные расходы, евро"
+PROPOSAL_TRAVEL_EXPENSES_LABEL_LEGACY = "Командировочные расходы"
+PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL = "actual"
+PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION = "calculation"
 PROPOSAL_REPORT_LANGUAGE_LABELS = ("русский", "английский", "казахский", "китайский")
 PROPOSAL_REPORT_LANGUAGE_ALIASES = {
     "ru": "русский",
@@ -52,6 +56,11 @@ NON_EDITABLE_PROPOSAL_STATUSES = {
     ProposalRegistration.ProposalStatus.SENT,
     ProposalRegistration.ProposalStatus.COMPLETED,
 }
+
+
+def is_proposal_travel_expenses_name(value) -> bool:
+    name = str(value or "").strip()
+    return name in {PROPOSAL_TRAVEL_EXPENSES_LABEL, PROPOSAL_TRAVEL_EXPENSES_LABEL_LEGACY}
 
 
 class DisabledOptionsSelect(forms.Select):
@@ -836,6 +845,7 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
                 "discount_percent": "5",
                 "rub_total_service_text": get_cbr_eur_rate_text(),
                 "discounted_total_service_text": "Размер скидки:",
+                "travel_expenses_mode": PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL,
             }
             eur_rate = get_cbr_eur_rate_for_today()
             if eur_rate is not None:
@@ -1205,6 +1215,21 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
             ensure_ascii=False,
         )
 
+    def _extract_travel_expenses_mode_from_payload(self):
+        raw = str(self.data.get("commercial_totals_payload") or "").strip()
+        if not raw:
+            return ""
+        try:
+            payload = json.loads(raw)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return ""
+        if not isinstance(payload, dict):
+            return ""
+        mode = str(payload.get("travel_expenses_mode") or "").strip()
+        if mode in {PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL, PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION}:
+            return mode
+        return ""
+
     def clean_commercial_offer_payload(self):
         raw = (self.cleaned_data.get("commercial_offer_payload") or "").strip()
         if not raw:
@@ -1219,6 +1244,7 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
         if not isinstance(rows, list):
             raise forms.ValidationError("Некорректный формат данных по коммерческому предложению.")
 
+        travel_expenses_mode = self._extract_travel_expenses_mode_from_payload()
         cleaned_rows = []
         for idx, row in enumerate(rows, start=1):
             if not isinstance(row, dict):
@@ -1237,23 +1263,40 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
                     f"Строка коммерческого предложения #{idx}: поле «Количество дней» передано некорректно."
                 )
 
+            is_travel_expenses_row = is_proposal_travel_expenses_name(service_name)
             asset_day_counts = []
-            for day_idx, raw_value in enumerate(asset_day_counts_raw, start=1):
-                value = str(raw_value or "").strip()
-                if not value:
-                    asset_day_counts.append("")
-                    continue
-                try:
-                    parsed_int = int(value)
-                except (TypeError, ValueError):
-                    raise forms.ValidationError(
-                        f"Строка коммерческого предложения #{idx}: значение дня #{day_idx} заполнено некорректно."
+            if is_travel_expenses_row and travel_expenses_mode == PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION:
+                for day_idx, raw_value in enumerate(asset_day_counts_raw, start=1):
+                    value = str(raw_value or "").strip()
+                    if not value:
+                        asset_day_counts.append("")
+                        continue
+                    parsed_amount = self._parse_payload_decimal(
+                        value,
+                        f"Строка коммерческого предложения #{idx}: значение по активу #{day_idx} заполнено некорректно.",
                     )
-                if parsed_int < 0:
-                    raise forms.ValidationError(
-                        f"Строка коммерческого предложения #{idx}: значение дня #{day_idx} не может быть отрицательным."
-                    )
-                asset_day_counts.append(parsed_int)
+                    if parsed_amount is not None and parsed_amount < 0:
+                        raise forms.ValidationError(
+                            f"Строка коммерческого предложения #{idx}: значение по активу #{day_idx} не может быть отрицательным."
+                        )
+                    asset_day_counts.append(self._serialize_payload_decimal(parsed_amount))
+            else:
+                for day_idx, raw_value in enumerate(asset_day_counts_raw, start=1):
+                    value = str(raw_value or "").strip()
+                    if not value:
+                        asset_day_counts.append("")
+                        continue
+                    try:
+                        parsed_int = int(value)
+                    except (TypeError, ValueError):
+                        raise forms.ValidationError(
+                            f"Строка коммерческого предложения #{idx}: значение дня #{day_idx} заполнено некорректно."
+                        )
+                    if parsed_int < 0:
+                        raise forms.ValidationError(
+                            f"Строка коммерческого предложения #{idx}: значение дня #{day_idx} не может быть отрицательным."
+                        )
+                    asset_day_counts.append(parsed_int)
 
             row_has_data = any(
                 [
@@ -1277,6 +1320,20 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
                 total_raw,
                 f"Строка коммерческого предложения #{idx}: поле «Итого, евро без НДС» заполнено некорректно.",
             )
+            if is_travel_expenses_row:
+                rate_value = None
+                if travel_expenses_mode == PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION:
+                    total_value = sum(
+                        (
+                            Decimal(str(value))
+                            for value in asset_day_counts
+                            if value not in (None, "")
+                        ),
+                        Decimal("0"),
+                    )
+                else:
+                    asset_day_counts = ["" for _ in asset_day_counts]
+                    total_value = None
 
             cleaned_rows.append(
                 {
@@ -1338,9 +1395,15 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
             str(payload.get("contract_total_auto") or "").strip(),
             "Расчётное значение итога по договору заполнено некорректно.",
         )
+        travel_expenses_mode = str(payload.get("travel_expenses_mode") or "").strip() or PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL
 
         if discount_percent is not None and (discount_percent < 0 or discount_percent > 100):
             raise forms.ValidationError("Скидка должна быть в диапазоне от 0% до 100%.")
+        if travel_expenses_mode not in {
+            PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL,
+            PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION,
+        }:
+            raise forms.ValidationError("Режим строки командировочных расходов заполнен некорректно.")
 
         self.cleaned_commercial_totals = {
             "exchange_rate": self._serialize_payload_decimal(exchange_rate),
@@ -1349,6 +1412,7 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
             "contract_total_auto": self._serialize_payload_decimal(contract_total_auto),
             "rub_total_service_text": str(payload.get("rub_total_service_text") or "").strip(),
             "discounted_total_service_text": str(payload.get("discounted_total_service_text") or "").strip(),
+            "travel_expenses_mode": travel_expenses_mode,
         }
         return json.dumps(self.cleaned_commercial_totals, ensure_ascii=False)
 

--- a/proposals_app/templates/proposals_app/proposal_form_page.html
+++ b/proposals_app/templates/proposals_app/proposal_form_page.html
@@ -434,7 +434,12 @@
         {{ form.evaluation_date }}
       </div>
       <div class="col">
-        <label class="form-label">{{ form.service_term_months.label }}</label>
+        <label class="form-label">
+          {{ form.service_term_months.label }}
+          <i class="bi bi-lock-fill ms-1 js-proposal-report-terms-lock"
+             role="button"
+             title="Разблокировать ввод сроков"></i>
+        </label>
         {{ form.service_term_months }}
       </div>
       <div class="col">
@@ -442,7 +447,12 @@
         {{ form.preliminary_report_date }}
       </div>
       <div class="col">
-        <label class="form-label">{{ form.final_report_term_weeks.label }}</label>
+        <label class="form-label">
+          {{ form.final_report_term_weeks.label }}
+          <i class="bi bi-lock-fill ms-1 js-proposal-report-terms-lock"
+             role="button"
+             title="Разблокировать ввод сроков"></i>
+        </label>
         {{ form.final_report_term_weeks }}
       </div>
       <div class="col">

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -567,7 +567,7 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertEqual(table_spec["rows"][1][1]["text"], "Геолог, Партнер")
         self.assertTrue(table_spec["rows"][1][1]["no_wrap"])
         self.assertEqual(table_spec["rows"][1][-2]["text"], "6")
-        self.assertEqual(table_spec["rows"][7][0]["text"], "ИТОГО в договор, рубли без НДС с учётом доп. скидки")
+        self.assertEqual(table_spec["rows"][8][0]["text"], "ИТОГО в договор, рубли без НДС с учётом доп. скидки")
 
     def test_resolve_budget_table_omits_asset_column_for_single_asset(self):
         proposal = ProposalRegistration.objects.create(

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -388,23 +388,26 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertIn("Геолог, Партнер", budget_rows[1])
         self.assertIn("6", budget_rows[1])
         self.assertIn("7\u00a0200,00", budget_rows[1])
-        self.assertIn("Командировочные расходы", budget_rows[3][0])
-        self.assertIn("ИТОГО, по расчёту", budget_rows[4][0])
-        self.assertIn("10\u00a0400,00", budget_rows[4][-1])
-        self.assertIn("ИТОГО, рубли без НДС", budget_rows[5][0])
-        self.assertIn("96,5", budget_rows[5][2])
-        self.assertIn("1\u00a0003\u00a0600,00", budget_rows[5][-1])
-        self.assertIn("ИТОГО, рубли без НДС с учетом скидки", budget_rows[6][0])
-        self.assertIn("7,5%", budget_rows[6][2])
-        self.assertIn("928\u00a0330,00", budget_rows[6][-1])
-        self.assertIn("ИТОГО в договор, рубли без НДС с учётом доп. скидки", budget_rows[7][0])
-        self.assertIn("900\u00a0000,00", budget_rows[7][-1])
+        self.assertIn("ИТОГО, по расчёту", budget_rows[3][0])
+        self.assertIn("10\u00a0400,00", budget_rows[3][-1])
+        self.assertIn("Командировочные расходы, евро", budget_rows[4][0])
+        self.assertIn("ИТОГО, евро с командировочными по расчёту", budget_rows[5][0])
+        self.assertIn("10\u00a0900,00", budget_rows[5][-1])
+        self.assertIn("ИТОГО, рубли без НДС", budget_rows[6][0])
+        self.assertIn("96,5", budget_rows[6][2])
+        self.assertIn("1\u00a0051\u00a0850,00", budget_rows[6][-1])
+        self.assertIn("ИТОГО, рубли без НДС с учетом скидки", budget_rows[7][0])
+        self.assertIn("7,5%", budget_rows[7][2])
+        self.assertIn("972\u00a0961,25", budget_rows[7][-1])
+        self.assertIn("ИТОГО в договор, рубли без НДС с учётом доп. скидки", budget_rows[8][0])
+        self.assertIn("900\u00a0000,00", budget_rows[8][-1])
         self.assertIn('w:tblLayout w:type="autofit"', budget_table._tbl.xml)
         self.assertIn('w:tblW w:type="auto" w:w="0"', budget_table._tbl.xml)
-        empty_fixed_cell = budget_table.rows[5].cells[3]
+        empty_fixed_cell = budget_table.rows[6].cells[3]
         self.assertTrue(empty_fixed_cell.paragraphs)
         self.assertTrue(empty_fixed_cell.paragraphs[0].runs)
         self.assertEqual(empty_fixed_cell.paragraphs[0].runs[0].font.size.pt, 7)
+        self.assertIn('w:sz w:val="14"', empty_fixed_cell.paragraphs[0]._element.xml)
         budget_run_sizes = [
             run.font.size.pt
             for row in budget_table.rows
@@ -566,7 +569,7 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertEqual(table_spec["rows"][1][-2]["text"], "6")
         self.assertEqual(table_spec["rows"][7][0]["text"], "ИТОГО в договор, рубли без НДС с учётом доп. скидки")
 
-    def test_resolve_budget_table_omits_total_days_column_for_single_asset(self):
+    def test_resolve_budget_table_omits_asset_column_for_single_asset(self):
         proposal = ProposalRegistration.objects.create(
             number=4444,
             group_member=self.group_member,
@@ -606,10 +609,12 @@ class ProposalDocumentGenerationTests(TestCase):
                 "Специалист",
                 "Должность/направление",
                 "Ставка,\n€/дн",
-                "Единственный актив",
+                "Кол-во\nдней",
                 "Итого,\n€ без НДС",
             ],
         )
+        self.assertEqual(tables["[[budget_table]]"]["font_size_pt"], 8)
+        self.assertEqual(tables["[[budget_table]]"]["column_widths_pct"], [20, 50, 10, 10, 10])
         data_row = tables["[[budget_table]]"]["rows"][1]
         self.assertEqual(len(data_row), 5)
         self.assertEqual(data_row[3]["text"], "2")
@@ -647,17 +652,19 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertIn("Геолог, Партнер", budget_rows[1])
         self.assertIn("6", budget_rows[1])
         self.assertIn("7\u00a0200,00", budget_rows[1])
-        self.assertIn("Командировочные расходы", budget_rows[3][0])
-        self.assertIn("ИТОГО, по расчёту", budget_rows[4][0])
-        self.assertIn("10\u00a0400,00", budget_rows[4][-1])
-        self.assertIn("ИТОГО, рубли без НДС", budget_rows[5][0])
-        self.assertIn("96,5", budget_rows[5][2])
-        self.assertIn("1\u00a0003\u00a0600,00", budget_rows[5][-1])
-        self.assertIn("ИТОГО, рубли без НДС с учетом скидки", budget_rows[6][0])
-        self.assertIn("7,5%", budget_rows[6][2])
-        self.assertIn("928\u00a0330,00", budget_rows[6][-1])
-        self.assertIn("ИТОГО в договор, рубли без НДС с учётом доп. скидки", budget_rows[7][0])
-        self.assertIn("900\u00a0000,00", budget_rows[7][-1])
+        self.assertIn("ИТОГО, по расчёту", budget_rows[3][0])
+        self.assertIn("10\u00a0400,00", budget_rows[3][-1])
+        self.assertIn("Командировочные расходы, евро", budget_rows[4][0])
+        self.assertIn("ИТОГО, евро с командировочными по расчёту", budget_rows[5][0])
+        self.assertIn("10\u00a0900,00", budget_rows[5][-1])
+        self.assertIn("ИТОГО, рубли без НДС", budget_rows[6][0])
+        self.assertIn("96,5", budget_rows[6][2])
+        self.assertIn("1\u00a0051\u00a0850,00", budget_rows[6][-1])
+        self.assertIn("ИТОГО, рубли без НДС с учетом скидки", budget_rows[7][0])
+        self.assertIn("7,5%", budget_rows[7][2])
+        self.assertIn("972\u00a0961,25", budget_rows[7][-1])
+        self.assertIn("ИТОГО в договор, рубли без НДС с учётом доп. скидки", budget_rows[8][0])
+        self.assertIn("900\u00a0000,00", budget_rows[8][-1])
         self.assertIn('w:tblLayout w:type="autofit"', budget_table._tbl.xml)
         self.assertIn('w:tblW w:type="auto" w:w="0"', budget_table._tbl.xml)
         budget_run_sizes = [
@@ -670,6 +677,68 @@ class ProposalDocumentGenerationTests(TestCase):
         ]
         self.assertTrue(budget_run_sizes)
         self.assertTrue(all(size == 7 for size in budget_run_sizes))
+
+    def test_process_template_inserts_single_asset_budget_table_with_pct_widths(self):
+        proposal = ProposalRegistration.objects.create(
+            number=5555,
+            group_member=self.group_member,
+            type=self.product,
+            name="Один актив",
+            year=2026,
+            status=ProposalRegistration.ProposalStatus.PRELIMINARY,
+            customer='ООО "Приморское"',
+        )
+        ProposalAsset.objects.create(
+            proposal=proposal,
+            short_name="Единственный актив",
+            position=1,
+        )
+        ProposalCommercialOffer.objects.create(
+            proposal=proposal,
+            specialist="Иванов И.И.",
+            job_title="Геолог",
+            professional_status="Партнер",
+            service_name="Раздел 1",
+            rate_eur_per_day="1200",
+            asset_day_counts=[2],
+            total_eur_without_vat="2400",
+            position=1,
+        )
+
+        template_doc = Document()
+        template_doc.add_paragraph("[[budget_table]]")
+        buffer = BytesIO()
+        template_doc.save(buffer)
+
+        replacements, lists, tables = resolve_variables(
+            proposal,
+            [ProposalVariable(key="[[budget_table]]", is_computed=True)],
+        )
+
+        generated_bytes = process_template(
+            buffer.getvalue(),
+            replacements,
+            table_replacements=tables,
+            list_replacements=lists,
+            default_language_code="ru-RU",
+        )
+
+        generated_doc = Document(BytesIO(generated_bytes))
+        budget_table = generated_doc.tables[0]
+        self.assertIn('w:tblLayout w:type="fixed"', budget_table._tbl.xml)
+        self.assertIn('w:tblW w:type="pct" w:w="5000"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="1000"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="2500"', budget_table._tbl.xml)
+        budget_run_sizes = [
+            run.font.size.pt
+            for row in budget_table.rows
+            for cell in row.cells
+            for paragraph in cell.paragraphs
+            for run in paragraph.runs
+            if run.text.strip()
+        ]
+        self.assertTrue(budget_run_sizes)
+        self.assertTrue(all(size == 8 for size in budget_run_sizes))
 
     @patch("ai_app.proposals_app.document_generation.get_any_connected_service_user")
     @patch("ai_app.proposals_app.document_generation.is_nextcloud_primary", return_value=False)
@@ -1525,6 +1594,7 @@ class ProposalRegistrationFormTests(TestCase):
                 "rub_total_service_text": f"Курс евро Банка России на {timezone.localdate().strftime('%d.%m.%Y')}:",
                 "discounted_total_service_text": "Размер скидки:",
                 "exchange_rate": "96.5432",
+                "travel_expenses_mode": "actual",
             },
         )
 
@@ -2832,7 +2902,8 @@ class ProposalRegistrationFormTests(TestCase):
                 "commercial_totals_payload": (
                     '{"exchange_rate":"96.50","discount_percent":"7.50",'
                     '"contract_total":"1200000","contract_total_auto":"1300000",'
-                    '"rub_total_service_text":"Курс ЦБ","discounted_total_service_text":"Скидка проекта"}'
+                    '"rub_total_service_text":"Курс ЦБ","discounted_total_service_text":"Скидка проекта",'
+                    '"travel_expenses_mode":"calculation"}'
                 ),
             }
         )
@@ -2849,6 +2920,7 @@ class ProposalRegistrationFormTests(TestCase):
                 "contract_total_auto": "1300000",
                 "rub_total_service_text": "Курс ЦБ",
                 "discounted_total_service_text": "Скидка проекта",
+                "travel_expenses_mode": "calculation",
             },
         )
 
@@ -2894,7 +2966,8 @@ class ProposalRegistrationFormTests(TestCase):
                 "commercial_totals_payload": (
                     '{"exchange_rate":"0","discount_percent":"0",'
                     '"contract_total":"0","contract_total_auto":"0",'
-                    '"rub_total_service_text":"Курс ЦБ","discounted_total_service_text":"Скидка проекта"}'
+                    '"rub_total_service_text":"Курс ЦБ","discounted_total_service_text":"Скидка проекта",'
+                    '"travel_expenses_mode":"actual"}'
                 ),
             }
         )
@@ -2911,6 +2984,7 @@ class ProposalRegistrationFormTests(TestCase):
                 "contract_total_auto": "0",
                 "rub_total_service_text": "Курс ЦБ",
                 "discounted_total_service_text": "Скидка проекта",
+                "travel_expenses_mode": "actual",
             },
         )
 
@@ -3453,6 +3527,7 @@ class ProposalFormContextTests(TestCase):
         self.assertContains(response, 'name="final_report_term_weeks"', html=False)
         self.assertContains(response, 'name="final_report_date"', html=False)
         self.assertContains(response, 'id="proposal-typical-service-terms-data"', html=False)
+        self.assertContains(response, 'js-proposal-report-terms-lock', count=2, html=False)
 
 
 class ProposalNextcloudWorkspaceHookTests(TestCase):

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -2924,6 +2924,65 @@ class ProposalRegistrationFormTests(TestCase):
             },
         )
 
+    def test_form_preserves_legacy_travel_total_in_actual_mode(self):
+        country = OKSMCountry.objects.create(
+            number=643,
+            code="643",
+            short_name="Россия",
+            full_name="Российская Федерация",
+            alpha2="RU",
+            alpha3="RUS",
+            position=1,
+        )
+        group_member = GroupMember.objects.create(
+            short_name="IMC Montan",
+            country_name="Россия",
+            country_code="643",
+            country_alpha2="RU",
+            position=1,
+        )
+        product = Product.objects.create(
+            short_name="DD",
+            name_en="Due Diligence",
+            name_ru="ДД",
+            service_type="service",
+            position=1,
+        )
+
+        form = ProposalRegistrationForm(
+            data={
+                "number": 3333,
+                "group_member": group_member.pk,
+                "type": product.pk,
+                "name": "Тестовое ТКП",
+                "kind": ProposalRegistration.ProposalKind.REGULAR,
+                "status": ProposalRegistration.ProposalStatus.FINAL,
+                "year": 2026,
+                "customer": 'ООО "Приморское"',
+                "country": country.pk,
+                "identifier": "ОГРН",
+                "registration_number": "1174910001683",
+                "registration_date": "01.04.2026",
+                "commercial_offer_payload": (
+                    '[{"specialist":"","job_title":"","professional_status":"",'
+                    '"service_name":"Командировочные расходы, евро","rate_eur_per_day":"",'
+                    '"asset_day_counts":["",""],"total_eur_without_vat":"500.00"}]'
+                ),
+                "commercial_totals_payload": (
+                    '{"discount_percent":"5","travel_expenses_mode":"actual"}'
+                ),
+            }
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        proposal = form.save()
+        form.save_commercial_offers(proposal)
+
+        offer = ProposalCommercialOffer.objects.get(proposal=proposal)
+        self.assertEqual(offer.service_name, "Командировочные расходы, евро")
+        self.assertEqual(offer.asset_day_counts, ["", ""])
+        self.assertEqual(str(offer.total_eur_without_vat), "500.00")
+
     def test_form_preserves_zero_values_in_commercial_totals_payload(self):
         country = OKSMCountry.objects.create(
             number=643,

--- a/proposals_app/variable_resolver.py
+++ b/proposals_app/variable_resolver.py
@@ -293,11 +293,20 @@ def _proposal_scope_of_work(proposal) -> list[dict[str, str] | str]:
     return fallback if isinstance(fallback, list) else [fallback]
 
 
-PROPOSAL_TRAVEL_EXPENSES_LABEL = "Командировочные расходы"
+PROPOSAL_TRAVEL_EXPENSES_LABEL = "Командировочные расходы, евро"
+PROPOSAL_TRAVEL_EXPENSES_LABEL_LEGACY = "Командировочные расходы"
+PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL = "actual"
+PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION = "calculation"
 PROPOSAL_SUMMARY_TOTAL_LABEL = "ИТОГО, по расчёту"
+PROPOSAL_SUMMARY_WITH_TRAVEL_TOTAL_LABEL = "ИТОГО, евро с командировочными по расчёту"
 PROPOSAL_RUB_TOTAL_LABEL = "ИТОГО, рубли без НДС"
 PROPOSAL_RUB_DISCOUNTED_LABEL = "ИТОГО, рубли без НДС с учетом скидки"
 PROPOSAL_CONTRACT_TOTAL_LABEL = "ИТОГО в договор, рубли без НДС с учётом доп. скидки"
+
+
+def _is_proposal_travel_expenses_name(value) -> bool:
+    name = str(value or "").strip()
+    return name in {PROPOSAL_TRAVEL_EXPENSES_LABEL, PROPOSAL_TRAVEL_EXPENSES_LABEL_LEGACY}
 
 
 def _parse_decimal(value) -> Decimal | None:
@@ -319,6 +328,22 @@ def _sum_day_counts(values) -> int:
     return total
 
 
+def _sum_decimal_values(values) -> Decimal:
+    total = Decimal("0")
+    for value in values:
+        parsed = _parse_decimal(str(value or "").strip().replace(",", "."))
+        if parsed is not None:
+            total += parsed
+    return total
+
+
+def _normalize_proposal_travel_expenses_mode(value) -> str:
+    mode = str(value or "").strip()
+    if mode in {PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL, PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION}:
+        return mode
+    return ""
+
+
 def _round_to_hundred_thousand(value: Decimal | None) -> Decimal | None:
     if value is None:
         return None
@@ -331,14 +356,14 @@ def _proposal_budget_table(proposal) -> dict:
         (
             item
             for item in offers
-            if str(getattr(item, "service_name", "") or "").strip() == PROPOSAL_TRAVEL_EXPENSES_LABEL
+            if _is_proposal_travel_expenses_name(getattr(item, "service_name", ""))
         ),
         None,
     )
     regular_offers = [
         item
         for item in offers
-        if str(getattr(item, "service_name", "") or "").strip() != PROPOSAL_TRAVEL_EXPENSES_LABEL
+        if not _is_proposal_travel_expenses_name(getattr(item, "service_name", ""))
     ]
 
     asset_labels = [
@@ -350,7 +375,8 @@ def _proposal_budget_table(proposal) -> dict:
         default=0,
     )
     asset_count = max(len(asset_labels), max_asset_count, 1)
-    show_total_days_column = asset_count > 1
+    show_asset_columns = asset_count > 1
+    show_total_days_column = True
     while len(asset_labels) < asset_count:
         asset_labels.append(f"Актив {len(asset_labels) + 1}")
     asset_labels = [label or f"Актив {index + 1}" for index, label in enumerate(asset_labels)]
@@ -360,27 +386,27 @@ def _proposal_budget_table(proposal) -> dict:
             {"text": "Специалист", "bold": True, "align": "left", "header": True, "vertical_align": "center"},
             {"text": "Должность/направление", "bold": True, "align": "left", "header": True, "vertical_align": "center", "no_wrap": True},
             {"text": "Ставка,\n€/дн", "bold": True, "align": "right", "header": True, "vertical_align": "center"},
-            *[
-                {
-                    "text": label,
-                    "bold": True,
-                    "align": "center",
-                    "header": True,
-                    "vertical_align": "center",
-                    "margins_cm": {
-                        "top": 0,
-                        "right": 0,
-                        "bottom": 0,
-                        "left": 0,
-                    },
-                }
-                for label in asset_labels
-            ],
             *(
-                [{"text": "Кол-во\nдней", "bold": True, "align": "right", "header": True, "vertical_align": "center"}]
-                if show_total_days_column
+                [
+                    {
+                        "text": label,
+                        "bold": True,
+                        "align": "center",
+                        "header": True,
+                        "vertical_align": "center",
+                        "margins_cm": {
+                            "top": 0,
+                            "right": 0,
+                            "bottom": 0,
+                            "left": 0,
+                        },
+                    }
+                    for label in asset_labels
+                ]
+                if show_asset_columns
                 else []
             ),
+            {"text": "Кол-во\nдней", "bold": True, "align": "right", "header": True, "vertical_align": "center"},
             {"text": "Итого,\n€ без НДС", "bold": True, "align": "right", "header": True, "vertical_align": "center"},
         ],
     ]
@@ -408,15 +434,15 @@ def _proposal_budget_table(proposal) -> dict:
                 {"text": str(getattr(item, "specialist", "") or "").strip()},
                 {"text": direction, "no_wrap": True},
                 {"text": _format_money(getattr(item, "rate_eur_per_day", None)), "align": "right"},
-                *[
-                    {"text": value, "align": "right"}
-                    for value in day_values
-                ],
                 *(
-                    [{"text": str(_sum_day_counts(day_values)) if _sum_day_counts(day_values) else "", "align": "right"}]
-                    if show_total_days_column
+                    [
+                        {"text": value, "align": "right"}
+                        for value in day_values
+                    ]
+                    if show_asset_columns
                     else []
                 ),
+                {"text": str(_sum_day_counts(day_values)) if _sum_day_counts(day_values) else "", "align": "right"},
                 {"text": _format_money(getattr(item, "total_eur_without_vat", None)), "align": "right"},
             ]
         )
@@ -440,10 +466,25 @@ def _proposal_budget_table(proposal) -> dict:
         (_parse_decimal(getattr(item, "total_eur_without_vat", None)) or Decimal("0"))
         for item in regular_offers
     )
+    travel_total = Decimal("0")
+    travel_day_values = []
+    if travel_offer is not None:
+        travel_day_values = build_day_values(getattr(travel_offer, "asset_day_counts", []) or [])
+        travel_total = _sum_decimal_values(travel_day_values)
+        if travel_total == Decimal("0"):
+            travel_total = _parse_decimal(getattr(travel_offer, "total_eur_without_vat", None)) or Decimal("0")
+    summary_with_travel_total = summary_total + travel_total
     totals_state = getattr(proposal, "commercial_totals_json", {}) or {}
+    travel_expenses_mode = _normalize_proposal_travel_expenses_mode(totals_state.get("travel_expenses_mode"))
+    if not travel_expenses_mode:
+        travel_expenses_mode = (
+            PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION
+            if travel_total or any(str(value or "").strip() for value in travel_day_values)
+            else PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL
+        )
     exchange_rate = _parse_decimal(totals_state.get("exchange_rate"))
     discount_percent = _parse_decimal(totals_state.get("discount_percent"))
-    rub_total = (summary_total * exchange_rate) if exchange_rate is not None else None
+    rub_total = (summary_with_travel_total * exchange_rate) if exchange_rate is not None else None
     discounted_total = (
         rub_total - (rub_total * (discount_percent / Decimal("100")))
         if rub_total is not None and discount_percent is not None
@@ -462,26 +503,17 @@ def _proposal_budget_table(proposal) -> dict:
             [
                 {"text": label, "colspan": label_colspan, "bold": True},
                 {"text": str(rate or ""), "align": "right"},
-                *[
-                    {"text": str(value or ""), "align": "right"}
-                    for value in current_day_values
-                ],
                 *(
-                    [{"text": str(_sum_day_counts(current_day_values)) if _sum_day_counts(current_day_values) else "", "align": "right"}]
-                    if show_total_days_column
+                    [
+                        {"text": str(value or ""), "align": "right"}
+                        for value in current_day_values
+                    ]
+                    if show_asset_columns
                     else []
                 ),
+                {"text": str(_sum_day_counts(current_day_values)) if _sum_day_counts(current_day_values) else "", "align": "right"},
                 {"text": str(total or ""), "align": "right"},
             ]
-        )
-
-    if travel_offer is not None:
-        travel_day_values = build_day_values(getattr(travel_offer, "asset_day_counts", []) or [])
-        append_fixed_row(
-            PROPOSAL_TRAVEL_EXPENSES_LABEL,
-            rate="по факту",
-            day_values=travel_day_values,
-            total=_format_money(getattr(travel_offer, "total_eur_without_vat", None)),
         )
 
     append_fixed_row(
@@ -489,6 +521,19 @@ def _proposal_budget_table(proposal) -> dict:
         rate="",
         day_values=summary_day_values,
         total=_format_money(summary_total),
+    )
+    if travel_offer is not None:
+        append_fixed_row(
+            PROPOSAL_TRAVEL_EXPENSES_LABEL,
+            rate="расчёт" if travel_expenses_mode == PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION else "по факту",
+            day_values=travel_day_values,
+            total=_format_money(travel_total),
+        )
+    append_fixed_row(
+        PROPOSAL_SUMMARY_WITH_TRAVEL_TOTAL_LABEL,
+        rate="",
+        day_values=[],
+        total=_format_money(summary_with_travel_total),
     )
     append_fixed_row(
         PROPOSAL_RUB_TOTAL_LABEL,
@@ -511,8 +556,9 @@ def _proposal_budget_table(proposal) -> dict:
 
     return {
         "rows": rows,
-        "font_size_pt": 7,
+        "font_size_pt": 8 if not show_asset_columns else 7,
         "style": "Table Grid",
+        "column_widths_pct": [20, 50, 10, 10, 10] if not show_asset_columns else [],
     }
 
 


### PR DESCRIPTION
## Summary
- improve editing behavior in the proposal registry form
- refine budget table layout, labels, and travel expense handling
- fix UI autofill and responsive truncation issues
## Test plan
- [ ] open proposal registry edit form
- [ ] verify date/term lock behavior
- [ ] verify commercial table layout on narrow screen
- [ ] verify travel expenses row modes
- [ ] verify adding a new asset does not autofill customer name