### PR TITLE
Fix classifiers partial rendering to preserve layout

### DIFF
--- a/classifiers_app/templates/classifiers_app/bea_table_partial.html
+++ b/classifiers_app/templates/classifiers_app/bea_table_partial.html
@@ -50,8 +50,8 @@
                     </div>
                 {% endif %}
             </td>
-            <td data-col="id-atr" class="text-nowrap"><span class="clf-id-mono">{{ item.pk|stringformat:"05d" }}-ATR</span></td>
-            <td data-col="id-idn" class="text-nowrap"><span class="clf-id-mono">{% if item.identifier_record %}{{ item.identifier_record.pk|stringformat:"05d" }}-IDN{% else %}—{% endif %}</span></td>
+            <td data-col="id-atr" class="text-nowrap"><span class="clf-id-droid-mono">{{ item.pk|stringformat:"05d" }}-ATR</span></td>
+            <td data-col="id-idn" class="text-nowrap"><span class="clf-id-droid-mono">{% if item.identifier_record %}{{ item.identifier_record.pk|stringformat:"05d" }}-IDN{% else %}—{% endif %}</span></td>
             <td data-col="country">{% if item.registration_country %}{{ item.registration_country.short_name }}{% else %}—{% endif %}</td>
             <td data-col="region">{{ item.registration_region|default:"—" }}</td>
             <td data-col="postal-code">{{ item.postal_code|default:"—" }}</td>

--- a/classifiers_app/templates/classifiers_app/bei_table_partial.html
+++ b/classifiers_app/templates/classifiers_app/bei_table_partial.html
@@ -45,8 +45,8 @@
                     </div>
                 {% endif %}
             </td>
-            <td class="text-nowrap"><span class="clf-id-mono">{{ item.pk|stringformat:"05d" }}-IDN</span></td>
-            <td class="text-nowrap"><span class="clf-id-mono">{{ item.business_entity.pk|stringformat:"05d" }}-BSN</span></td>
+            <td class="text-nowrap"><span class="clf-id-droid-mono">{{ item.pk|stringformat:"05d" }}-IDN</span></td>
+            <td class="text-nowrap"><span class="clf-id-droid-mono">{{ item.business_entity.pk|stringformat:"05d" }}-BSN</span></td>
             <td class="text-nowrap">{{ item.registration_code|default:"—" }}</td>
             <td>{% if item.registration_country %}{{ item.registration_country.short_name }}{% else %}—{% endif %}</td>
             <td>{{ item.identifier_type|default:"—" }}</td>

--- a/classifiers_app/templates/classifiers_app/ber_table_partial.html
+++ b/classifiers_app/templates/classifiers_app/ber_table_partial.html
@@ -39,7 +39,7 @@
                     </div>
                 {% endif %}
             </td>
-            <td class="text-nowrap"><span class="clf-id-mono">{{ item.pk|stringformat:"05d" }}-BSN</span></td>
+            <td class="text-nowrap"><span class="clf-id-droid-mono">{{ item.pk|stringformat:"05d" }}-BSN</span></td>
             <td>{{ item.name }}</td>
             <td>{{ item.comment|default:"—" }}</td>
             <td class="text-nowrap">{% if item.record_date %}{{ item.record_date|date:"d.m.Y" }}{% else %}—{% endif %}</td>

--- a/classifiers_app/templates/classifiers_app/brl_table_partial.html
+++ b/classifiers_app/templates/classifiers_app/brl_table_partial.html
@@ -42,8 +42,8 @@
             </td>
             <td class="text-nowrap"><span class="clf-id-mono">{{ item.pk|stringformat:"05d" }}-RLT</span></td>
             <td>{{ item.event.relation_type|default:"—" }}</td>
-            <td class="text-nowrap"><span class="clf-id-mono">{{ item.from_business_entity.pk|stringformat:"05d" }}-BSN</span></td>
-            <td class="text-nowrap"><span class="clf-id-mono">{{ item.to_business_entity.pk|stringformat:"05d" }}-BSN</span></td>
+            <td class="text-nowrap"><span class="clf-id-droid-mono">{{ item.from_business_entity.pk|stringformat:"05d" }}-BSN</span></td>
+            <td class="text-nowrap"><span class="clf-id-droid-mono">{{ item.to_business_entity.pk|stringformat:"05d" }}-BSN</span></td>
             <td class="text-nowrap"><span class="clf-id-mono">{{ item.event.reorganization_event_uid|default:"—" }}</span></td>
             <td class="text-nowrap">{% if item.event.event_date %}{{ item.event.event_date|date:"d.m.Y" }}{% else %}—{% endif %}</td>
             <td>{{ item.event.comment|default:"—" }}</td>

--- a/classifiers_app/templates/classifiers_app/ler_table_partial.html
+++ b/classifiers_app/templates/classifiers_app/ler_table_partial.html
@@ -42,8 +42,8 @@
                     </div>
                 {% endif %}
             </td>
-            <td class="text-nowrap"><span class="clf-id-mono">{{ item.pk|stringformat:"05d" }}-ATR</span></td>
-            <td class="text-nowrap"><span class="clf-id-mono">{% if item.identifier_record %}{{ item.identifier_record.pk|stringformat:"05d" }}-IDN{% else %}—{% endif %}</span></td>
+            <td class="text-nowrap"><span class="clf-id-droid-mono">{{ item.pk|stringformat:"05d" }}-ATR</span></td>
+            <td class="text-nowrap"><span class="clf-id-droid-mono">{% if item.identifier_record %}{{ item.identifier_record.pk|stringformat:"05d" }}-IDN{% else %}—{% endif %}</span></td>
             <td>{{ item.short_name }}</td>
             <td>{{ item.full_name|default:"—" }}</td>
             <td class="text-nowrap">{% if item.record_date %}{{ item.record_date|date:"d.m.Y" }}{% else %}—{% endif %}</td>

--- a/classifiers_app/tests.py
+++ b/classifiers_app/tests.py
@@ -1054,6 +1054,18 @@ class BusinessRegistryMasterFilterTests(TestCase):
         self.assertNotContains(response, "Связь 02")
         self.assertContains(response, "Показаны 51-55 из 55")
 
+    def test_home_page_binds_business_registry_partials_to_their_own_wrappers(self):
+        response = self.client.get(reverse("home"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="business-entities-table-wrap"')
+        self.assertContains(response, 'id="business-entity-identifiers-table-wrap"')
+        self.assertContains(response, 'id="business-entity-attributes-table-wrap"')
+        self.assertContains(response, 'id="ler-table-wrap"')
+        self.assertContains(response, 'id="business-entity-addresses-table-wrap"')
+        self.assertContains(response, 'id="business-entity-relations-table-wrap"')
+        self.assertGreaterEqual(response.content.decode().count('hx-target="this"'), 6)
+
 
 class BusinessEntityIdentifierFormTests(TestCase):
     def setUp(self):

--- a/core/static/core/js/classifiers-panels.js
+++ b/core/static/core/js/classifiers-panels.js
@@ -763,6 +763,11 @@
   async function refreshTable(name) {
     const cfg = TABLE_CONFIG[name];
     if (!cfg) {
+      const legacyPane = document.getElementById('classifiers-pane');
+      if (!legacyPane) {
+        console.warn('[classifiers] skipped refresh for unknown table:', name);
+        return;
+      }
       await htmx.ajax('GET', '/classifiers/partial/' + filterQueryString(), {
         target: '#classifiers-pane',
         swap: 'outerHTML',

--- a/templates/index.html
+++ b/templates/index.html
@@ -973,6 +973,7 @@
                         <div id="business-entities-table-wrap"
                              hx-get="{% url 'ber_table_partial' %}"
                              hx-trigger="business-entities:load from:body once"
+                             hx-target="this"
                              hx-swap="innerHTML">
                           <div class="text-muted p-3">Загрузка данных…</div>
                         </div>
@@ -1075,6 +1076,7 @@
                         <div id="business-entity-identifiers-table-wrap"
                              hx-get="{% url 'bei_table_partial' %}"
                              hx-trigger="business-entity-identifiers:load from:body once"
+                             hx-target="this"
                              hx-swap="innerHTML">
                           <div class="text-muted p-3">Загрузка данных…</div>
                         </div>
@@ -1154,6 +1156,7 @@
                         <div id="business-entity-attributes-table-wrap"
                              hx-get="{% url 'bat_table_partial' %}"
                              hx-trigger="business-entity-attributes:load from:body once"
+                             hx-target="this"
                              hx-swap="innerHTML">
                           <div class="text-muted p-3">Загрузка данных…</div>
                         </div>
@@ -1190,6 +1193,7 @@
                         <div id="ler-table-wrap"
                              hx-get="{% url 'ler_table_partial' %}"
                              hx-trigger="legal-entities:load from:body once"
+                             hx-target="this"
                              hx-swap="innerHTML">
                           <div class="text-muted p-3">Загрузка данных…</div>
                         </div>
@@ -1290,6 +1294,7 @@
                         <div id="business-entity-addresses-table-wrap"
                              hx-get="{% url 'bea_table_partial' %}"
                              hx-trigger="business-entity-addresses:load from:body once"
+                             hx-target="this"
                              hx-swap="innerHTML">
                           <div class="text-muted p-3">Загрузка данных…</div>
                         </div>
@@ -1443,6 +1448,7 @@
                         <div id="business-entity-relations-table-wrap"
                              hx-get="{% url 'brl_table_partial' %}"
                              hx-trigger="business-entity-relations:load from:body once"
+                             hx-target="this"
                              hx-swap="innerHTML">
                           <div class="text-muted p-3">Загрузка данных…</div>
                         </div>


### PR DESCRIPTION
## Summary
- fix HTMX targets for business registry tables on the main page
- prevent classifiers fallback refresh from replacing the whole layout
- add regression coverage for home page business registry wrappers
## Test plan
- [ ] open the app as an executor from another expertise direction
- [ ] verify the left menu remains visible
- [ ] verify business registry tables load inside their own blocks
- [ ] run CI/CD