### PR TITLE
Adjust single-asset budget table column widths

### DIFF
--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -614,7 +614,7 @@ class ProposalDocumentGenerationTests(TestCase):
             ],
         )
         self.assertEqual(tables["[[budget_table]]"]["font_size_pt"], 8)
-        self.assertEqual(tables["[[budget_table]]"]["column_widths_pct"], [20, 50, 10, 10, 10])
+        self.assertEqual(tables["[[budget_table]]"]["column_widths_pct"], [18, 46, 12, 12, 12])
         data_row = tables["[[budget_table]]"]["rows"][1]
         self.assertEqual(len(data_row), 5)
         self.assertEqual(data_row[3]["text"], "2")

--- a/proposals_app/variable_resolver.py
+++ b/proposals_app/variable_resolver.py
@@ -558,7 +558,7 @@ def _proposal_budget_table(proposal) -> dict:
         "rows": rows,
         "font_size_pt": 8 if not show_asset_columns else 7,
         "style": "Table Grid",
-        "column_widths_pct": [20, 50, 10, 10, 10] if not show_asset_columns else [],
+        "column_widths_pct": [18, 46, 12, 12, 12] if not show_asset_columns else [],
     }
 
 


### PR DESCRIPTION
## Summary
- update single-asset budget table column widths to 18/46/12/12/12
- align the related test expectation with the new layout
## Test plan
- [ ] verify generated budget table for a single asset uses the new widths
- [ ] run the affected proposal budget table tests