### PR TITLE
Update proposal signing and budget table layout

### DIFF
--- a/contracts_app/docx_processor.py
+++ b/contracts_app/docx_processor.py
@@ -1293,7 +1293,14 @@ def _replace_literal_in_paragraph(paragraph, literal: str, replacement: str = ""
     return len(matches)
 
 
-def _build_anchor_from_inline(inline, *, x_offset_emu: int = 0, y_offset_emu: int = 0):
+def _build_anchor_from_inline(
+    inline,
+    *,
+    x_offset_emu: int = 0,
+    y_offset_emu: int = 0,
+    x_relative_from: str = "column",
+    x_align: str | None = None,
+):
     from docx.oxml import OxmlElement
 
     anchor = OxmlElement("wp:anchor")
@@ -1314,10 +1321,15 @@ def _build_anchor_from_inline(inline, *, x_offset_emu: int = 0, y_offset_emu: in
     anchor.append(simple_pos)
 
     position_h = OxmlElement("wp:positionH")
-    position_h.set("relativeFrom", "column")
-    pos_offset_h = OxmlElement("wp:posOffset")
-    pos_offset_h.text = str(int(x_offset_emu))
-    position_h.append(pos_offset_h)
+    position_h.set("relativeFrom", x_relative_from)
+    if x_align:
+        align_h = OxmlElement("wp:align")
+        align_h.text = str(x_align)
+        position_h.append(align_h)
+    else:
+        pos_offset_h = OxmlElement("wp:posOffset")
+        pos_offset_h.text = str(int(x_offset_emu))
+        position_h.append(pos_offset_h)
     anchor.append(position_h)
 
     position_v = OxmlElement("wp:positionV")
@@ -1368,9 +1380,11 @@ def _append_floating_image_run(
     paragraph,
     image_bytes: bytes,
     *,
-    width_cm: float | None = 4.0,
+    width_cm: float | None = None,
     x_offset_cm: float = 0,
     y_offset_cm: float = 0,
+    x_relative_from: str = "page",
+    x_align: str | None = "center",
 ) -> None:
     from docx.image.exceptions import UnexpectedEndOfFileError, UnrecognizedImageError
 
@@ -1394,6 +1408,8 @@ def _append_floating_image_run(
         inline,
         x_offset_emu=int(Cm(x_offset_cm).emu),
         y_offset_emu=int(Cm(y_offset_cm).emu),
+        x_relative_from=x_relative_from,
+        x_align=x_align,
     )
     drawing.remove(inline)
     drawing.append(anchor)
@@ -1404,9 +1420,11 @@ def insert_floating_image_at_placeholder(
     image_bytes: bytes,
     *,
     placeholder: str = "[[facsimile]]",
-    width_cm: float | None = 4.0,
+    width_cm: float | None = None,
     x_offset_cm: float = 0,
     y_offset_cm: float = 0,
+    x_relative_from: str = "page",
+    x_align: str | None = "center",
 ) -> bytes:
     if not file_bytes or not image_bytes or not str(placeholder or "").strip():
         return file_bytes
@@ -1424,6 +1442,8 @@ def insert_floating_image_at_placeholder(
                 width_cm=width_cm,
                 x_offset_cm=x_offset_cm,
                 y_offset_cm=y_offset_cm,
+                x_relative_from=x_relative_from,
+                x_align=x_align,
             )
         inserted = True
 

--- a/proposals_app/document_generation.py
+++ b/proposals_app/document_generation.py
@@ -362,6 +362,37 @@ def generate_and_store_proposal_pdf(user, proposal, *, source_url: str) -> dict[
     return store_generated_pdf_document(user, proposal, pdf_bytes)
 
 
+def store_existing_proposal_docx_bytes(user, proposal, docx_bytes: bytes) -> dict[str, str]:
+    docx_name = str(getattr(proposal, "docx_file_name", "") or "").strip()
+    raw_link = str(getattr(proposal, "docx_file_link", "") or "").strip()
+    media_url = str(getattr(settings, "MEDIA_URL", "") or "").strip()
+
+    if raw_link:
+        if media_url and raw_link.startswith(media_url):
+            relative_path = raw_link[len(media_url):].lstrip("/")
+            local_media_path = Path(settings.MEDIA_ROOT) / relative_path
+            local_media_path.parent.mkdir(parents=True, exist_ok=True)
+            local_media_path.write_bytes(docx_bytes)
+            return {
+                "docx_name": docx_name or local_media_path.name,
+                "docx_path": raw_link,
+                "output_dir": str(local_media_path.parent),
+            }
+
+        cloud_user = _get_cloud_upload_user(user)
+        if not cloud_user:
+            raise RuntimeError("Не найден пользователь с подключенным облачным хранилищем для загрузки DOCX.")
+        if not cloud_upload_file(cloud_user, raw_link, docx_bytes):
+            raise RuntimeError("Не удалось обновить DOCX в рабочей папке ТКП.")
+        return {
+            "docx_name": docx_name or posixpath.basename(raw_link),
+            "docx_path": raw_link,
+            "output_dir": posixpath.dirname(raw_link) or "/",
+        }
+
+    return store_generated_documents(user, proposal, docx_bytes, None)
+
+
 def store_generated_documents(user, proposal, docx_bytes: bytes, pdf_bytes: bytes | None = None) -> dict[str, str]:
     paths = build_proposal_workspace_document_paths(proposal)
     cloud_user = _get_cloud_upload_user(user)

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -417,8 +417,9 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertIn('w:tcW w:type="pct" w:w="775"', budget_table._tbl.xml)
         self.assertIn('w:tcW w:type="pct" w:w="2000"', budget_table._tbl.xml)
         self.assertIn('w:tcW w:type="pct" w:w="350"', budget_table._tbl.xml)
-        self.assertIn('w:tcW w:type="pct" w:w="267"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="358"', budget_table._tbl.xml)
         self.assertIn('w:tcW w:type="pct" w:w="300"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="500"', budget_table._tbl.xml)
         empty_fixed_cell = budget_table.rows[6].cells[3]
         self.assertTrue(empty_fixed_cell.paragraphs)
         self.assertTrue(empty_fixed_cell.paragraphs[0].runs)
@@ -575,7 +576,7 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertEqual(table_spec["style"], "Table Grid")
         self.assertEqual(len(table_spec["column_widths_pct"]), 8)
         self.assertEqual(table_spec["column_widths_pct"][:3], [15.5, 40.0, 7.0])
-        self.assertEqual(table_spec["column_widths_pct"][-2:], [6.0, 15.5])
+        self.assertEqual(table_spec["column_widths_pct"][-2:], [6.0, 10.0])
         self.assertTrue(all(width == table_spec["column_widths_pct"][3] for width in table_spec["column_widths_pct"][3:6]))
         self.assertEqual(table_spec["rows"][0][0]["text"], "Специалист")
         self.assertEqual(table_spec["rows"][0][2]["text"], "Ставка,\n€/дн")
@@ -690,8 +691,9 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertIn('w:tcW w:type="pct" w:w="775"', budget_table._tbl.xml)
         self.assertIn('w:tcW w:type="pct" w:w="2000"', budget_table._tbl.xml)
         self.assertIn('w:tcW w:type="pct" w:w="350"', budget_table._tbl.xml)
-        self.assertIn('w:tcW w:type="pct" w:w="267"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="358"', budget_table._tbl.xml)
         self.assertIn('w:tcW w:type="pct" w:w="300"', budget_table._tbl.xml)
+        self.assertIn('w:tcW w:type="pct" w:w="500"', budget_table._tbl.xml)
         budget_run_sizes = [
             run.font.size.pt
             for row in budget_table.rows
@@ -782,6 +784,8 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertEqual(paragraph.text, "Подпись ")
         self.assertIn("wp:anchor", paragraph._p.xml)
         self.assertIn('behindDoc="1"', paragraph._p.xml)
+        self.assertIn('wp:positionH relativeFrom="page"', paragraph._p.xml)
+        self.assertIn("<wp:align>center</wp:align>", paragraph._p.xml)
         self.assertNotIn("[[facsimile]]", paragraph._p.xml)
 
     def test_insert_floating_image_at_placeholder_rejects_truncated_image(self):
@@ -1333,11 +1337,25 @@ class ProposalDispatchSignTests(TestCase):
         )
 
     @override_settings(ONLYOFFICE_DOCUMENT_SERVER_URL="https://docs.example.com")
+    @patch("proposals_app.views.store_existing_proposal_docx_bytes")
+    @patch("proposals_app.views.load_existing_proposal_docx_bytes")
     @patch("proposals_app.views.generate_and_store_proposal_pdf")
     def test_dispatch_sign_generates_pdf_via_dedicated_endpoint(
         self,
         mocked_generate_and_store_proposal_pdf,
+        mocked_load_existing_proposal_docx_bytes,
+        mocked_store_existing_proposal_docx_bytes,
     ):
+        template_doc = Document()
+        template_doc.add_paragraph("[[facsimile]]")
+        buffer = BytesIO()
+        template_doc.save(buffer)
+        mocked_load_existing_proposal_docx_bytes.return_value = buffer.getvalue()
+        mocked_store_existing_proposal_docx_bytes.return_value = {
+            "docx_name": "existing-offer.docx",
+            "docx_path": "/Corporate Root/ТКП/2026/333300RU DD Приморское/existing-offer.docx",
+            "output_dir": "/Corporate Root/ТКП/2026/333300RU DD Приморское",
+        }
         mocked_generate_and_store_proposal_pdf.return_value = {
             "pdf_name": "existing-offer.pdf",
             "pdf_path": "/Corporate Root/ТКП/2026/333300RU DD Приморское/existing-offer.pdf",
@@ -1363,6 +1381,8 @@ class ProposalDispatchSignTests(TestCase):
             self.proposal.pdf_file_link,
             "/Corporate Root/ТКП/2026/333300RU DD Приморское/existing-offer.pdf",
         )
+        mocked_load_existing_proposal_docx_bytes.assert_called_once_with(self.user, self.proposal)
+        mocked_store_existing_proposal_docx_bytes.assert_called_once()
         mocked_generate_and_store_proposal_pdf.assert_called_once()
         self.assertEqual(mocked_generate_and_store_proposal_pdf.call_args.args[0], self.user)
         self.assertEqual(mocked_generate_and_store_proposal_pdf.call_args.args[1], self.proposal)
@@ -1376,6 +1396,47 @@ class ProposalDispatchSignTests(TestCase):
         token_payload = get_proposal_docx_source_token_payload(self.proposal, token)
         self.assertIsNotNone(token_payload)
         self.assertEqual(token_payload["signer_user_id"], self.user.pk)
+
+    @override_settings(ONLYOFFICE_DOCUMENT_SERVER_URL="https://docs.example.com")
+    @patch("proposals_app.views.store_existing_proposal_docx_bytes")
+    @patch("proposals_app.views.load_existing_proposal_docx_bytes")
+    @patch("proposals_app.views.generate_and_store_proposal_pdf")
+    def test_dispatch_sign_inserts_facsimile_into_saved_docx(
+        self,
+        mocked_generate_and_store_proposal_pdf,
+        mocked_load_existing_proposal_docx_bytes,
+        mocked_store_existing_proposal_docx_bytes,
+    ):
+        template_doc = Document()
+        template_doc.add_paragraph("Подпись [[facsimile]]")
+        buffer = BytesIO()
+        template_doc.save(buffer)
+        mocked_load_existing_proposal_docx_bytes.return_value = buffer.getvalue()
+        mocked_store_existing_proposal_docx_bytes.return_value = {
+            "docx_name": "existing-offer.docx",
+            "docx_path": "/Corporate Root/ТКП/2026/333300RU DD Приморское/existing-offer.docx",
+            "output_dir": "/Corporate Root/ТКП/2026/333300RU DD Приморское",
+        }
+        mocked_generate_and_store_proposal_pdf.return_value = {
+            "pdf_name": "existing-offer.pdf",
+            "pdf_path": "/Corporate Root/ТКП/2026/333300RU DD Приморское/existing-offer.pdf",
+        }
+
+        response = self.client.post(
+            reverse("proposal_dispatch_sign_documents"),
+            {
+                "proposal_ids[]": [self.proposal.pk],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        saved_docx_bytes = mocked_store_existing_proposal_docx_bytes.call_args.args[2]
+        saved_doc = Document(BytesIO(saved_docx_bytes))
+        paragraph = saved_doc.paragraphs[0]
+        self.assertEqual(paragraph.text, "Подпись ")
+        self.assertIn("wp:anchor", paragraph._p.xml)
+        self.assertIn('behindDoc="1"', paragraph._p.xml)
+        self.assertNotIn("[[facsimile]]", paragraph._p.xml)
 
     @patch("proposals_app.views.generate_and_store_proposal_pdf")
     def test_dispatch_sign_returns_error_without_current_user_facsimile(
@@ -1421,6 +1482,8 @@ class ProposalDispatchSignTests(TestCase):
         self.assertEqual(paragraph.text, "")
         self.assertIn("wp:anchor", paragraph._p.xml)
         self.assertIn('behindDoc="1"', paragraph._p.xml)
+        self.assertIn('wp:positionH relativeFrom="page"', paragraph._p.xml)
+        self.assertIn("<wp:align>center</wp:align>", paragraph._p.xml)
         self.assertNotIn("[[facsimile]]", paragraph._p.xml)
 
 

--- a/proposals_app/variable_resolver.py
+++ b/proposals_app/variable_resolver.py
@@ -340,9 +340,9 @@ def _sum_decimal_values(values) -> Decimal:
 def _proposal_multi_asset_column_widths_pct(asset_count: int) -> list[float]:
     if asset_count <= 0:
         return []
-    fixed_total = Decimal("84.0")
     fixed_columns = [Decimal("15.5"), Decimal("40"), Decimal("7")]
-    trailing_columns = [Decimal("6"), Decimal("15.5")]
+    trailing_columns = [Decimal("6"), Decimal("10")]
+    fixed_total = sum(fixed_columns + trailing_columns, Decimal("0"))
     asset_width = (Decimal("100.0") - fixed_total) / Decimal(str(asset_count))
     widths = fixed_columns + [asset_width] * asset_count + trailing_columns
     return [float(width) for width in widths]

--- a/proposals_app/views.py
+++ b/proposals_app/views.py
@@ -59,6 +59,7 @@ from .document_generation import (
     get_proposal_docx_source_token_payload,
     is_onlyoffice_conversion_configured,
     load_existing_proposal_docx_bytes,
+    store_existing_proposal_docx_bytes,
     store_generated_documents,
 )
 from .models import ProposalRegistration, ProposalTemplate, ProposalVariable
@@ -1706,7 +1707,7 @@ def proposal_dispatch_sign_documents(request):
         return JsonResponse({"ok": False, "error": "Часть выбранных строк не найдена."}, status=400)
 
     try:
-        _load_proposal_signer_facsimile_bytes(getattr(request.user, "pk", None))
+        facsimile_bytes = _load_proposal_signer_facsimile_bytes(getattr(request.user, "pk", None))
     except RuntimeError as exc:
         return JsonResponse(
             {
@@ -1724,7 +1725,7 @@ def proposal_dispatch_sign_documents(request):
             status=400,
         )
 
-    pdf_updates = []
+    document_updates = []
     errors = []
 
     for proposal in proposals:
@@ -1732,6 +1733,28 @@ def proposal_dispatch_sign_documents(request):
             errors.append(f"Для {proposal.short_uid} сначала сформируйте DOCX-файл ТКП.")
             continue
         try:
+            original_docx_name = str(getattr(proposal, "docx_file_name", "") or "").strip()
+            original_docx_link = str(getattr(proposal, "docx_file_link", "") or "").strip()
+            docx_bytes = load_existing_proposal_docx_bytes(request.user, proposal)
+            from contracts_app.docx_processor import insert_floating_image_at_placeholder
+
+            signed_docx_bytes = insert_floating_image_at_placeholder(
+                docx_bytes,
+                facsimile_bytes,
+                placeholder=PROPOSAL_FACSIMILE_PLACEHOLDER,
+            )
+            stored_docx = store_existing_proposal_docx_bytes(request.user, proposal, signed_docx_bytes)
+            proposal.docx_file_name = stored_docx["docx_name"]
+            proposal.docx_file_link = stored_docx["docx_path"]
+            if (
+                proposal.docx_file_name != original_docx_name
+                or proposal.docx_file_link != original_docx_link
+            ):
+                ProposalRegistration.objects.filter(pk=proposal.pk).update(
+                    docx_file_name=proposal.docx_file_name,
+                    docx_file_link=proposal.docx_file_link,
+                )
+
             stored_pdf = generate_and_store_proposal_pdf(
                 request.user,
                 proposal,
@@ -1744,11 +1767,13 @@ def proposal_dispatch_sign_documents(request):
         except Exception as exc:
             errors.append(f"{proposal.short_uid}: {exc}")
             continue
+        proposal.docx_file_name = stored_docx["docx_name"]
+        proposal.docx_file_link = stored_docx["docx_path"]
         proposal.pdf_file_name = stored_pdf["pdf_name"]
         proposal.pdf_file_link = stored_pdf["pdf_path"]
-        pdf_updates.append(proposal)
+        document_updates.append(proposal)
 
-    if errors and not pdf_updates:
+    if errors and not document_updates:
         return JsonResponse(
             {
                 "ok": False,
@@ -1759,23 +1784,28 @@ def proposal_dispatch_sign_documents(request):
             status=400,
         )
 
-    if pdf_updates:
-        ProposalRegistration.objects.bulk_update(pdf_updates, ["pdf_file_name", "pdf_file_link"])
-        _attach_proposal_folder_urls(pdf_updates, request.user, request=request)
+    if document_updates:
+        ProposalRegistration.objects.bulk_update(
+            document_updates,
+            ["docx_file_name", "docx_file_link", "pdf_file_name", "pdf_file_link"],
+        )
+        _attach_proposal_folder_urls(document_updates, request.user, request=request)
 
     return JsonResponse(
         {
             "ok": True,
             "message": "PDF для ТКП успешно сформирован.",
-            "generated": len(pdf_updates),
+            "generated": len(document_updates),
             "warnings": errors,
             "updates": [
                 {
                     "id": proposal.pk,
+                    "docx_file_name": proposal.docx_file_name,
+                    "proposal_docx_file_url": getattr(proposal, "proposal_docx_file_url", "") or "",
                     "pdf_file_name": proposal.pdf_file_name,
                     "proposal_pdf_file_url": getattr(proposal, "proposal_pdf_file_url", "") or "",
                 }
-                for proposal in pdf_updates
+                for proposal in document_updates
             ],
         }
     )


### PR DESCRIPTION
## Summary
- insert the current user's facsimile into proposal DOCX files during the sign-to-PDF flow
- validate missing or invalid facsimile files with user-facing errors
- refine multi-asset budget table widths and update related tests
## Test plan
- [ ] run pytest -q
- [ ] manually verify signed PDF generation with `[[facsimile]]`
- [ ] manually verify multi-asset budget table column widths in generated DOCX/PDF