### PR TITLE
Guard classifiers refresh against missing HTMX targets

### DIFF
--- a/core/static/core/js/classifiers-panels.js
+++ b/core/static/core/js/classifiers-panels.js
@@ -774,6 +774,11 @@
       });
       return;
     }
+    const targetEl = document.querySelector(cfg.target);
+    if (!targetEl) {
+      console.warn('[classifiers] skipped refresh without target:', name, cfg.target);
+      return;
+    }
     await htmx.ajax('GET', cfg.url + filterQueryString(), {
       target: cfg.target,
       swap: cfg.swap,

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -133,7 +133,7 @@
         <script defer src="{% static 'core/js/ui-prefs-restore.js' %}?v=20260420-2"></script>
         <script defer src="{% static 'core/js/selectable-tables.js' %}"></script>
         <script defer src="{% static 'core/js/policy-panels.js' %}"></script>
-        <script defer src="{% static 'core/js/classifiers-panels.js' %}?v=20260418-3"></script>
+        <script defer src="{% static 'core/js/classifiers-panels.js' %}?v=20260422-1"></script>
         <script defer src="{% static 'core/js/contacts-panels.js' %}?v=20260420-30"></script>
         <script defer src="{% static 'core/js/group-panels.js' %}"></script>
         <script defer src="{% static 'core/js/experts-panels.js' %}"></script>

--- a/staticfiles/core/js/classifiers-panels.js
+++ b/staticfiles/core/js/classifiers-panels.js
@@ -287,10 +287,20 @@
   async function refreshTable(name) {
     const cfg = TABLE_CONFIG[name];
     if (!cfg) {
+      const legacyPane = document.getElementById('classifiers-pane');
+      if (!legacyPane) {
+        console.warn('[classifiers] skipped refresh for unknown table:', name);
+        return;
+      }
       await htmx.ajax('GET', '/classifiers/partial/' + filterQueryString(), {
         target: '#classifiers-pane',
         swap: 'outerHTML',
       });
+      return;
+    }
+    const targetEl = document.querySelector(cfg.target);
+    if (!targetEl) {
+      console.warn('[classifiers] skipped refresh without target:', name, cfg.target);
       return;
     }
     await htmx.ajax('GET', cfg.url + filterQueryString(), {


### PR DESCRIPTION
## Summary
- add a safety guard before refreshing classifiers tables via HTMX
- prevent refresh requests when the expected DOM target is missing
- bump the classifiers panel script version and sync the staticfiles copy
## Test plan
- [ ] open the app under the affected executor account
- [ ] verify the page no longer collapses into a single legal entities table
- [ ] verify the left menu stays available
- [ ] run CI/CD