### PR TITLE
Add proposal facsimile signing support

### DIFF
--- a/contracts_app/docx_processor.py
+++ b/contracts_app/docx_processor.py
@@ -1372,7 +1372,7 @@ def _append_floating_image_run(
     x_offset_cm: float = 0,
     y_offset_cm: float = 0,
 ) -> None:
-    from docx.image.exceptions import UnrecognizedImageError
+    from docx.image.exceptions import UnexpectedEndOfFileError, UnrecognizedImageError
 
     run = paragraph.add_run()
     try:
@@ -1380,7 +1380,7 @@ def _append_floating_image_run(
             run.add_picture(BytesIO(image_bytes))
         else:
             run.add_picture(BytesIO(image_bytes), width=Cm(width_cm))
-    except UnrecognizedImageError as exc:
+    except (UnrecognizedImageError, UnexpectedEndOfFileError) as exc:
         raise RuntimeError(
             "Факсимиле должно быть изображением в поддерживаемом формате Word (например PNG или JPEG)."
         ) from exc

--- a/contracts_app/docx_processor.py
+++ b/contracts_app/docx_processor.py
@@ -1212,6 +1212,229 @@ def _process_tables(
                 )
 
 
+def _iter_table_paragraphs(tables):
+    for table in tables:
+        for row in table.rows:
+            for cell in row.cells:
+                for paragraph in cell.paragraphs:
+                    yield paragraph
+                yield from _iter_table_paragraphs(cell.tables)
+
+
+def _iter_document_paragraphs(doc):
+    for paragraph in doc.paragraphs:
+        yield paragraph
+    yield from _iter_table_paragraphs(doc.tables)
+    for section in doc.sections:
+        for header_footer in (
+            section.header,
+            section.footer,
+            section.first_page_header,
+            section.first_page_footer,
+            section.even_page_header,
+            section.even_page_footer,
+        ):
+            if header_footer and header_footer.is_linked_to_previous:
+                continue
+            if header_footer:
+                for paragraph in header_footer.paragraphs:
+                    yield paragraph
+                yield from _iter_table_paragraphs(header_footer.tables)
+
+
+def _replace_literal_in_paragraph(paragraph, literal: str, replacement: str = "") -> int:
+    runs = paragraph.runs
+    if not runs:
+        return 0
+
+    full_text = "".join(run.text for run in runs)
+    matches = list(re.finditer(re.escape(str(literal or "")), full_text))
+    if not matches:
+        return 0
+
+    run_texts = [run.text for run in runs]
+    run_starts: list[int] = []
+    offset = 0
+    for text in run_texts:
+        run_starts.append(offset)
+        offset += len(text)
+
+    def _run_at(char_pos: int) -> int:
+        for index in range(len(run_starts) - 1, -1, -1):
+            if char_pos >= run_starts[index]:
+                return index
+        return 0
+
+    for match in reversed(matches):
+        start, end = match.start(), match.end()
+        first_run_idx = _run_at(start)
+        last_run_idx = _run_at(end - 1)
+
+        if first_run_idx == last_run_idx:
+            local_start = start - run_starts[first_run_idx]
+            local_end = end - run_starts[first_run_idx]
+            current = run_texts[first_run_idx]
+            run_texts[first_run_idx] = current[:local_start] + replacement + current[local_end:]
+            continue
+
+        first_text = run_texts[first_run_idx]
+        local_start = start - run_starts[first_run_idx]
+        run_texts[first_run_idx] = first_text[:local_start] + replacement
+
+        last_text = run_texts[last_run_idx]
+        local_end = end - run_starts[last_run_idx]
+        run_texts[last_run_idx] = last_text[local_end:]
+
+        for middle_idx in range(first_run_idx + 1, last_run_idx):
+            run_texts[middle_idx] = ""
+
+    for index, run in enumerate(runs):
+        run.text = run_texts[index]
+    return len(matches)
+
+
+def _build_anchor_from_inline(inline, *, x_offset_emu: int = 0, y_offset_emu: int = 0):
+    from docx.oxml import OxmlElement
+
+    anchor = OxmlElement("wp:anchor")
+    anchor.set("behindDoc", "1")
+    anchor.set("distT", "0")
+    anchor.set("distB", "0")
+    anchor.set("distL", "0")
+    anchor.set("distR", "0")
+    anchor.set("simplePos", "0")
+    anchor.set("relativeHeight", "0")
+    anchor.set("locked", "0")
+    anchor.set("layoutInCell", "1")
+    anchor.set("allowOverlap", "1")
+
+    simple_pos = OxmlElement("wp:simplePos")
+    simple_pos.set("x", "0")
+    simple_pos.set("y", "0")
+    anchor.append(simple_pos)
+
+    position_h = OxmlElement("wp:positionH")
+    position_h.set("relativeFrom", "column")
+    pos_offset_h = OxmlElement("wp:posOffset")
+    pos_offset_h.text = str(int(x_offset_emu))
+    position_h.append(pos_offset_h)
+    anchor.append(position_h)
+
+    position_v = OxmlElement("wp:positionV")
+    position_v.set("relativeFrom", "paragraph")
+    pos_offset_v = OxmlElement("wp:posOffset")
+    pos_offset_v.text = str(int(y_offset_emu))
+    position_v.append(pos_offset_v)
+    anchor.append(position_v)
+
+    extent = inline.find(qn("wp:extent"))
+    if extent is not None:
+        anchor.append(deepcopy(extent))
+    effect_extent = inline.find(qn("wp:effectExtent"))
+    if effect_extent is not None:
+        anchor.append(deepcopy(effect_extent))
+    else:
+        effect_extent = OxmlElement("wp:effectExtent")
+        effect_extent.set("l", "0")
+        effect_extent.set("t", "0")
+        effect_extent.set("r", "0")
+        effect_extent.set("b", "0")
+        anchor.append(effect_extent)
+
+    anchor.append(OxmlElement("wp:wrapNone"))
+
+    doc_pr = inline.find(qn("wp:docPr"))
+    if doc_pr is not None:
+        anchor.append(deepcopy(doc_pr))
+    else:
+        generated_doc_pr = OxmlElement("wp:docPr")
+        generated_doc_pr.set("id", str(uuid.uuid4().int % 100000))
+        generated_doc_pr.set("name", "FloatingImage")
+        anchor.append(generated_doc_pr)
+
+    c_nv_graphic_frame_pr = inline.find(qn("wp:cNvGraphicFramePr"))
+    if c_nv_graphic_frame_pr is not None:
+        anchor.append(deepcopy(c_nv_graphic_frame_pr))
+    else:
+        anchor.append(OxmlElement("wp:cNvGraphicFramePr"))
+
+    graphic = inline.find(qn("a:graphic"))
+    if graphic is not None:
+        anchor.append(deepcopy(graphic))
+    return anchor
+
+
+def _append_floating_image_run(
+    paragraph,
+    image_bytes: bytes,
+    *,
+    width_cm: float | None = 4.0,
+    x_offset_cm: float = 0,
+    y_offset_cm: float = 0,
+) -> None:
+    from docx.image.exceptions import UnrecognizedImageError
+
+    run = paragraph.add_run()
+    try:
+        if width_cm is None:
+            run.add_picture(BytesIO(image_bytes))
+        else:
+            run.add_picture(BytesIO(image_bytes), width=Cm(width_cm))
+    except UnrecognizedImageError as exc:
+        raise RuntimeError(
+            "Факсимиле должно быть изображением в поддерживаемом формате Word (например PNG или JPEG)."
+        ) from exc
+
+    drawing = run._r.find(qn("w:drawing"))
+    inline = drawing.find(qn("wp:inline")) if drawing is not None else None
+    if drawing is None or inline is None:
+        raise RuntimeError("Не удалось вставить факсимиле в DOCX-документ.")
+
+    anchor = _build_anchor_from_inline(
+        inline,
+        x_offset_emu=int(Cm(x_offset_cm).emu),
+        y_offset_emu=int(Cm(y_offset_cm).emu),
+    )
+    drawing.remove(inline)
+    drawing.append(anchor)
+
+
+def insert_floating_image_at_placeholder(
+    file_bytes: bytes,
+    image_bytes: bytes,
+    *,
+    placeholder: str = "[[facsimile]]",
+    width_cm: float | None = 4.0,
+    x_offset_cm: float = 0,
+    y_offset_cm: float = 0,
+) -> bytes:
+    if not file_bytes or not image_bytes or not str(placeholder or "").strip():
+        return file_bytes
+
+    doc = Document(BytesIO(file_bytes))
+    inserted = False
+    for paragraph in _iter_document_paragraphs(doc):
+        occurrences = _replace_literal_in_paragraph(paragraph, placeholder, "")
+        if not occurrences:
+            continue
+        for _ in range(occurrences):
+            _append_floating_image_run(
+                paragraph,
+                image_bytes,
+                width_cm=width_cm,
+                x_offset_cm=x_offset_cm,
+                y_offset_cm=y_offset_cm,
+            )
+        inserted = True
+
+    if not inserted:
+        return file_bytes
+
+    out = BytesIO()
+    doc.save(out)
+    return out.getvalue()
+
+
 def process_template(
     file_bytes: bytes,
     replacements: dict[str, str],

--- a/proposals_app/document_generation.py
+++ b/proposals_app/document_generation.py
@@ -180,16 +180,17 @@ def _proposal_docx_source_token_ttl() -> int:
     return int(getattr(settings, "ONLYOFFICE_DOCX_SOURCE_TOKEN_TTL", 300) or 300)
 
 
-def build_proposal_docx_source_token(proposal) -> str:
+def build_proposal_docx_source_token(proposal, *, signer_user_id: int | None = None) -> str:
     payload = {
         "proposal_id": int(proposal.pk),
         "docx_file_name": str(getattr(proposal, "docx_file_name", "") or "").strip(),
         "docx_file_link": str(getattr(proposal, "docx_file_link", "") or "").strip(),
+        "signer_user_id": int(signer_user_id) if signer_user_id else None,
     }
     return signing.dumps(payload, salt=PROPOSAL_DOCX_SOURCE_TOKEN_SALT, compress=True)
 
 
-def is_valid_proposal_docx_source_token(proposal, token: str) -> bool:
+def get_proposal_docx_source_token_payload(proposal, token: str) -> dict[str, object] | None:
     try:
         payload = signing.loads(
             str(token or "").strip(),
@@ -197,17 +198,23 @@ def is_valid_proposal_docx_source_token(proposal, token: str) -> bool:
             max_age=_proposal_docx_source_token_ttl(),
         )
     except signing.BadSignature:
-        return False
+        return None
 
-    return (
+    if not (
         payload.get("proposal_id") == proposal.pk
         and payload.get("docx_file_name") == str(getattr(proposal, "docx_file_name", "") or "").strip()
         and payload.get("docx_file_link") == str(getattr(proposal, "docx_file_link", "") or "").strip()
-    )
+    ):
+        return None
+    return payload
 
 
-def build_proposal_docx_source_url(request, proposal) -> str:
-    token = build_proposal_docx_source_token(proposal)
+def is_valid_proposal_docx_source_token(proposal, token: str) -> bool:
+    return get_proposal_docx_source_token_payload(proposal, token) is not None
+
+
+def build_proposal_docx_source_url(request, proposal, *, signer_user_id: int | None = None) -> str:
+    token = build_proposal_docx_source_token(proposal, signer_user_id=signer_user_id)
     path = reverse("proposal_onlyoffice_docx_source", args=[proposal.pk])
     query = urlencode({"token": token})
     if request is not None:

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+import base64
 import json
 import tempfile
 from datetime import date, datetime
 from decimal import Decimal
 from io import BytesIO
 from unittest.mock import Mock, patch
-from urllib.parse import quote
+from urllib.parse import parse_qs, quote, urlparse
 
 from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -42,8 +44,13 @@ from projects_app.models import ProjectRegistration
 from users_app.models import Employee
 from yandexdisk_app.models import YandexDiskAccount
 
-from contracts_app.docx_processor import process_template
-from .document_generation import generate_and_store_proposal_pdf, store_generated_documents
+from contracts_app.docx_processor import insert_floating_image_at_placeholder, process_template
+from .document_generation import (
+    build_proposal_docx_source_token,
+    generate_and_store_proposal_pdf,
+    get_proposal_docx_source_token_payload,
+    store_generated_documents,
+)
 from .forms import ProposalDispatchForm, ProposalRegistrationForm, _proposal_variable_column_choices
 from .forms import ProposalVariableForm
 from .models import (
@@ -57,6 +64,10 @@ from .models import (
 )
 from .views import PROPOSAL_NEXTCLOUD_TARGETS_SESSION_KEY
 from .variable_resolver import resolve_variables
+
+TEST_FACSIMILE_PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMBAAZ/qh8AAAAASUVORK5CYII="
+)
 
 
 @override_settings(MEDIA_URL="/media/")
@@ -557,6 +568,10 @@ class ProposalDocumentGenerationTests(TestCase):
         table_spec = tables["[[budget_table]]"]
         self.assertEqual(table_spec["font_size_pt"], 7)
         self.assertEqual(table_spec["style"], "Table Grid")
+        self.assertEqual(len(table_spec["column_widths_pct"]), 8)
+        self.assertEqual(table_spec["column_widths_pct"][:3], [15.5, 40.0, 7.0])
+        self.assertEqual(table_spec["column_widths_pct"][-2:], [6.0, 15.5])
+        self.assertTrue(all(width == table_spec["column_widths_pct"][3] for width in table_spec["column_widths_pct"][3:6]))
         self.assertEqual(table_spec["rows"][0][0]["text"], "Специалист")
         self.assertEqual(table_spec["rows"][0][2]["text"], "Ставка,\n€/дн")
         self.assertEqual(table_spec["rows"][0][-2]["text"], "Кол-во\nдней")
@@ -665,8 +680,13 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertIn("972\u00a0961,25", budget_rows[7][-1])
         self.assertIn("ИТОГО в договор, рубли без НДС с учётом доп. скидки", budget_rows[8][0])
         self.assertIn("900\u00a0000,00", budget_rows[8][-1])
-        self.assertIn('w:tblLayout w:type="autofit"', budget_table._tbl.xml)
-        self.assertIn('w:tblW w:type="auto" w:w="0"', budget_table._tbl.xml)
+        self.assertIn('w:tblLayout w:type="fixed"', budget_table._tbl.xml)
+        self.assertIn('w:tblW w:type="pct" w:w="5000"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="775"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="2000"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="350"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="267"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="300"', budget_table._tbl.xml)
         budget_run_sizes = [
             run.font.size.pt
             for row in budget_table.rows
@@ -740,6 +760,24 @@ class ProposalDocumentGenerationTests(TestCase):
         ]
         self.assertTrue(budget_run_sizes)
         self.assertTrue(all(size == 8 for size in budget_run_sizes))
+
+    def test_insert_floating_image_at_placeholder_replaces_marker_with_anchor(self):
+        template_doc = Document()
+        template_doc.add_paragraph("Подпись [[facsimile]]")
+        buffer = BytesIO()
+        template_doc.save(buffer)
+
+        generated_bytes = insert_floating_image_at_placeholder(
+            buffer.getvalue(),
+            TEST_FACSIMILE_PNG_BYTES,
+        )
+
+        generated_doc = Document(BytesIO(generated_bytes))
+        paragraph = generated_doc.paragraphs[0]
+        self.assertEqual(paragraph.text, "Подпись ")
+        self.assertIn("wp:anchor", paragraph._p.xml)
+        self.assertIn('behindDoc="1"', paragraph._p.xml)
+        self.assertNotIn("[[facsimile]]", paragraph._p.xml)
 
     @patch("ai_app.proposals_app.document_generation.get_any_connected_service_user")
     @patch("ai_app.proposals_app.document_generation.is_nextcloud_primary", return_value=False)
@@ -1218,6 +1256,12 @@ class ProposalDispatchSendTests(TestCase):
 @override_settings(ROOT_URLCONF="proposals_app.urls")
 class ProposalDispatchSignTests(TestCase):
     def setUp(self):
+        self.temp_media = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_media.cleanup)
+        self.media_override = override_settings(MEDIA_ROOT=self.temp_media.name)
+        self.media_override.enable()
+        self.addCleanup(self.media_override.disable)
+
         self.user = get_user_model().objects.create_user(
             username="proposal-dispatch-pdf-staff",
             email="staff@example.com",
@@ -1225,6 +1269,13 @@ class ProposalDispatchSignTests(TestCase):
             is_staff=True,
         )
         self.client.force_login(self.user)
+        self.employee = Employee.objects.create(user=self.user, patronymic="Иванович")
+        self.expert_profile = ExpertProfile.objects.create(employee=self.employee, position=1)
+        self.expert_profile.facsimile_file.save(
+            "facsimile.png",
+            ContentFile(TEST_FACSIMILE_PNG_BYTES),
+            save=True,
+        )
 
         self.group_member = GroupMember.objects.create(
             short_name="IMC Montan",
@@ -1295,11 +1346,62 @@ class ProposalDispatchSignTests(TestCase):
         mocked_generate_and_store_proposal_pdf.assert_called_once()
         self.assertEqual(mocked_generate_and_store_proposal_pdf.call_args.args[0], self.user)
         self.assertEqual(mocked_generate_and_store_proposal_pdf.call_args.args[1], self.proposal)
+        source_url = mocked_generate_and_store_proposal_pdf.call_args.kwargs["source_url"]
         self.assertTrue(
-            mocked_generate_and_store_proposal_pdf.call_args.kwargs["source_url"].startswith(
+            source_url.startswith(
                 f"http://testserver{reverse('proposal_onlyoffice_docx_source', args=[self.proposal.pk])}?token="
             )
         )
+        token = parse_qs(urlparse(source_url).query)["token"][0]
+        token_payload = get_proposal_docx_source_token_payload(self.proposal, token)
+        self.assertIsNotNone(token_payload)
+        self.assertEqual(token_payload["signer_user_id"], self.user.pk)
+
+    @patch("proposals_app.views.generate_and_store_proposal_pdf")
+    def test_dispatch_sign_returns_error_without_current_user_facsimile(
+        self,
+        mocked_generate_and_store_proposal_pdf,
+    ):
+        self.expert_profile.facsimile_file.delete(save=True)
+
+        response = self.client.post(
+            reverse("proposal_dispatch_sign_documents"),
+            {
+                "proposal_ids[]": [self.proposal.pk],
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertFalse(payload["ok"])
+        self.assertIn("Факсимиле", payload["error"])
+        mocked_generate_and_store_proposal_pdf.assert_not_called()
+
+    @patch("proposals_app.views.load_existing_proposal_docx_bytes")
+    def test_onlyoffice_docx_source_inserts_facsimile_behind_text(
+        self,
+        mocked_load_existing_proposal_docx_bytes,
+    ):
+        template_doc = Document()
+        template_doc.add_paragraph("[[facsimile]]")
+        buffer = BytesIO()
+        template_doc.save(buffer)
+        mocked_load_existing_proposal_docx_bytes.return_value = buffer.getvalue()
+
+        response = self.client.get(
+            reverse("proposal_onlyoffice_docx_source", args=[self.proposal.pk]),
+            {
+                "token": build_proposal_docx_source_token(self.proposal, signer_user_id=self.user.pk),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        generated_doc = Document(BytesIO(response.content))
+        paragraph = generated_doc.paragraphs[0]
+        self.assertEqual(paragraph.text, "")
+        self.assertIn("wp:anchor", paragraph._p.xml)
+        self.assertIn('behindDoc="1"', paragraph._p.xml)
+        self.assertNotIn("[[facsimile]]", paragraph._p.xml)
 
 
 @override_settings(ROOT_URLCONF="proposals_app.urls")

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -412,8 +412,13 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertIn("972\u00a0961,25", budget_rows[7][-1])
         self.assertIn("ИТОГО в договор, рубли без НДС с учётом доп. скидки", budget_rows[8][0])
         self.assertIn("900\u00a0000,00", budget_rows[8][-1])
-        self.assertIn('w:tblLayout w:type="autofit"', budget_table._tbl.xml)
-        self.assertIn('w:tblW w:type="auto" w:w="0"', budget_table._tbl.xml)
+        self.assertIn('w:tblLayout w:type="fixed"', budget_table._tbl.xml)
+        self.assertIn('w:tblW w:type="pct" w:w="5000"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="775"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="2000"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="350"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="267"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="300"', budget_table._tbl.xml)
         empty_fixed_cell = budget_table.rows[6].cells[3]
         self.assertTrue(empty_fixed_cell.paragraphs)
         self.assertTrue(empty_fixed_cell.paragraphs[0].runs)
@@ -778,6 +783,21 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertIn("wp:anchor", paragraph._p.xml)
         self.assertIn('behindDoc="1"', paragraph._p.xml)
         self.assertNotIn("[[facsimile]]", paragraph._p.xml)
+
+    def test_insert_floating_image_at_placeholder_rejects_truncated_image(self):
+        template_doc = Document()
+        template_doc.add_paragraph("[[facsimile]]")
+        buffer = BytesIO()
+        template_doc.save(buffer)
+
+        with self.assertRaisesMessage(
+            RuntimeError,
+            "Факсимиле должно быть изображением в поддерживаемом формате Word",
+        ):
+            insert_floating_image_at_placeholder(
+                buffer.getvalue(),
+                TEST_FACSIMILE_PNG_BYTES[:16],
+            )
 
     @patch("ai_app.proposals_app.document_generation.get_any_connected_service_user")
     @patch("ai_app.proposals_app.document_generation.is_nextcloud_primary", return_value=False)

--- a/proposals_app/variable_resolver.py
+++ b/proposals_app/variable_resolver.py
@@ -337,6 +337,17 @@ def _sum_decimal_values(values) -> Decimal:
     return total
 
 
+def _proposal_multi_asset_column_widths_pct(asset_count: int) -> list[float]:
+    if asset_count <= 0:
+        return []
+    fixed_total = Decimal("84.0")
+    fixed_columns = [Decimal("15.5"), Decimal("40"), Decimal("7")]
+    trailing_columns = [Decimal("6"), Decimal("15.5")]
+    asset_width = (Decimal("100.0") - fixed_total) / Decimal(str(asset_count))
+    widths = fixed_columns + [asset_width] * asset_count + trailing_columns
+    return [float(width) for width in widths]
+
+
 def _normalize_proposal_travel_expenses_mode(value) -> str:
     mode = str(value or "").strip()
     if mode in {PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL, PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION}:
@@ -558,7 +569,7 @@ def _proposal_budget_table(proposal) -> dict:
         "rows": rows,
         "font_size_pt": 8 if not show_asset_columns else 7,
         "style": "Table Grid",
-        "column_widths_pct": [18, 46, 12, 12, 12] if not show_asset_columns else [],
+        "column_widths_pct": [18, 46, 12, 12, 12] if not show_asset_columns else _proposal_multi_asset_column_widths_pct(asset_count),
     }
 
 

--- a/proposals_app/views.py
+++ b/proposals_app/views.py
@@ -56,8 +56,8 @@ from .document_generation import (
     build_proposal_docx_source_url,
     generate_and_store_proposal_pdf,
     get_generated_docx_path,
+    get_proposal_docx_source_token_payload,
     is_onlyoffice_conversion_configured,
-    is_valid_proposal_docx_source_token,
     load_existing_proposal_docx_bytes,
     store_generated_documents,
 )
@@ -76,12 +76,56 @@ HX_TRIGGER_HEADER = "HX-Trigger"
 HX_PROPOSALS_UPDATED_EVENT = "proposals-updated"
 PROPOSAL_NEXTCLOUD_TARGETS_SESSION_KEY = "proposal_nextcloud_target_paths"
 logger = logging.getLogger(__name__)
+PROPOSAL_FACSIMILE_PLACEHOLDER = "[[facsimile]]"
+PROPOSAL_FACSIMILE_ALLOWED_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tif", ".tiff"}
 
 # CI can import this module through either `proposals_app.views` or
 # `ai_app.proposals_app.views`. Keep both names bound to the same module object
 # so patch() targets stay stable.
 sys.modules.setdefault("proposals_app.views", sys.modules[__name__])
 sys.modules.setdefault("ai_app.proposals_app.views", sys.modules[__name__])
+
+
+def _get_proposal_signer_expert_profile(user_id: int | None) -> ExpertProfile:
+    try:
+        clean_user_id = int(user_id or 0)
+    except (TypeError, ValueError):
+        clean_user_id = 0
+    if clean_user_id <= 0:
+        raise RuntimeError("Не удалось определить пользователя, подписывающего ТКП.")
+    try:
+        return ExpertProfile.objects.select_related("employee", "employee__user").get(employee__user_id=clean_user_id)
+    except ExpertProfile.DoesNotExist as exc:
+        raise RuntimeError(
+            "Для текущего пользователя не заполнена строка в разделе «Эксперты -> Реквизиты для договора»."
+        ) from exc
+
+
+def _load_proposal_signer_facsimile_bytes(user_id: int | None) -> bytes:
+    profile = _get_proposal_signer_expert_profile(user_id)
+    facsimile = getattr(profile, "facsimile_file", None)
+    facsimile_name = str(getattr(facsimile, "name", "") or "").strip()
+    if not facsimile_name:
+        raise RuntimeError(
+            "Для текущего пользователя не заполнено поле «Факсимиле» в разделе «Эксперты -> Реквизиты для договора»."
+        )
+
+    file_extension = os.path.splitext(facsimile_name)[1].lower()
+    if file_extension and file_extension not in PROPOSAL_FACSIMILE_ALLOWED_EXTENSIONS:
+        raise RuntimeError("Факсимиле должно быть изображением в формате PNG, JPG, GIF, BMP или TIFF.")
+
+    try:
+        facsimile.open("rb")
+        try:
+            facsimile_bytes = facsimile.read()
+        finally:
+            facsimile.close()
+    except Exception as exc:
+        raise RuntimeError("Не удалось прочитать файл факсимиле текущего пользователя.") from exc
+
+    if not facsimile_bytes:
+        raise RuntimeError("Файл факсимиле текущего пользователя пустой.")
+    return facsimile_bytes
 
 
 def _normalize_nextcloud_path(path: str) -> str:
@@ -1667,6 +1711,19 @@ def proposal_dispatch_sign_documents(request):
     if len(proposals) != len(proposal_ids):
         return JsonResponse({"ok": False, "error": "Часть выбранных строк не найдена."}, status=400)
 
+    try:
+        _load_proposal_signer_facsimile_bytes(getattr(request.user, "pk", None))
+    except RuntimeError as exc:
+        return JsonResponse(
+            {
+                "ok": False,
+                "error": str(exc),
+                "generated": 0,
+                "warnings": [],
+            },
+            status=400,
+        )
+
     pdf_updates = []
     errors = []
 
@@ -1678,7 +1735,11 @@ def proposal_dispatch_sign_documents(request):
             stored_pdf = generate_and_store_proposal_pdf(
                 request.user,
                 proposal,
-                source_url=build_proposal_docx_source_url(request, proposal),
+                source_url=build_proposal_docx_source_url(
+                    request,
+                    proposal,
+                    signer_user_id=getattr(request.user, "pk", None),
+                ),
             )
         except Exception as exc:
             errors.append(f"{proposal.short_uid}: {exc}")
@@ -1842,7 +1903,8 @@ def proposal_dispatch_create_documents(request):
 def proposal_onlyoffice_docx_source(request, pk: int):
     proposal = get_object_or_404(ProposalRegistration, pk=pk)
     token = str(request.GET.get("token") or "").strip()
-    if not is_valid_proposal_docx_source_token(proposal, token):
+    token_payload = get_proposal_docx_source_token_payload(proposal, token)
+    if token_payload is None:
         return HttpResponseForbidden("Недействительная ссылка на DOCX-файл ТКП.")
 
     try:
@@ -1852,6 +1914,20 @@ def proposal_onlyoffice_docx_source(request, pk: int):
         )
     except RuntimeError as exc:
         raise Http404(str(exc))
+
+    signer_user_id = token_payload.get("signer_user_id") if isinstance(token_payload, dict) else None
+    if signer_user_id:
+        try:
+            facsimile_bytes = _load_proposal_signer_facsimile_bytes(signer_user_id)
+            from contracts_app.docx_processor import insert_floating_image_at_placeholder
+
+            docx_bytes = insert_floating_image_at_placeholder(
+                docx_bytes,
+                facsimile_bytes,
+                placeholder=PROPOSAL_FACSIMILE_PLACEHOLDER,
+            )
+        except RuntimeError as exc:
+            return HttpResponse(str(exc), status=400)
 
     file_name = str(getattr(proposal, "docx_file_name", "") or "").strip() or "proposal.docx"
     response = HttpResponse(docx_bytes, content_type=DOCX_CONTENT_TYPE)

--- a/proposals_app/views.py
+++ b/proposals_app/views.py
@@ -1687,12 +1687,6 @@ def proposal_dispatch_transfer_to_contract(request):
 @user_passes_test(staff_required)
 @require_POST
 def proposal_dispatch_sign_documents(request):
-    if not is_onlyoffice_conversion_configured():
-        return JsonResponse(
-            {"ok": False, "error": "Не настроен ONLYOFFICE Document Server для генерации PDF."},
-            status=400,
-        )
-
     raw_ids = request.POST.getlist("proposal_ids[]") or request.POST.getlist("proposal_ids")
     if not raw_ids:
         return JsonResponse({"ok": False, "error": "Не выбраны строки для подписи ТКП."}, status=400)
@@ -1721,6 +1715,12 @@ def proposal_dispatch_sign_documents(request):
                 "generated": 0,
                 "warnings": [],
             },
+            status=400,
+        )
+
+    if not is_onlyoffice_conversion_configured():
+        return JsonResponse(
+            {"ok": False, "error": "Не настроен ONLYOFFICE Document Server для генерации PDF."},
             status=400,
         )
 


### PR DESCRIPTION
## Summary
- insert the current user's facsimile into proposal DOCX files during the sign-to-PDF flow
- validate that the signer has a configured facsimile and return a clear error otherwise
- update related proposal document generation and budget table tests
## Test plan
- [x] ./.venv/bin/python -m pytest -q proposals_app/tests.py -k "facsimile or dispatch_sign or onlyoffice_docx_source or generate_and_store_pdf_uses_onlyoffice"
- [ ] manually verify `[[facsimile]]` replacement in the signed PDF