### PR TITLE
Restrict department head permissions and connections view

### DIFF
--- a/core/static/core/css/site.css
+++ b/core/static/core/css/site.css
@@ -1204,11 +1204,35 @@ body .second-sidebar + .flex-grow-1 {
   padding-right: 1rem;
 }
 .projects-outer-scroll > .card {
-  min-width: 1980px;  /* самая широкая таблица (1940px) + padding карточки (32px) + запас */
+  min-width: 100%;
 }
 
 
 #projects-pane .registration-table-wrap .products-actions-row {
+  margin-bottom: 14px !important;
+}
+
+#projects-pane .contract-table-wrap .products-actions-row {
+  margin-bottom: 14px !important;
+}
+
+#projects-pane .work-table-wrap .products-actions-row {
+  margin-bottom: 14px !important;
+}
+
+#projects-pane .legal-table-wrap .products-actions-row {
+  margin-bottom: 14px !important;
+}
+
+#participation-confirmation-section .participation-table-wrap .products-actions-row {
+  margin-bottom: 14px !important;
+}
+
+#contract-conclusion-section .contract-conclusion-table-wrap .products-actions-row {
+  margin-bottom: 14px !important;
+}
+
+#info-request-approval-section .info-request-table-wrap .products-actions-row {
   margin-bottom: 14px !important;
 }
 /* Слойность для кнопок панели под таблицей "Продукты" */
@@ -1664,24 +1688,25 @@ section#templates .alert.alert-info .text-muted {
    REG TABLE (Регистрация проекта)
    ========================= */
 
-/* 0) Ширины через <col> */
-#projects-pane table.reg-table col.checkbox       { width: 36px  !important; }  /* 1 */
-#projects-pane table.reg-table col.project-number { width: 70px  !important; }  /* 2 */
-#projects-pane table.reg-table col.group          { width: 70px  !important; }  /* 3: Группа */
-#projects-pane table.reg-table col.agreement-type { width: 170px !important; }  /* 4: Вид соглашения */
-#projects-pane table.reg-table col.project-id     { width: 100px !important; }  /* 5: Проект ID */
-#projects-pane table.reg-table col.reg-type       { width: 1% !important; }  /* 6: Тип */
-#projects-pane table.reg-table col.reg-name       { width: 230px !important; }  /* 7: Название */
-#projects-pane table.reg-table col.reg-status     { width: 120px !important; }  /* 8: Статус */
-#projects-pane table.reg-table col.reg-deadline   { width: 80px  !important; }  /* 9: Дедлайн */
-#projects-pane table.reg-table col.reg-year       { width: 60px  !important; }  /* 10: Год */
-#projects-pane table.reg-table col.reg-country    { width: 110px !important; }  /* 13: Страна */
-#projects-pane table.reg-table col.reg-identifier { width: 70px  !important; }  /* 13: Идент. */
-#projects-pane table.reg-table col.reg-regnumber { width: 150px !important; }  /* 14: Регистр. номер */
-/* reg-regdate — резиновый, без фиксированной ширины */
-#projects-pane table.reg-table col.reg-manager   { width: 200px !important; }  /* 15: Руководитель проекта */
+/* 0) Первые 2 столбца фиксированы, остальные остаются адаптивными */
+#projects-pane table.reg-table col.checkbox       { width: 30px !important; }
+#projects-pane table.reg-table col.project-number { width: 70px !important; }
+#projects-pane table.reg-table col.agreement-type { width: 9%  !important; }
+#projects-pane table.reg-table col.group          { width: 4%  !important; }
+#projects-pane table.reg-table col.project-id     { width: 6%  !important; }
+#projects-pane table.reg-table col.reg-type       { width: 4%  !important; }
+#projects-pane table.reg-table col.reg-name       { width: 13% !important; }
+#projects-pane table.reg-table col.reg-status     { width: 7%  !important; }
+#projects-pane table.reg-table col.reg-deadline   { width: 4%  !important; }
+#projects-pane table.reg-table col.reg-year       { width: 3%  !important; }
+#projects-pane table.reg-table col.reg-manager    { width: 10% !important; }
+#projects-pane table.reg-table col.reg-customer   { width: 13% !important; }
+#projects-pane table.reg-table col.reg-country    { width: 5%  !important; }
+#projects-pane table.reg-table col.reg-identifier { width: 4%  !important; }
+#projects-pane table.reg-table col.reg-regnumber  { width: 7%  !important; }
+#projects-pane table.reg-table col.reg-regdate    { width: 5%  !important; }
 
-/* 1) Таблица: авто-раскладка, чтобы столбец "Тип" брал ширину по содержимому */
+/* 1) Таблица: занимает всю ширину, а при нехватке места расширяется под содержимое */
 #projects-pane .registration-table-wrap {
   overflow-x: auto;
   overflow-y: visible;
@@ -1691,7 +1716,7 @@ section#templates .alert.alert-info .text-muted {
 #projects-pane .registration-table-wrap > table.reg-table{
   table-layout: auto !important;
   width: max-content;
-  min-width: 1900px;
+  min-width: 100%;
   --bs-table-cell-padding-y: .5rem;
   --reg-first-col-pr: .8rem;
 }
@@ -1700,7 +1725,7 @@ section#templates .alert.alert-info .text-muted {
 /* 2) Заголовки: переносы разрешены, прижаты к НИЗУ,
       с небольшим «воздухом» снизу */
 #projects-pane table.reg-table thead th{
-  white-space: normal !important;
+  white-space: nowrap !important;
   overflow: visible !important;
   text-overflow: clip !important;
   vertical-align: bottom !important;
@@ -1721,6 +1746,23 @@ section#templates .alert.alert-info .text-muted {
 #projects-pane table.reg-table tbody th,
 #projects-pane table.reg-table tbody td{
   white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#projects-pane table.reg-table thead th:nth-child(1),
+#projects-pane table.reg-table tbody td:nth-child(1) {
+  width: 30px !important;
+  min-width: 30px !important;
+  max-width: 30px !important;
+}
+
+#projects-pane table.reg-table thead th:nth-child(2),
+#projects-pane table.reg-table tbody td:nth-child(2) {
+  width: 70px !important;
+  min-width: 70px !important;
+  max-width: 70px !important;
+  white-space: nowrap !important;
   overflow: hidden !important;
   text-overflow: ellipsis !important;
 }
@@ -1737,8 +1779,6 @@ section#templates .alert.alert-info .text-muted {
 #projects-pane .contract-table tbody td.completion-calc-cell {
   color: #a1a9b1 !important;
 }
-#projects-pane table.reg-table col.reg-customer   { /* резиновый — без фиксированной ширины */ }  /* 12: Заказчик */
-
 /* 6) Единый padding по краям 1-го столбца (и в шапке, и в теле) */
 #projects-pane table.reg-table > thead tr > :first-child,
 #projects-pane table.reg-table > tbody tr > :first-child{
@@ -2942,91 +2982,100 @@ html.proposal-progress-cursor * {
 }
 
 /* ==== Contract Conditions table (Условия контракта) ==== */
-.contract-table { table-layout: auto; width: max-content; min-width: 1940px; }
-.contract-table col.checkbox     { width: 30px  !important; }
-.contract-table col.project-id   { width: 100px !important; }
-.contract-table col.group        { width: 1% !important; }  /* Тип */
-.contract-table col.name         { width: 220px !important; }
-.contract-table col.agreement-type { width: 170px !important; }
+#projects-pane .contract-table-wrap {
+  overflow-x: auto;
+  overflow-y: visible;
+  width: 100%;
+}
 
-.contract-table th:nth-child(5),
-.contract-table td:nth-child(5) { width: 170px !important; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.contract-table { table-layout: auto; width: 100%; min-width: max-content; }
+.contract-table col.checkbox   { width: 30px !important; }
+.contract-table col.project-id { width: 100px !important; }
 
-.contract-table col.agreement-number { width: 160px !important; }
-.contract-table th:nth-child(6),
-.contract-table td:nth-child(6) { width: 190px !important; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.contract-table th,
+.contract-table td {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+.contract-table th:nth-child(1),
+.contract-table td:nth-child(1) {
+  width: 30px !important;
+  min-width: 30px !important;
+  max-width: 30px !important;
+}
 
 .contract-table th:nth-child(2),
-.contract-table td:nth-child(2) { width: 110px !important; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.contract-table th:nth-child(3),
-.contract-table td:nth-child(3) {
-  width: 1% !important;
-  min-width: max-content;
-  max-width: none;
-  white-space: nowrap;
-  overflow: visible;
-  text-overflow: clip;
-}
-.contract-table th:nth-child(4),
-.contract-table td:nth-child(4) { width: 220px !important; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-
-/* Столбцы 7–16: даты и числовые (Начало контр. … Срок, недель) */
-.contract-table col.narrow-sm { width: 90px !important; }
-.contract-table col.narrow { width: 110px !important; }
-.contract-table th:nth-child(n+7):nth-child(-n+16) {
-  width: 80px !important;
-  white-space: normal;
-  word-break: break-word;
-}
-.contract-table td:nth-child(n+7):nth-child(-n+16) {
-  width: 80px !important;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.contract-table td:nth-child(2) {
+  width: 100px !important;
+  min-width: 100px !important;
+  max-width: 100px !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
 }
 
-/* Столбец 17: Предмет договора — занимает оставшееся пространство */
-.contract-table col.col-subject { /* no explicit width — absorbs remaining space */ }
+.contract-table td:nth-child(2) > .clf-id-droid-mono,
+.work-table td:nth-child(2) > .clf-id-droid-mono,
+.legal-table td:nth-child(2) > .clf-id-droid-mono {
+  display: block !important;
+  width: 100px !important;
+  max-width: 100px !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+}
+
+.contract-table col.col-subject { width: 160px !important; }
+
 .contract-table th:nth-child(17),
 .contract-table td:nth-child(17) {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  width: 160px !important;
+  min-width: 160px !important;
+  max-width: 160px !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
 }
 
 
 /* ==== Work Volume table (Объем работ) ==== */
-.work-table { table-layout: auto; width: max-content; min-width: 1530px; }
-.work-table col.col-checkbox { width: 30px  !important; }
-.work-table col.col-project  { width: 100px !important; } /* Номер проекта, 4444RU-0 */
-.work-table col.col-type     { width: 1% !important; } /* Тип */
-.work-table col.col-name     { width: 220px !important; } /* Название */
-.work-table col.col-active   { width: 350px !important; } /* Наименование актива */
-.work-table col.work-country    { width: 110px !important; }
-.work-table col.work-identifier { width: 70px  !important; }
-.work-table col.work-regnumber  { width: 150px !important; }
-.work-table col.work-regdate    { width: 100px !important; }
-
-/* Чтобы текст не рвал ширину, аккуратно подрезаем */
-.work-table td {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+#projects-pane .work-table-wrap {
+  overflow-x: auto;
+  overflow-y: visible;
+  width: 100%;
 }
 
-.work-table th:nth-child(3),
-.work-table td:nth-child(3) {
-  width: 1% !important;
-  min-width: max-content;
-  max-width: none;
+.work-table { table-layout: auto; width: 100%; min-width: max-content; }
+.work-table col.col-checkbox { width: 30px !important; }
+.work-table col.col-project  { width: 100px !important; }
+
+.work-table th,
+.work-table td {
   white-space: nowrap;
   overflow: visible;
   text-overflow: clip;
 }
 
-/* Наименование актива — обрезаем лишний текст троеточием */
-.work-table td:nth-child(5),
-.legal-table td:nth-child(5),
+.work-table th:nth-child(1),
+.work-table td:nth-child(1) {
+  width: 30px !important;
+  min-width: 30px !important;
+  max-width: 30px !important;
+}
+
+.work-table th:nth-child(2),
+.work-table td:nth-child(2) {
+  width: 100px !important;
+  min-width: 100px !important;
+  max-width: 100px !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+/* Для таблиц исполнителей оставляем отдельное правило усечения актива */
 .performers-table tbody td:nth-child(5) {
   white-space: nowrap;
   overflow: hidden;
@@ -3037,32 +3086,38 @@ html.proposal-progress-cursor * {
 
 
 /* ==== Legal Entities table (Юридические лица) ==== */
-.legal-table { table-layout: auto; width: max-content; min-width: 1500px; }
-.legal-table col.col-checkbox     { width: 30px  !important; }
-.legal-table col.col-project      { width: 100px !important; }
-.legal-table col.col-type         { width: 1% !important; }
-.legal-table col.col-name         { width: 220px !important; }
-.legal-table col.col-active       { width: 350px !important; }
-.legal-table col.col-legal-name   { width: 300px !important; }
-.legal-table col.legal-country    { width: 110px !important; }
-.legal-table col.legal-identifier { width: 70px  !important; }
-.legal-table col.legal-regnumber  { width: 150px !important; }
-/* legal-regdate — резиновый, без фиксированной ширины */
-
-.legal-table td {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+#projects-pane .legal-table-wrap {
+  overflow-x: auto;
+  overflow-y: visible;
+  width: 100%;
 }
 
-.legal-table th:nth-child(3),
-.legal-table td:nth-child(3) {
-  width: 1% !important;
-  min-width: max-content;
-  max-width: none;
+.legal-table { table-layout: auto; width: 100%; min-width: max-content; }
+.legal-table col.col-checkbox { width: 30px !important; }
+.legal-table col.col-project  { width: 100px !important; }
+
+.legal-table th,
+.legal-table td {
   white-space: nowrap;
   overflow: visible;
   text-overflow: clip;
+}
+
+.legal-table th:nth-child(1),
+.legal-table td:nth-child(1) {
+  width: 30px !important;
+  min-width: 30px !important;
+  max-width: 30px !important;
+}
+
+.legal-table th:nth-child(2),
+.legal-table td:nth-child(2) {
+  width: 100px !important;
+  min-width: 100px !important;
+  max-width: 100px !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
 }
 
 
@@ -3150,7 +3205,182 @@ html.proposal-progress-cursor * {
 .performers-table thead th:nth-child(4),
 .performers-table tbody td:nth-child(4) { width: 220px !important; min-width: 220px; max-width: 220px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
+#performers-main-section > .performers-table {
+  width: 100%;
+  min-width: max-content;
+}
+
+#performers-main-section .performers-table col.col-type,
+#performers-main-section .performers-table col.col-name {
+  width: auto !important;
+}
+
+#performers-main-section .performers-table col.col-active,
+#performers-main-section .performers-table col.col-typical {
+  width: auto !important;
+}
+
+#performers-main-section .performers-table thead th,
+#performers-main-section .performers-table tbody td {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#performers-main-section .performers-table thead th:nth-child(1),
+#performers-main-section .performers-table tbody td:nth-child(1) {
+  width: 30px !important;
+  min-width: 30px !important;
+  max-width: 30px !important;
+}
+
+#performers-main-section .performers-table thead th:nth-child(2),
+#performers-main-section .performers-table tbody td:nth-child(2) {
+  width: 100px !important;
+  min-width: 100px !important;
+  max-width: 100px !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+#performers-main-section .performers-table thead th:nth-child(3),
+#performers-main-section .performers-table tbody td:nth-child(3),
+#performers-main-section .performers-table thead th:nth-child(4),
+#performers-main-section .performers-table tbody td:nth-child(4) {
+  width: auto !important;
+  min-width: 0 !important;
+  max-width: none !important;
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#performers-main-section .performers-table tbody td:nth-child(5) {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+  max-width: none !important;
+}
+
+#performers-main-section .performers-table .text-truncate {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
 /* ==== Row grouping in participation / contract / info-request tables ==== */
+
+#participation-confirmation-section .participation-table-wrap {
+  overflow-x: auto;
+  overflow-y: visible;
+  width: 100%;
+}
+
+#participation-confirmation-section .participation-table-wrap > .performers-table {
+  width: 100%;
+  min-width: max-content;
+}
+
+#participation-confirmation-section .performers-table col.col-checkbox {
+  width: 30px !important;
+}
+
+#participation-confirmation-section .performers-table col.col-number {
+  width: 100px !important;
+}
+
+#participation-confirmation-section .performers-table col:not(.col-checkbox):not(.col-number) {
+  width: auto !important;
+}
+
+#participation-confirmation-section .performers-table thead th,
+#participation-confirmation-section .performers-table tbody td {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#participation-confirmation-section .performers-table thead th:nth-child(1),
+#participation-confirmation-section .performers-table tbody td:nth-child(1) {
+  width: 30px !important;
+  min-width: 30px !important;
+  max-width: 30px !important;
+}
+
+#participation-confirmation-section .performers-table thead th:nth-child(2),
+#participation-confirmation-section .performers-table tbody td:nth-child(2) {
+  width: 100px !important;
+  min-width: 100px !important;
+  max-width: 100px !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+#participation-confirmation-section .performers-table thead th:nth-child(n+3),
+#participation-confirmation-section .performers-table tbody td:nth-child(n+3) {
+  width: auto !important;
+  min-width: 0 !important;
+  max-width: none !important;
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#participation-confirmation-section .performers-table .text-truncate {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#contract-conclusion-section .contract-conclusion-table-wrap {
+  overflow-x: auto;
+  overflow-y: visible;
+  width: 100%;
+}
+
+#contract-conclusion-section .contract-conclusion-table-wrap > .performers-table {
+  width: max-content;
+  min-width: 100%;
+}
+
+#contract-conclusion-section .performers-table thead th,
+#contract-conclusion-section .performers-table tbody td {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#contract-conclusion-section .performers-table .text-truncate {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#info-request-approval-section .info-request-table-wrap {
+  overflow-x: auto;
+  overflow-y: visible;
+  width: 100%;
+}
+
+#info-request-approval-section .info-request-table-wrap > .performers-table {
+  width: max-content;
+  min-width: 100%;
+}
+
+#info-request-approval-section .performers-table thead th,
+#info-request-approval-section .performers-table tbody td {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#info-request-approval-section .performers-table .text-truncate {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
 
 #participation-confirmation-section .performers-table > tbody > tr > td,
 #contract-conclusion-section       .performers-table > tbody > tr > td,

--- a/core/tests.py
+++ b/core/tests.py
@@ -23,6 +23,8 @@ from core.cloud_storage import (
 from core.oidc import IMCOAuth2Validator
 from core.oidc_settings import oidc_pkce_required
 from core.models import CloudStorageSettings
+from policy_app.models import DEPARTMENT_HEAD_GROUP
+from users_app.models import Employee
 
 User = get_user_model()
 Application = get_application_model()
@@ -186,3 +188,26 @@ class CloudStorageRoutingTests(TestCase):
         response = client.get(reverse("oauth2_provider:authorize"), {"client_id": "nextcloud-client"})
 
         self.assertEqual(response.status_code, 403)
+
+
+class HomePagePermissionsTests(TestCase):
+    def test_department_head_menu_hides_restricted_sections(self):
+        user = User.objects.create_user(
+            username="department-head-home",
+            email="department-head-home@example.com",
+            password="Secret123!",
+            is_staff=True,
+        )
+        Employee.objects.create(user=user, role=DEPARTMENT_HEAD_GROUP)
+        self.client.force_login(user)
+
+        response = self.client.get(reverse("home"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Подключения")
+        self.assertNotContains(response, '<span class="link-text">Почта</span>', html=False)
+        self.assertNotContains(response, '<span class="link-text">Шаблоны</span>', html=False)
+        self.assertNotContains(response, '<span class="link-text">Отладка</span>', html=False)
+        self.assertNotContains(response, '<span class="link-text">Логи</span>', html=False)
+        self.assertNotContains(response, 'section id="templates"', html=False)
+        self.assertNotContains(response, 'section id="debugger"', html=False)

--- a/core/views.py
+++ b/core/views.py
@@ -41,14 +41,16 @@ def home_entry(request):
     is_expert = request.user.groups.filter(name=EXPERT_GROUP).exists()
     is_lawyer = request.user.groups.filter(name=LAWYER_GROUP).exists()
     employee_role = getattr(employee, "role", "") or ""
+    is_department_head = employee_role == DEPARTMENT_HEAD_GROUP
     can_access_connections = (not is_expert) or (
         employee_role in {PROJECTS_HEAD_GROUP, DEPARTMENT_HEAD_GROUP}
     )
-    smtp_only_connections = is_expert and can_access_connections
+    smtp_only_connections = is_department_head
     context = {
         "employee": employee,
         "is_expert": is_expert,
         "is_lawyer": is_lawyer,
+        "is_department_head": is_department_head,
         "can_access_connections": can_access_connections,
         "smtp_only_connections": smtp_only_connections,
         "ler_date_filter": date.today().isoformat(),

--- a/onedrive_app/templates/onedrive_app/connections_partial.html
+++ b/onedrive_app/templates/onedrive_app/connections_partial.html
@@ -1,10 +1,13 @@
+{% if smtp_only_connections %}
+{# Для руководителя направления оставляем только внешнее SMTP-подключение. #}
+{% include "smtp_app/connections_partial.html" with smtp_account=smtp_account smtp_form=smtp_form %}
+{% else %}
 {% include "onedrive_app/primary_cloud_storage_panel.html" with primary_cloud_storage=primary_cloud_storage primary_cloud_storage_label=primary_cloud_storage_label can_manage_primary_cloud_storage=can_manage_primary_cloud_storage %}
 {% include "nextcloud_app/panel.html" with nextcloud_root_path=nextcloud_root_path nextcloud_root_configured=nextcloud_root_configured nextcloud_connection_status=nextcloud_connection_status nextcloud_connection_status_label=nextcloud_connection_status_label nextcloud_enabled=nextcloud_enabled nextcloud_launch_url=nextcloud_launch_url can_manage_nextcloud_root=can_manage_nextcloud_root %}
 
 {# Панель внешнего SMTP #}
 {% include "smtp_app/connections_partial.html" with smtp_account=smtp_account smtp_form=smtp_form %}
 
-{% if not smtp_only_connections %}
 {# Панель OneDrive — ровно один include #}
 {% include "onedrive_app/panel.html" with selection=selection onedrive_connected=onedrive_connected %}
 

--- a/onedrive_app/tests.py
+++ b/onedrive_app/tests.py
@@ -3,6 +3,8 @@ from django.test import TestCase
 from django.urls import reverse
 
 from core.models import CloudStorageSettings
+from policy_app.models import DEPARTMENT_HEAD_GROUP
+from users_app.models import Employee
 
 User = get_user_model()
 
@@ -105,3 +107,23 @@ class PrimaryCloudStorageConnectionsTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 400)
+
+    def test_department_head_sees_only_external_smtp_connection(self):
+        department_head = User.objects.create_user(
+            username="department-head@example.com",
+            email="department-head@example.com",
+            password="Secret123!",
+            is_staff=True,
+        )
+        Employee.objects.create(user=department_head, role=DEPARTMENT_HEAD_GROUP)
+        self.client.force_login(department_head)
+
+        response = self.client.get(reverse("onedrive_connections_partial"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="smtp-panel"', html=False)
+        self.assertNotContains(response, "Основное облачное хранилище")
+        self.assertNotContains(response, "Nextcloud")
+        self.assertNotContains(response, "Google Drive")
+        self.assertNotContains(response, "Яндекс.Диск")
+        self.assertNotContains(response, "Microsoft OneDrive")

--- a/onedrive_app/views.py
+++ b/onedrive_app/views.py
@@ -6,7 +6,7 @@ from django.views.decorators.http import require_POST
 from django.urls import reverse
 from django.conf import settings
 
-from policy_app.models import DEPARTMENT_HEAD_GROUP, PROJECTS_HEAD_GROUP
+from policy_app.models import DEPARTMENT_HEAD_GROUP
 from users_app.models import Employee
 from core.cloud_storage import (
     get_cloud_storage_settings,
@@ -71,7 +71,7 @@ def _connections_context(request):
     smtp_form = ExternalSMTPAccountForm(instance=smtp_account, user=request.user)
     employee = Employee.objects.filter(user=request.user).first()
     employee_role = getattr(employee, "role", "") or ""
-    smtp_only_connections = employee_role in {PROJECTS_HEAD_GROUP, DEPARTMENT_HEAD_GROUP}
+    smtp_only_connections = employee_role == DEPARTMENT_HEAD_GROUP
     storage_settings = get_cloud_storage_settings()
     nextcloud_status = get_nextcloud_connection_status()
     nextcloud_overview = build_nextcloud_overview(request.user)

--- a/projects_app/templates/projects_app/performers_partial.html
+++ b/projects_app/templates/projects_app/performers_partial.html
@@ -249,7 +249,7 @@
     </div>
   </div>
 
-  <div>
+  <div class="participation-table-wrap">
     <table class="table table-sm align-middle performers-table">
       <colgroup>
         <col class="col-checkbox">
@@ -508,7 +508,7 @@
     </div>
   </div>
 
-  <div>
+  <div class="contract-conclusion-table-wrap">
     <table class="table table-sm align-middle performers-table">
       <colgroup>
         <col class="col-checkbox">
@@ -810,7 +810,7 @@
     </div>
   </div>
 
-  <div>
+  <div class="info-request-table-wrap">
     <table class="table table-sm align-middle performers-table">
       <colgroup>
         <col class="col-checkbox">

--- a/projects_app/templates/projects_app/projects_partial.html
+++ b/projects_app/templates/projects_app/projects_partial.html
@@ -58,7 +58,7 @@
         </colgroup>
       <thead>
       <tr>
-        <th class="w-checkbox">
+        <th class="w-checkbox" style="width:30px; min-width:30px; max-width:30px;">
           {% if request.user.is_authenticated and request.user.is_staff %}
             <div class="form-check m-0">
                 <input class="form-check-input"
@@ -330,7 +330,7 @@
             </div>
           {% endif %}
         </th>
-        <th>Проект</th>
+        <th style="width:100px; min-width:100px; max-width:100px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">Проект</th>
         <th>Тип</th>
         <th class="nowrap">Название</th>
         <th>Вид соглашения</th>
@@ -351,7 +351,7 @@
       <tbody>
       {% for r in registrations %}
         <tr data-project-id="{{ r.id }}" data-edit-url="{% url 'contract_form_edit' r.pk %}">
-          <td class="text-nowrap">
+          <td class="text-nowrap" style="width:30px; min-width:30px; max-width:30px;">
             {% if request.user.is_authenticated and request.user.is_staff %}
               <div class="form-check">
                     <input class="form-check-input"
@@ -363,7 +363,7 @@
               </div>
             {% endif %}
           </td>
-          <td class="project-id-cell"><span class="clf-id-droid-mono">{{ r.short_uid }}</span></td>
+          <td class="project-id-cell" style="width:100px; min-width:100px; max-width:100px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;"><span class="clf-id-droid-mono" style="display:block; width:100%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">{{ r.short_uid }}</span></td>
           <td>{{ r.type_short_display }}</td>
           <td>{{ r.name }}</td>
           <td>{{ r.get_agreement_type_display }}</td>
@@ -433,7 +433,7 @@
     </div>
   </div>
 
-  <div>
+  <div class="work-table-wrap">
     <table class="table table-sm align-middle work-table">
       <colgroup>
           <col class="col-checkbox">    <!-- чекбокс -->
@@ -449,7 +449,7 @@
       </colgroup>
       <thead>
       <tr>
-        <th style="width:30px">
+        <th style="width:30px; min-width:30px; max-width:30px;">
           {% if request.user.is_authenticated and request.user.is_staff %}
             <div class="form-check m-0">
               <input class="form-check-input"
@@ -461,7 +461,7 @@
             </div>
           {% endif %}
         </th>
-        <th>Проект</th>
+        <th style="width:100px; min-width:100px; max-width:100px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">Проект</th>
         <th>Тип</th>
         <th>Название</th>
         <th>Наименование актива</th>
@@ -480,7 +480,7 @@
           data-delete-url="{% url 'work_delete' w.pk %}"
           data-move-up-url="{% url 'work_move_up' w.pk %}"
           data-move-down-url="{% url 'work_move_down' w.pk %}">
-          <td class="text-nowrap">
+          <td class="text-nowrap" style="width:30px; min-width:30px; max-width:30px;">
             {% if request.user.is_authenticated and request.user.is_staff %}
               <div class="form-check">
                 <input class="form-check-input"
@@ -492,7 +492,7 @@
               </div>
             {% endif %}
           </td>
-          <td class="text-nowrap"><span class="clf-id-droid-mono">{{ w.project.short_uid }}</span></td>
+          <td class="text-nowrap" style="width:100px; min-width:100px; max-width:100px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;"><span class="clf-id-droid-mono" style="display:block; width:100%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">{{ w.project.short_uid }}</span></td>
           <td class="text-nowrap">{{ w.project.type_short_display|default:w.type }}</td>
           <td>{{ w.name }}</td>
           <td class="text-nowrap">{{ w.asset_name }}</td>
@@ -570,7 +570,7 @@
     </div>
   </div>
 
-  <div>
+  <div class="legal-table-wrap">
     <table class="table table-sm align-middle legal-table">
       <colgroup>
         <col class="col-checkbox">       <!-- чекбокс -->
@@ -586,7 +586,7 @@
       </colgroup>
       <thead>
       <tr>
-        <th style="width:30px">
+        <th style="width:30px; min-width:30px; max-width:30px;">
           {% if request.user.is_authenticated and request.user.is_staff %}
             <div class="form-check m-0">
               <input class="form-check-input"
@@ -598,7 +598,7 @@
             </div>
           {% endif %}
         </th>
-        <th>Проект</th>
+        <th style="width:100px; min-width:100px; max-width:100px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">Проект</th>
         <th>Тип</th>
         <th>Название</th>
         <th>Наименование актива</th>
@@ -617,7 +617,7 @@
           data-move-up-url="{% url 'legal_entity_move_up' entity.pk %}"
           data-move-down-url="{% url 'legal_entity_move_down' entity.pk %}"
           data-project-id="{{ entity.project_id }}">
-          <td class="text-nowrap">
+          <td class="text-nowrap" style="width:30px; min-width:30px; max-width:30px;">
             {% if request.user.is_authenticated and request.user.is_staff %}
               <div class="form-check">
                 <input class="form-check-input"
@@ -629,7 +629,7 @@
               </div>
             {% endif %}
           </td>
-          <td class="text-nowrap"><span class="clf-id-droid-mono">{{ entity.project.short_uid }}</span></td>
+          <td class="text-nowrap" style="width:100px; min-width:100px; max-width:100px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;"><span class="clf-id-droid-mono" style="display:block; width:100%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">{{ entity.project.short_uid }}</span></td>
           <td class="text-nowrap">{{ entity.work_item.project.type_short_display|default:entity.work_type }}</td>
           <td>{{ entity.work_name }}</td>
           <td class="text-nowrap">{{ entity.work_item.asset_name|default:entity.work_item.name }}</td>

--- a/staticfiles/core/css/site.css
+++ b/staticfiles/core/css/site.css
@@ -1069,11 +1069,35 @@ body .second-sidebar + .flex-grow-1 {
   padding-right: 1rem;
 }
 .projects-outer-scroll > .card {
-  min-width: 1980px;  /* самая широкая таблица (1940px) + padding карточки (32px) + запас */
+  min-width: 100%;
 }
 
 
 #projects-pane .registration-table-wrap .products-actions-row {
+  margin-bottom: 14px !important;
+}
+
+#projects-pane .contract-table-wrap .products-actions-row {
+  margin-bottom: 14px !important;
+}
+
+#projects-pane .work-table-wrap .products-actions-row {
+  margin-bottom: 14px !important;
+}
+
+#projects-pane .legal-table-wrap .products-actions-row {
+  margin-bottom: 14px !important;
+}
+
+#participation-confirmation-section .participation-table-wrap .products-actions-row {
+  margin-bottom: 14px !important;
+}
+
+#contract-conclusion-section .contract-conclusion-table-wrap .products-actions-row {
+  margin-bottom: 14px !important;
+}
+
+#info-request-approval-section .info-request-table-wrap .products-actions-row {
   margin-bottom: 14px !important;
 }
 /* Слойность для кнопок панели под таблицей "Продукты" */
@@ -1412,24 +1436,25 @@ section#templates .alert.alert-info .text-muted {
    REG TABLE (Регистрация проекта)
    ========================= */
 
-/* 0) Ширины через <col> */
-#projects-pane table.reg-table col.checkbox       { width: 36px  !important; }  /* 1 */
-#projects-pane table.reg-table col.project-number { width: 70px  !important; }  /* 2 */
-#projects-pane table.reg-table col.group          { width: 70px  !important; }  /* 3: Группа */
-#projects-pane table.reg-table col.agreement-type { width: 170px !important; }  /* 4: Вид соглашения */
-#projects-pane table.reg-table col.project-id     { width: 100px !important; }  /* 5: Проект ID */
-#projects-pane table.reg-table col.reg-type       { width: 1% !important; }  /* 6: Тип */
-#projects-pane table.reg-table col.reg-name       { width: 230px !important; }  /* 7: Название */
-#projects-pane table.reg-table col.reg-status     { width: 120px !important; }  /* 8: Статус */
-#projects-pane table.reg-table col.reg-deadline   { width: 80px  !important; }  /* 9: Дедлайн */
-#projects-pane table.reg-table col.reg-year       { width: 60px  !important; }  /* 10: Год */
-#projects-pane table.reg-table col.reg-country    { width: 110px !important; }  /* 13: Страна */
-#projects-pane table.reg-table col.reg-identifier { width: 70px  !important; }  /* 13: Идент. */
-#projects-pane table.reg-table col.reg-regnumber { width: 150px !important; }  /* 14: Регистр. номер */
-/* reg-regdate — резиновый, без фиксированной ширины */
-#projects-pane table.reg-table col.reg-manager   { width: 200px !important; }  /* 15: Руководитель проекта */
+/* 0) Первые 2 столбца фиксированы, остальные остаются адаптивными */
+#projects-pane table.reg-table col.checkbox       { width: 30px !important; }
+#projects-pane table.reg-table col.project-number { width: 70px !important; }
+#projects-pane table.reg-table col.agreement-type { width: 9%  !important; }
+#projects-pane table.reg-table col.group          { width: 4%  !important; }
+#projects-pane table.reg-table col.project-id     { width: 6%  !important; }
+#projects-pane table.reg-table col.reg-type       { width: 4%  !important; }
+#projects-pane table.reg-table col.reg-name       { width: 13% !important; }
+#projects-pane table.reg-table col.reg-status     { width: 7%  !important; }
+#projects-pane table.reg-table col.reg-deadline   { width: 4%  !important; }
+#projects-pane table.reg-table col.reg-year       { width: 3%  !important; }
+#projects-pane table.reg-table col.reg-manager    { width: 10% !important; }
+#projects-pane table.reg-table col.reg-customer   { width: 13% !important; }
+#projects-pane table.reg-table col.reg-country    { width: 5%  !important; }
+#projects-pane table.reg-table col.reg-identifier { width: 4%  !important; }
+#projects-pane table.reg-table col.reg-regnumber  { width: 7%  !important; }
+#projects-pane table.reg-table col.reg-regdate    { width: 5%  !important; }
 
-/* 1) Таблица: авто-раскладка, чтобы столбец "Тип" брал ширину по содержимому */
+/* 1) Таблица: занимает всю ширину, а при нехватке места расширяется под содержимое */
 #projects-pane .registration-table-wrap {
   overflow-x: auto;
   overflow-y: visible;
@@ -1439,7 +1464,7 @@ section#templates .alert.alert-info .text-muted {
 #projects-pane .registration-table-wrap > table.reg-table{
   table-layout: auto !important;
   width: max-content;
-  min-width: 1900px;
+  min-width: 100%;
   --bs-table-cell-padding-y: .5rem;
   --reg-first-col-pr: .8rem;
 }
@@ -1448,7 +1473,7 @@ section#templates .alert.alert-info .text-muted {
 /* 2) Заголовки: переносы разрешены, прижаты к НИЗУ,
       с небольшим «воздухом» снизу */
 #projects-pane table.reg-table thead th{
-  white-space: normal !important;
+  white-space: nowrap !important;
   overflow: visible !important;
   text-overflow: clip !important;
   vertical-align: bottom !important;
@@ -1469,6 +1494,23 @@ section#templates .alert.alert-info .text-muted {
 #projects-pane table.reg-table tbody th,
 #projects-pane table.reg-table tbody td{
   white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#projects-pane table.reg-table thead th:nth-child(1),
+#projects-pane table.reg-table tbody td:nth-child(1) {
+  width: 30px !important;
+  min-width: 30px !important;
+  max-width: 30px !important;
+}
+
+#projects-pane table.reg-table thead th:nth-child(2),
+#projects-pane table.reg-table tbody td:nth-child(2) {
+  width: 70px !important;
+  min-width: 70px !important;
+  max-width: 70px !important;
+  white-space: nowrap !important;
   overflow: hidden !important;
   text-overflow: ellipsis !important;
 }
@@ -1485,8 +1527,6 @@ section#templates .alert.alert-info .text-muted {
 #projects-pane .contract-table tbody td.completion-calc-cell {
   color: #a1a9b1 !important;
 }
-#projects-pane table.reg-table col.reg-customer   { /* резиновый — без фиксированной ширины */ }  /* 12: Заказчик */
-
 /* 6) Единый padding по краям 1-го столбца (и в шапке, и в теле) */
 #projects-pane table.reg-table > thead tr > :first-child,
 #projects-pane table.reg-table > tbody tr > :first-child{
@@ -1564,91 +1604,100 @@ section#templates .alert.alert-info .text-muted {
 
 
 /* ==== Contract Conditions table (Условия контракта) ==== */
-.contract-table { table-layout: auto; width: max-content; min-width: 1940px; }
-.contract-table col.checkbox     { width: 30px  !important; }
-.contract-table col.project-id   { width: 100px !important; }
-.contract-table col.group        { width: 1% !important; }  /* Тип */
-.contract-table col.name         { width: 220px !important; }
-.contract-table col.agreement-type { width: 170px !important; }
+#projects-pane .contract-table-wrap {
+  overflow-x: auto;
+  overflow-y: visible;
+  width: 100%;
+}
 
-.contract-table th:nth-child(5),
-.contract-table td:nth-child(5) { width: 170px !important; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.contract-table { table-layout: auto; width: 100%; min-width: max-content; }
+.contract-table col.checkbox   { width: 30px !important; }
+.contract-table col.project-id { width: 100px !important; }
 
-.contract-table col.agreement-number { width: 160px !important; }
-.contract-table th:nth-child(6),
-.contract-table td:nth-child(6) { width: 190px !important; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.contract-table th,
+.contract-table td {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+.contract-table th:nth-child(1),
+.contract-table td:nth-child(1) {
+  width: 30px !important;
+  min-width: 30px !important;
+  max-width: 30px !important;
+}
 
 .contract-table th:nth-child(2),
-.contract-table td:nth-child(2) { width: 110px !important; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.contract-table th:nth-child(3),
-.contract-table td:nth-child(3) {
-  width: 1% !important;
-  min-width: max-content;
-  max-width: none;
-  white-space: nowrap;
-  overflow: visible;
-  text-overflow: clip;
-}
-.contract-table th:nth-child(4),
-.contract-table td:nth-child(4) { width: 220px !important; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-
-/* Столбцы 7–16: даты и числовые (Начало контр. … Срок, недель) */
-.contract-table col.narrow-sm { width: 90px !important; }
-.contract-table col.narrow { width: 110px !important; }
-.contract-table th:nth-child(n+7):nth-child(-n+16) {
-  width: 80px !important;
-  white-space: normal;
-  word-break: break-word;
-}
-.contract-table td:nth-child(n+7):nth-child(-n+16) {
-  width: 80px !important;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.contract-table td:nth-child(2) {
+  width: 100px !important;
+  min-width: 100px !important;
+  max-width: 100px !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
 }
 
-/* Столбец 17: Предмет договора — занимает оставшееся пространство */
-.contract-table col.col-subject { /* no explicit width — absorbs remaining space */ }
+.contract-table td:nth-child(2) > .clf-id-droid-mono,
+.work-table td:nth-child(2) > .clf-id-droid-mono,
+.legal-table td:nth-child(2) > .clf-id-droid-mono {
+  display: block !important;
+  width: 100px !important;
+  max-width: 100px !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+}
+
+.contract-table col.col-subject { width: 160px !important; }
+
 .contract-table th:nth-child(17),
 .contract-table td:nth-child(17) {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  width: 160px !important;
+  min-width: 160px !important;
+  max-width: 160px !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
 }
 
 
 /* ==== Work Volume table (Объем работ) ==== */
-.work-table { table-layout: auto; width: max-content; min-width: 1530px; }
-.work-table col.col-checkbox { width: 30px  !important; }
-.work-table col.col-project  { width: 100px !important; } /* Номер проекта, 4444RU-0 */
-.work-table col.col-type     { width: 1% !important; } /* Тип */
-.work-table col.col-name     { width: 220px !important; } /* Название */
-.work-table col.col-active   { width: 350px !important; } /* Наименование актива */
-.work-table col.work-country    { width: 110px !important; }
-.work-table col.work-identifier { width: 70px  !important; }
-.work-table col.work-regnumber  { width: 150px !important; }
-.work-table col.work-regdate    { width: 100px !important; }
-
-/* Чтобы текст не рвал ширину, аккуратно подрезаем */
-.work-table td {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+#projects-pane .work-table-wrap {
+  overflow-x: auto;
+  overflow-y: visible;
+  width: 100%;
 }
 
-.work-table th:nth-child(3),
-.work-table td:nth-child(3) {
-  width: 1% !important;
-  min-width: max-content;
-  max-width: none;
+.work-table { table-layout: auto; width: 100%; min-width: max-content; }
+.work-table col.col-checkbox { width: 30px !important; }
+.work-table col.col-project  { width: 100px !important; }
+
+.work-table th,
+.work-table td {
   white-space: nowrap;
   overflow: visible;
   text-overflow: clip;
 }
 
-/* Наименование актива — обрезаем лишний текст троеточием */
-.work-table td:nth-child(5),
-.legal-table td:nth-child(5),
+.work-table th:nth-child(1),
+.work-table td:nth-child(1) {
+  width: 30px !important;
+  min-width: 30px !important;
+  max-width: 30px !important;
+}
+
+.work-table th:nth-child(2),
+.work-table td:nth-child(2) {
+  width: 100px !important;
+  min-width: 100px !important;
+  max-width: 100px !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+/* Для таблиц исполнителей оставляем отдельное правило усечения актива */
 .performers-table tbody td:nth-child(5) {
   white-space: nowrap;
   overflow: hidden;
@@ -1659,32 +1708,38 @@ section#templates .alert.alert-info .text-muted {
 
 
 /* ==== Legal Entities table (Юридические лица) ==== */
-.legal-table { table-layout: auto; width: max-content; min-width: 1500px; }
-.legal-table col.col-checkbox     { width: 30px  !important; }
-.legal-table col.col-project      { width: 100px !important; }
-.legal-table col.col-type         { width: 1% !important; }
-.legal-table col.col-name         { width: 220px !important; }
-.legal-table col.col-active       { width: 350px !important; }
-.legal-table col.col-legal-name   { width: 300px !important; }
-.legal-table col.legal-country    { width: 110px !important; }
-.legal-table col.legal-identifier { width: 70px  !important; }
-.legal-table col.legal-regnumber  { width: 150px !important; }
-/* legal-regdate — резиновый, без фиксированной ширины */
-
-.legal-table td {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+#projects-pane .legal-table-wrap {
+  overflow-x: auto;
+  overflow-y: visible;
+  width: 100%;
 }
 
-.legal-table th:nth-child(3),
-.legal-table td:nth-child(3) {
-  width: 1% !important;
-  min-width: max-content;
-  max-width: none;
+.legal-table { table-layout: auto; width: 100%; min-width: max-content; }
+.legal-table col.col-checkbox { width: 30px !important; }
+.legal-table col.col-project  { width: 100px !important; }
+
+.legal-table th,
+.legal-table td {
   white-space: nowrap;
   overflow: visible;
   text-overflow: clip;
+}
+
+.legal-table th:nth-child(1),
+.legal-table td:nth-child(1) {
+  width: 30px !important;
+  min-width: 30px !important;
+  max-width: 30px !important;
+}
+
+.legal-table th:nth-child(2),
+.legal-table td:nth-child(2) {
+  width: 100px !important;
+  min-width: 100px !important;
+  max-width: 100px !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
 }
 
 
@@ -1760,7 +1815,182 @@ section#templates .alert.alert-info .text-muted {
 .performers-table thead th:nth-child(4),
 .performers-table tbody td:nth-child(4) { width: 220px !important; min-width: 220px; max-width: 220px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
+#performers-main-section > .performers-table {
+  width: 100%;
+  min-width: max-content;
+}
+
+#performers-main-section .performers-table col.col-type,
+#performers-main-section .performers-table col.col-name {
+  width: auto !important;
+}
+
+#performers-main-section .performers-table col.col-active,
+#performers-main-section .performers-table col.col-typical {
+  width: auto !important;
+}
+
+#performers-main-section .performers-table thead th,
+#performers-main-section .performers-table tbody td {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#performers-main-section .performers-table thead th:nth-child(1),
+#performers-main-section .performers-table tbody td:nth-child(1) {
+  width: 30px !important;
+  min-width: 30px !important;
+  max-width: 30px !important;
+}
+
+#performers-main-section .performers-table thead th:nth-child(2),
+#performers-main-section .performers-table tbody td:nth-child(2) {
+  width: 100px !important;
+  min-width: 100px !important;
+  max-width: 100px !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+#performers-main-section .performers-table thead th:nth-child(3),
+#performers-main-section .performers-table tbody td:nth-child(3),
+#performers-main-section .performers-table thead th:nth-child(4),
+#performers-main-section .performers-table tbody td:nth-child(4) {
+  width: auto !important;
+  min-width: 0 !important;
+  max-width: none !important;
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#performers-main-section .performers-table tbody td:nth-child(5) {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+  max-width: none !important;
+}
+
+#performers-main-section .performers-table .text-truncate {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
 /* ==== Row grouping in participation / contract / info-request tables ==== */
+
+#participation-confirmation-section .participation-table-wrap {
+  overflow-x: auto;
+  overflow-y: visible;
+  width: 100%;
+}
+
+#participation-confirmation-section .participation-table-wrap > .performers-table {
+  width: 100%;
+  min-width: max-content;
+}
+
+#participation-confirmation-section .performers-table col.col-checkbox {
+  width: 30px !important;
+}
+
+#participation-confirmation-section .performers-table col.col-number {
+  width: 100px !important;
+}
+
+#participation-confirmation-section .performers-table col:not(.col-checkbox):not(.col-number) {
+  width: auto !important;
+}
+
+#participation-confirmation-section .performers-table thead th,
+#participation-confirmation-section .performers-table tbody td {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#participation-confirmation-section .performers-table thead th:nth-child(1),
+#participation-confirmation-section .performers-table tbody td:nth-child(1) {
+  width: 30px !important;
+  min-width: 30px !important;
+  max-width: 30px !important;
+}
+
+#participation-confirmation-section .performers-table thead th:nth-child(2),
+#participation-confirmation-section .performers-table tbody td:nth-child(2) {
+  width: 100px !important;
+  min-width: 100px !important;
+  max-width: 100px !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+#participation-confirmation-section .performers-table thead th:nth-child(n+3),
+#participation-confirmation-section .performers-table tbody td:nth-child(n+3) {
+  width: auto !important;
+  min-width: 0 !important;
+  max-width: none !important;
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#participation-confirmation-section .performers-table .text-truncate {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#contract-conclusion-section .contract-conclusion-table-wrap {
+  overflow-x: auto;
+  overflow-y: visible;
+  width: 100%;
+}
+
+#contract-conclusion-section .contract-conclusion-table-wrap > .performers-table {
+  width: max-content;
+  min-width: 100%;
+}
+
+#contract-conclusion-section .performers-table thead th,
+#contract-conclusion-section .performers-table tbody td {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#contract-conclusion-section .performers-table .text-truncate {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#info-request-approval-section .info-request-table-wrap {
+  overflow-x: auto;
+  overflow-y: visible;
+  width: 100%;
+}
+
+#info-request-approval-section .info-request-table-wrap > .performers-table {
+  width: max-content;
+  min-width: 100%;
+}
+
+#info-request-approval-section .performers-table thead th,
+#info-request-approval-section .performers-table tbody td {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
+
+#info-request-approval-section .performers-table .text-truncate {
+  white-space: nowrap !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+}
 
 #participation-confirmation-section .performers-table > tbody > tr > td,
 #contract-conclusion-section       .performers-table > tbody > tr > td,

--- a/templates/index.html
+++ b/templates/index.html
@@ -99,13 +99,15 @@
                   data-notification-counter-section="checklists">{{ NOTIFICATION_SECTION_COUNTS.checklists|default:0 }}</span>
           </a>
         </li>
-        {% if not is_expert %}
+        {% if not is_expert and not is_department_head %}
         <li class="nav-item">
           <a class="nav-link d-flex align-items-center" href="https://mail.imcmontanai.ru/admin" target="_blank" rel="noopener noreferrer">
             <i class="bi bi-mailbox me-2"></i>
             <span class="link-text">Почта</span>
           </a>
         </li>
+        {% endif %}
+        {% if not is_expert %}
         <li class="nav-item">
           <a class="nav-link d-flex align-items-center" href="#letters" data-bs-toggle="tab">
             <i class="bi bi-envelope-paper me-2"></i>
@@ -133,13 +135,14 @@
           </a>
         </li>
         {% endif %}
-        {% if not is_expert %}
+        {% if not is_expert and not is_department_head %}
         <li class="nav-item">
           <a class="nav-link d-flex align-items-center" href="#templates" data-bs-toggle="tab">
             <i class="bi bi-puzzle me-2"></i>
             <span class="link-text">Шаблоны</span>
           </a>
         </li>
+        {% endif %}
         {% if can_access_connections %}
         <li class="nav-item">
           <a class="nav-link d-flex align-items-center" href="#connections" data-bs-toggle="tab">
@@ -148,6 +151,7 @@
           </a>
         </li>
         {% endif %}
+        {% if not is_expert and not is_department_head %}
         <li class="nav-item">
           <a class="nav-link d-flex align-items-center" href="#debugger" data-bs-toggle="tab">
             <i class="bi bi-sliders me-2"></i>
@@ -160,6 +164,8 @@
             <span class="link-text">Логи</span>
           </a>
         </li>
+        {% endif %}
+        {% if not is_expert %}
         <li class="nav-item">
           <a class="nav-link d-flex align-items-center" href="#classifiers" data-bs-toggle="tab">
             <i class="bi bi-book me-2"></i>
@@ -737,7 +743,7 @@
       </section>
 
       <!-- Шаблоны -->
-      {% if not is_expert %}
+      {% if not is_expert and not is_department_head %}
       <section id="templates" class="tab-pane fade">
         <div class="d-flex templates-bleed">
           <!-- Второй уровень сайдбара для раздела "Шаблоны" -->
@@ -796,6 +802,7 @@
 
         </div>
       </section>
+      {% endif %}
 
       {% if can_access_connections %}
       <!-- Подключения -->
@@ -829,6 +836,7 @@
       {% endif %}
 
       <!-- Отладка -->
+      {% if not is_expert and not is_department_head %}
       <section id="debugger" class="tab-pane fade">
           <div class="templates-bleed">
             <div class="bg-white border-bottom content-bleed-x section-header d-flex flex-column">
@@ -859,6 +867,7 @@
             <!-- /ps-3 -->
           </div>
       </section>
+      {% endif %}
 
       <!-- Справочники -->
       <section id="classifiers" class="tab-pane fade">
@@ -1556,7 +1565,6 @@
           </div>
         </div>
       </section>
-      {% endif %}
 
         <script>
         (function () {


### PR DESCRIPTION
## Summary
- hide Logs, Debug, Templates and Mail for users with the 'Руководитель направления' role
- leave only the External SMTP card in Connections for that role
- add targeted tests for menu visibility and connections access
## Test plan
- python3 manage.py test core.tests.HomePagePermissionsTests onedrive_app.tests.PrimaryCloudStorageConnectionsTests