### PR TITLE
Update proposal and project registry workflows

### DIFF
--- a/core/static/core/css/site.css
+++ b/core/static/core/css/site.css
@@ -2902,6 +2902,34 @@ html.proposal-progress-cursor * {
   position: relative;
 }
 
+#proposals-pane .number-input-shell {
+  position: relative;
+}
+
+#proposals-pane .number-input-shell input[type="number"] {
+  color: transparent;
+  caret-color: #212529;
+}
+
+#proposals-pane .number-input-shell input[type="number"]::placeholder {
+  color: transparent;
+}
+
+#proposals-pane .number-input-display {
+  position: absolute;
+  top: 50%;
+  left: .75rem;
+  right: 2rem;
+  z-index: 2;
+  transform: translateY(-50%);
+  pointer-events: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #212529;
+  line-height: 1.5;
+}
+
 #proposals-pane .group-select-shell select {
   position: relative;
   z-index: 2;
@@ -2938,6 +2966,262 @@ html.proposal-progress-cursor * {
   background-size: 16px 12px;
   opacity: .7;
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
+}
+
+#proposals-pane .proposal-type-block {
+  border: 1px solid #dee2e6;
+  border-radius: .5rem;
+  background: #f8f9fa;
+  padding: .75rem;
+}
+
+#proposals-pane .proposal-type-card {
+  border: 1px solid #dee2e6;
+  border-radius: .5rem;
+  background: #fff;
+  padding: .75rem .75rem 1.25rem .75rem;
+}
+
+#proposals-pane .proposal-type-head {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) 1.5rem;
+  column-gap: .5rem;
+  align-items: end;
+  margin-bottom: .5rem;
+}
+
+#proposals-pane .proposal-type-head-labels {
+  min-width: 0;
+  margin: 0;
+}
+
+#proposals-pane .proposal-type-head-field-label {
+  display: block;
+  color: inherit;
+  font: inherit;
+  line-height: 1.5;
+}
+
+#proposals-pane .proposal-products-container {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+}
+
+#proposals-pane .proposal-product-row {
+  padding: 0;
+}
+
+#proposals-pane .proposal-product-row-inner {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  column-gap: .5rem;
+  align-items: center;
+}
+
+#proposals-pane .proposal-product-badge {
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: .65rem;
+  border: 1px solid #6c757d;
+  color: #6c757d;
+  background: transparent;
+  font-weight: 400;
+  font-family: "SF Pro Text", system-ui, -apple-system, sans-serif;
+  font-variant-numeric: tabular-nums;
+  align-self: center;
+  justify-self: center;
+}
+
+#proposals-pane .proposal-product-fields {
+  min-width: 0;
+  margin: 0;
+  --bs-gutter-y: 0;
+  align-items: center;
+}
+
+#proposals-pane .proposal-product-select-shell {
+  position: relative;
+}
+
+#proposals-pane .proposal-product-fields .form-select,
+#proposals-pane .proposal-product-display {
+  min-height: calc(1.5em + .75rem + 2px);
+  height: calc(1.5em + .75rem + 2px);
+}
+
+#proposals-pane .proposal-product-select-shell select {
+  position: relative;
+  z-index: 2;
+  opacity: .01;
+}
+
+#proposals-pane .proposal-product-display {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  padding: .375rem 2.25rem .375rem .75rem;
+  color: #212529;
+  background-color: #fff;
+  border: 1px solid #ced4da;
+  border-radius: .375rem;
+  pointer-events: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#proposals-pane .proposal-product-display::after {
+  content: "";
+  position: absolute;
+  right: .75rem;
+  top: 50%;
+  width: 16px;
+  height: 16px;
+  transform: translateY(-50%);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 16px 12px;
+  opacity: .7;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
+}
+
+#proposals-pane .proposal-product-display.is-placeholder {
+  color: #6c757d;
+}
+
+#policy-modal .policy-product-select-shell {
+  position: relative;
+}
+
+#policy-modal .policy-product-select-shell select.policy-product-select {
+  position: relative;
+  z-index: 2;
+  opacity: .01;
+}
+
+#policy-modal .policy-product-select-display {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  min-height: calc(1.5em + .75rem + 2px);
+  height: calc(1.5em + .75rem + 2px);
+  padding: .375rem 2.25rem .375rem .75rem;
+  color: #212529;
+  background-color: #fff;
+  border: 1px solid #ced4da;
+  border-radius: .375rem;
+  pointer-events: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#policy-modal .policy-product-select-display::after {
+  content: "";
+  position: absolute;
+  right: .75rem;
+  top: 50%;
+  width: 16px;
+  height: 16px;
+  transform: translateY(-50%);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 16px 12px;
+  opacity: .7;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
+}
+
+#policy-modal .policy-product-select-display.is-placeholder {
+  color: #6c757d;
+}
+
+#proposals-pane .proposal-product-remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  position: relative;
+  top: -1px;
+  left: -2px;
+  color: #adb5bd;
+  border: none;
+  font-size: 1.25rem;
+  line-height: 1;
+  padding: 0 .25rem;
+  align-self: center;
+  justify-self: center;
+}
+
+#proposals-pane .proposal-product-remove:hover {
+  color: #dc3545;
+}
+
+#proposals-pane .proposal-add-product-btn {
+  margin-top: .75rem;
+  border: 1px solid #ced4da;
+  background-color: #fff;
+  color: #495057;
+  font-size: 1rem;
+  padding: .375rem .75rem;
+}
+
+#proposals-pane .proposal-stage-blocks-container {
+  display: contents;
+}
+
+#proposals-pane .proposal-stage-service-block {
+  margin-top: var(--bs-gutter-y, 1rem);
+  padding-left: calc(var(--bs-gutter-x, 1.5rem) * .5);
+  padding-right: calc(var(--bs-gutter-x, 1.5rem) * .5);
+}
+
+#proposals-pane .proposal-stage-commercial-block {
+  margin-top: .25rem;
+  padding-left: calc(var(--bs-gutter-x, 1.5rem) * .5);
+  padding-right: calc(var(--bs-gutter-x, 1.5rem) * .5);
+}
+
+#proposals-pane .proposal-stage-commercial-block + .proposal-stage-commercial-block {
+  margin-top: var(--bs-gutter-y, 1rem);
+}
+
+#proposals-pane .proposal-stage-block-title {
+  display: block;
+  margin-top: 0;
+}
+
+#proposals-pane .proposal-terms-table .proposal-terms-stage-col {
+  width: 5.5rem;
+  min-width: 5.5rem;
+  max-width: 5.5rem;
+}
+
+#proposals-pane .proposal-terms-table th.proposal-terms-stage-col,
+#proposals-pane .proposal-terms-table td.proposal-terms-stage-col {
+  padding-left: 0 !important;
+  padding-right: .25rem !important;
+}
+
+#proposals-pane .proposal-terms-table > :not(caption) > * > * {
+  border-top: 0;
+  border-bottom: 0;
+}
+
+#proposals-pane .proposal-stage-label-input {
+  text-align: center;
+}
+
+#proposals-pane .proposal-stage-terms-total-row td {
+  background: transparent;
 }
 
 #proposals-pane .proposal-project-name-composite {
@@ -3807,6 +4091,10 @@ body.proposal-service-text-modal-open {
 
 #proposals-pane .proposal-service-text-modal__toolbar,
 #policy-modal .proposal-service-text-modal__toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: .75rem;
   padding: .75rem 1rem;
   border-left: 0;
   border-right: 0;
@@ -3816,9 +4104,11 @@ body.proposal-service-text-modal-open {
 #proposals-pane .proposal-service-text-toolbar,
 #policy-modal .proposal-service-text-toolbar {
   display: flex;
+  flex: 1 1 auto;
   flex-wrap: wrap;
   gap: .5rem;
   align-items: center;
+  min-width: 0;
   padding: 0;
   border: 0;
   border-radius: 0;
@@ -3831,8 +4121,8 @@ body.proposal-service-text-modal-open {
   display: inline-flex;
   align-items: center;
   gap: .5rem;
-  margin: 0 0 0 1.25rem;
-  padding-left: .9rem;
+  margin: 0 0 0 .35rem;
+  padding-left: .75rem;
   border-left: 1px solid #e9ecef;
   min-height: 2rem;
 }

--- a/core/static/core/js/policy-panels.js
+++ b/core/static/core/js/policy-panels.js
@@ -69,6 +69,45 @@
     }
   }
 
+  function syncPolicyProductSelectDisplay(select) {
+    const shell = select?.closest('.policy-product-select-shell');
+    const display = shell?.querySelector('.policy-product-select-display');
+    if (!display) return;
+    const selected = select.options[select.selectedIndex];
+    const hasValue = !!String(selected?.value || '').trim();
+    const shortLabel = String(selected?.dataset?.shortLabel || '').trim();
+    const fallbackLabel = String(selected?.textContent || '').trim();
+    display.textContent = hasValue ? (shortLabel || fallbackLabel) : (fallbackLabel || '---------');
+    display.classList.toggle('is-placeholder', !hasValue);
+  }
+
+  function enhancePolicyProductSelect(select) {
+    if (!select || select.dataset.policyProductEnhanced === '1') {
+      if (select) syncPolicyProductSelectDisplay(select);
+      return;
+    }
+    const parent = select.parentElement;
+    if (!parent) return;
+    const shell = document.createElement('div');
+    shell.className = 'policy-product-select-shell';
+    parent.insertBefore(shell, select);
+    shell.appendChild(select);
+    const display = document.createElement('div');
+    display.className = 'policy-product-select-display';
+    shell.appendChild(display);
+    select.dataset.policyProductEnhanced = '1';
+    select.addEventListener('change', function () {
+      syncPolicyProductSelectDisplay(select);
+    });
+    syncPolicyProductSelectDisplay(select);
+  }
+
+  function initPolicyProductSelects(root) {
+    qa('select.policy-product-select', root).forEach(function (select) {
+      enhancePolicyProductSelect(select);
+    });
+  }
+
   function getMasterForPanel(panel) {
     const id = panel?.id;
     if (!id) return null;
@@ -326,6 +365,12 @@
     window.__tableSelLast = null;
   });
 
+  document.body.addEventListener('htmx:afterSwap', function (e) {
+    if (!e.target) return;
+    initPolicyProductSelects(e.target);
+  });
+
+  initPolicyProductSelects(document);
   initTypicalServiceCompositionWrapToggle();
   collapseSpecialtyTariffsSpecialties();
 })();

--- a/core/static/core/js/proposals-panels.js
+++ b/core/static/core/js/proposals-panels.js
@@ -35,6 +35,13 @@
   const PROPOSAL_STATUS_FILTER_PREF_KEY = 'proposals:status-filter';
   const PROPOSAL_KIND_FILTER_ALL = '__all__';
   const PROPOSAL_STATUS_FILTER_ALL = '__all__';
+  const PROPOSAL_STATUS_FILTER_OPTIONS = [
+    { value: 'preliminary', label: 'Предварительное' },
+    { value: 'final', label: 'Итоговое' },
+    { value: 'sent', label: 'Отправленное' },
+    { value: 'completed', label: 'Завершённое' },
+    { value: 'not_held', label: 'Несостоявшееся' },
+  ];
   const QUILL_JS = '/static/letters_app/vendor/quill/quill.min.js';
   const QUILL_CSS = '/static/letters_app/vendor/quill/quill.snow.css';
   let proposalQuillLoaded = false;
@@ -375,12 +382,27 @@
 
     const availableStatuses = [];
     const seenStatuses = new Set();
+    const availableStatusLabels = new Map();
     rows.forEach((row) => {
       const statusValue = row.dataset.status || '';
       const statusText = row.dataset.statusLabel || statusValue;
-      if (!statusValue || seenStatuses.has(statusValue)) return;
-      seenStatuses.add(statusValue);
-      availableStatuses.push({ value: statusValue, label: statusText });
+      if (!statusValue) return;
+      if (!availableStatusLabels.has(statusValue)) {
+        availableStatusLabels.set(statusValue, statusText);
+      }
+    });
+    PROPOSAL_STATUS_FILTER_OPTIONS.forEach((item) => {
+      if (seenStatuses.has(item.value)) return;
+      seenStatuses.add(item.value);
+      availableStatuses.push({
+        value: item.value,
+        label: availableStatusLabels.get(item.value) || item.label,
+      });
+    });
+    availableStatusLabels.forEach((label, value) => {
+      if (seenStatuses.has(value)) return;
+      seenStatuses.add(value);
+      availableStatuses.push({ value: value, label: label });
     });
 
     kindListContainer.innerHTML = '';
@@ -712,6 +734,23 @@
     };
 
     select.addEventListener('change', sync);
+    sync();
+  }
+
+  function attachProposalNumberDisplay(root) {
+    if (!root) return;
+    const input = root.querySelector('#proposal-number-input');
+    const display = root.querySelector('#proposal-number-display');
+    if (!input || !display || input.dataset.numberBound === '1') return;
+    input.dataset.numberBound = '1';
+
+    const sync = function () {
+      const raw = String(input.value || '').replace(/\D+/g, '').slice(0, 4);
+      display.textContent = raw ? raw.padStart(4, '0') : '';
+    };
+
+    input.addEventListener('input', sync);
+    input.addEventListener('change', sync);
     sync();
   }
 
@@ -1795,8 +1834,52 @@
     }
   }
 
+  function getProposalOwningForm(node) {
+    if (!node) return null;
+    if (node.matches?.('form[data-proposal-form]')) return node;
+    return node.closest?.('form[data-proposal-form]') || null;
+  }
+
+  function getProposalStageScope(node) {
+    if (!node) return null;
+    if (node.matches?.('[data-proposal-stage-root="1"]')) return node;
+    return node.closest?.('[data-proposal-stage-root="1"]') || null;
+  }
+
+  function getProposalScope(node) {
+    return getProposalStageScope(node) || getProposalOwningForm(node) || node;
+  }
+
+  function getProposalStageKey(node) {
+    return String(getProposalStageScope(node)?.dataset?.proposalStageKey || '').trim();
+  }
+
+  function getProposalStageRoots(form, stageKey) {
+    const key = String(stageKey || '').trim();
+    if (!form || !key) return [];
+    return Array.from(form.querySelectorAll('[data-proposal-stage-root="1"]')).filter(function (node) {
+      return String(node?.dataset?.proposalStageKey || '').trim() === key;
+    });
+  }
+
+  function getProposalStageRootByKind(form, stageKey, kind) {
+    return getProposalStageRoots(form, stageKey).find(function (node) {
+      return String(node?.dataset?.proposalStageKind || '').trim() === String(kind || '').trim();
+    }) || null;
+  }
+
   function getProposalTypeId(form) {
-    return (form?.querySelector('select[name="type"]')?.value || '').trim();
+    const stageScope = getProposalStageScope(form);
+    if (stageScope) {
+      const stageTypeInput = stageScope.querySelector?.('[data-proposal-stage-type]');
+      if (stageTypeInput) {
+        return String(stageTypeInput.value || '').trim();
+      }
+    }
+    const scope = getProposalOwningForm(form) || form;
+    const typeSelects = Array.from(scope?.querySelectorAll?.('select[name="type"]') || []);
+    if (!typeSelects.length) return '';
+    return String(typeSelects[typeSelects.length - 1]?.value || '').trim();
   }
 
   function getProposalTypicalSectionEntries(form) {
@@ -1988,7 +2071,8 @@
   function getProposalCommercialDayCounts(form, serviceName, currentValues, options) {
     const autofill = getProposalCommercialAutofill(form, serviceName);
     const defaultDays = Number.parseInt(autofill.serviceDaysTkp || 0, 10) || 0;
-    const assetsPayloadInput = form?.querySelector('#proposal-assets-payload');
+    const assetsPayloadInput = form?.querySelector('#proposal-assets-payload')
+      || getProposalOwningForm(form)?.querySelector('#proposal-assets-payload');
     let assetCount = 0;
     try {
       const rows = JSON.parse(assetsPayloadInput?.value || '[]');
@@ -2977,11 +3061,20 @@
 
   function attachProposalServicesStore(root) {
     if (!root) return null;
-    const form = root.closest('form[data-proposal-form]') || root;
-    const commercialInput = form.querySelector('#proposal-commercial-offer-payload');
-    const serviceInput = form.querySelector('#proposal-service-sections-payload');
+    const scope = getProposalScope(root);
+    const form = getProposalOwningForm(scope) || scope;
+    const stageKey = getProposalStageKey(scope);
+    const commercialRoot = stageKey ? getProposalStageRootByKind(form, stageKey, 'commercial') : scope;
+    const serviceRoot = stageKey ? getProposalStageRootByKind(form, stageKey, 'service') : scope;
+    const commercialInput = commercialRoot?.querySelector('#proposal-commercial-offer-payload');
+    const serviceInput = serviceRoot?.querySelector('#proposal-service-sections-payload');
     if (!commercialInput || !serviceInput) return null;
-    if (form.__proposalServicesStore) return form.__proposalServicesStore;
+    if (stageKey) {
+      form.__proposalStageServicesStores = form.__proposalStageServicesStores || {};
+      if (form.__proposalStageServicesStores[stageKey]) return form.__proposalStageServicesStores[stageKey];
+    } else if (form.__proposalServicesStore) {
+      return form.__proposalServicesStore;
+    }
 
     function parsePayload(input) {
       try {
@@ -2997,19 +3090,19 @@
         return normalizeProposalTravelExpensesRow(row);
       }
       const serviceName = String(row?.service_name || '').trim();
-      const autofill = getProposalCommercialAutofill(form, serviceName);
+      const autofill = getProposalCommercialAutofill(scope, serviceName);
       const specialty = autofill.jobTitle || String(row?.job_title || '').trim();
       const forceAutofill = options?.forceAutofill === true;
       const specialistValue = String(row?.specialist || '').trim();
       const statusValue = String(row?.professional_status || '').trim();
       const specialist = forceAutofill ? autofill.specialist : (specialistValue || autofill.specialist);
-      const specialistStatus = getProposalCommercialSpecialistStatus(form, serviceName, specialist);
+      const specialistStatus = getProposalCommercialSpecialistStatus(scope, serviceName, specialist);
       const currentRate = String(row?.rate_eur_per_day || '').trim();
-      const autofillRate = getProposalCommercialRateValue(form, serviceName, specialist);
+      const autofillRate = getProposalCommercialRateValue(scope, serviceName, specialist);
       const currentDayCounts = Array.isArray(row?.asset_day_counts)
         ? row.asset_day_counts.map(function (value) { return String(value ?? '').trim(); })
         : [];
-      const autofillDayCounts = getProposalCommercialDayCounts(form, serviceName, currentDayCounts, {
+      const autofillDayCounts = getProposalCommercialDayCounts(scope, serviceName, currentDayCounts, {
         replaceAll: forceAutofill,
       });
       return {
@@ -3019,7 +3112,7 @@
           ? (specialistStatus || autofill.professionalStatus)
           : (statusValue || specialistStatus || autofill.professionalStatus),
         service_name: serviceName,
-        code: getProposalTypicalSectionCode(form, serviceName) || String(row?.code || '').trim(),
+        code: getProposalTypicalSectionCode(scope, serviceName) || String(row?.code || '').trim(),
         rate_eur_per_day: forceAutofill ? (autofillRate || currentRate) : (currentRate || autofillRate),
         asset_day_counts: forceAutofill
           ? autofillDayCounts
@@ -3091,13 +3184,16 @@
         serviceRows: api.getServiceRows(),
         meta: meta || null,
       };
-      form.dispatchEvent(new CustomEvent('proposal-commercial-changed', { detail: detail }));
-      form.dispatchEvent(new CustomEvent('proposal-service-sections-changed', {
-        detail: {
-          rows: detail.serviceRows,
-          meta: meta || null,
-        },
-      }));
+      const eventTargets = stageKey ? getProposalStageRoots(form, stageKey) : [form];
+      eventTargets.forEach(function (target) {
+        target.dispatchEvent(new CustomEvent('proposal-commercial-changed', { detail: detail }));
+        target.dispatchEvent(new CustomEvent('proposal-service-sections-changed', {
+          detail: {
+            rows: detail.serviceRows,
+            meta: meta || null,
+          },
+        }));
+      });
       listeners.slice().forEach(function (listener) {
         listener(detail);
       });
@@ -3144,7 +3240,7 @@
       },
       replaceFromType: function (meta) {
         api.commitServiceRows(
-          getProposalTypicalSectionEntries(form).map(function (entry) {
+          getProposalTypicalSectionEntries(scope).map(function (entry) {
             return {
               service_name: (entry?.name || '').trim(),
               code: (entry?.code || '').trim(),
@@ -3172,28 +3268,91 @@
     };
 
     syncHiddenInputs();
-    form.__proposalServicesStore = api;
+    if (stageKey) {
+      form.__proposalStageServicesStores[stageKey] = api;
+    } else {
+      form.__proposalServicesStore = api;
+    }
     return api;
   }
 
   function attachProposalCommercialTable(root, assetsApi) {
     if (!root) return null;
-    const form = root.closest('form[data-proposal-form]') || root;
-    const servicesStore = attachProposalServicesStore(form);
-    const serviceCostInput = form.querySelector('[name="service_cost"]');
-    const table = form.querySelector('#proposal-commercial-table');
-    const payloadInput = form.querySelector('#proposal-commercial-offer-payload');
-    const totalsPayloadInput = form.querySelector('#proposal-commercial-totals-payload');
-    const thead = form.querySelector('#proposal-commercial-thead');
-    const tbody = form.querySelector('#proposal-commercial-tbody');
-    const addBtn = form.querySelector('#proposal-commercial-add-btn');
-    const actions = form.querySelector('#proposal-commercial-row-actions');
-    const upBtn = form.querySelector('#proposal-commercial-up-btn');
-    const downBtn = form.querySelector('#proposal-commercial-down-btn');
-    const deleteBtn = form.querySelector('#proposal-commercial-delete-btn');
-    if (!table || !payloadInput || !totalsPayloadInput || !thead || !tbody || !addBtn || !actions || !upBtn || !downBtn || !deleteBtn) return null;
-    if (form.dataset.commercialBound === '1') return form.__proposalCommercialTableApi || null;
-    form.dataset.commercialBound = '1';
+    const scope = getProposalScope(root);
+    const formRoot = getProposalOwningForm(scope) || scope;
+    const form = scope;
+    const isSummaryCommercialBlock = scope.dataset.proposalCommercialSummary === '1';
+    const servicesStore = isSummaryCommercialBlock ? null : attachProposalServicesStore(scope);
+    const serviceCostInput = formRoot.querySelector('[name="service_cost"]');
+    const table = scope.querySelector('#proposal-commercial-table');
+    const payloadInput = scope.querySelector('#proposal-commercial-offer-payload');
+    const totalsPayloadInput = scope.querySelector('#proposal-commercial-totals-payload');
+    const thead = scope.querySelector('#proposal-commercial-thead');
+    const tbody = scope.querySelector('#proposal-commercial-tbody');
+    const addBtn = scope.querySelector('#proposal-commercial-add-btn');
+    const actions = scope.querySelector('#proposal-commercial-row-actions');
+    const upBtn = scope.querySelector('#proposal-commercial-up-btn');
+    const downBtn = scope.querySelector('#proposal-commercial-down-btn');
+    const deleteBtn = scope.querySelector('#proposal-commercial-delete-btn');
+    if (
+      !table || !payloadInput || !totalsPayloadInput || !thead || !tbody
+      || (!isSummaryCommercialBlock && (!addBtn || !actions || !upBtn || !downBtn || !deleteBtn))
+    ) return null;
+    if (scope.dataset.commercialBound === '1') return scope.__proposalCommercialTableApi || null;
+    scope.dataset.commercialBound = '1';
+
+    function hasVisibleSummaryCommercialBlock() {
+      const summaryBlock = formRoot.querySelector('[data-proposal-commercial-summary="1"]');
+      return !!summaryBlock && !summaryBlock.classList.contains('d-none');
+    }
+
+    function getStageCommercialBlocks() {
+      return Array.from(
+        formRoot.querySelectorAll('#proposal-commercial-stages-container [data-proposal-stage-kind="commercial"]')
+      );
+    }
+
+    function getMasterCommercialBlock() {
+      return getStageCommercialBlocks()[0] || null;
+    }
+
+    function isCommercialRateMasterBlock() {
+      if (scope.dataset.proposalCommercialRateMaster === '1') return true;
+      return !isSummaryCommercialBlock && getMasterCommercialBlock() === scope;
+    }
+
+    function shouldSyncServiceCost() {
+      return isSummaryCommercialBlock ? hasVisibleSummaryCommercialBlock() : !hasVisibleSummaryCommercialBlock();
+    }
+
+    function readCommercialTotalsState(block) {
+      try {
+        return normalizeProposalCommercialTotalsState(
+          JSON.parse(block?.querySelector('#proposal-commercial-totals-payload')?.value || '{}')
+        );
+      } catch (error) {
+        return normalizeProposalCommercialTotalsState({});
+      }
+    }
+
+    function getCommercialRateStateFromBlock(block) {
+      if (!block) return null;
+      const totalsState = readCommercialTotalsState(block);
+      const rubTotalRow = block.querySelector('tr[data-rub-total-row="1"]');
+      const rateInput = rubTotalRow?.querySelector('.proposal-commercial-rate');
+      const serviceInput = rubTotalRow?.querySelector('.proposal-commercial-service-text');
+      return {
+        exchange_rate: rawMoney(rateInput?.value || totalsState.exchange_rate || ''),
+        rub_total_service_text: String(serviceInput?.value || totalsState.rub_total_service_text || '').trim(),
+      };
+    }
+
+    function getSharedCommercialRateState() {
+      if (isCommercialRateMasterBlock()) return null;
+      const masterBlock = getMasterCommercialBlock();
+      if (!masterBlock || masterBlock === scope) return null;
+      return getCommercialRateStateFromBlock(masterBlock);
+    }
 
     function parsePayload() {
       if (servicesStore) return servicesStore.getRows();
@@ -3253,10 +3412,36 @@
       totalsPayloadInput.value = JSON.stringify(normalizeProposalCommercialTotalsState(state));
     }
 
-    function getEditableRows() {
+    function applySharedCommercialRateState() {
+      const sharedState = getSharedCommercialRateState();
+      if (!sharedState) return;
+      const rubTotalRow = findFixedRow('tr[data-rub-total-row="1"]');
+      const serviceInput = rubTotalRow?.querySelector('.proposal-commercial-service-text');
+      const rateInput = rubTotalRow?.querySelector('.proposal-commercial-rate');
+      if (serviceInput && document.activeElement !== serviceInput) {
+        serviceInput.value = String(sharedState.rub_total_service_text || '').trim();
+      }
+      if (rateInput && document.activeElement !== rateInput) {
+        rateInput.value = sharedState.exchange_rate
+          ? formatProposalExchangeRateDisplay(sharedState.exchange_rate)
+          : '';
+      }
+      const currentState = parseTotalsPayload();
+      setTotalsPayload({
+        ...currentState,
+        exchange_rate: sharedState.exchange_rate,
+        rub_total_service_text: String(sharedState.rub_total_service_text || '').trim(),
+      });
+    }
+
+    function getDataRows() {
       return getRows().filter(function (row) {
         return !isFixedRow(row);
       });
+    }
+
+    function getEditableRows() {
+      return getDataRows();
     }
 
     function getSelectedRows() {
@@ -3396,6 +3581,11 @@
 
     function syncActions() {
       const hasSelected = getSelectedRows().length > 0;
+      if (isSummaryCommercialBlock) {
+        if (upBtn) upBtn.disabled = !hasSelected;
+        if (downBtn) downBtn.disabled = !hasSelected;
+        return;
+      }
       actions.classList.toggle('d-none', !hasSelected);
       actions.classList.toggle('d-flex', hasSelected);
     }
@@ -3470,7 +3660,7 @@
         return;
       }
 
-      if (isTravelExpenses && isReadOnly) {
+      if (isTravelExpenses && getTravelExpensesMode(row) !== PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION) {
         sourceValues = Array.from({ length: assetRows.length }, function () { return ''; });
       }
 
@@ -3553,12 +3743,12 @@
     }
 
     function computeSummaryValues() {
-      const editableRows = getEditableRows();
+      const dataRows = getDataRows();
       const assetCount = Math.max(getAssetRows().length, 1);
       const dayCounts = Array.from({ length: assetCount }, function () { return 0; });
       let total = 0;
 
-      editableRows.forEach(function (row) {
+      dataRows.forEach(function (row) {
         getDayInputs(row).forEach(function (input, index) {
           const value = parseInt((input.value || '').trim(), 10);
           if (Number.isFinite(value)) dayCounts[index] += value;
@@ -3621,6 +3811,7 @@
     }
 
     function computeCommercialFinancialTotals() {
+      applySharedCommercialRateState();
       const summaryTotal = parseFloat(rawMoney(
         findFixedRow('tr[data-summary-with-travel-row="1"]')?.querySelector('.proposal-commercial-total')?.value
         || findFixedRow('tr[data-summary-row="1"]')?.querySelector('.proposal-commercial-total')?.value
@@ -3669,6 +3860,7 @@
     }
 
     function syncServiceCostValue(valueRaw) {
+      if (!shouldSyncServiceCost()) return;
       if (!serviceCostInput || document.activeElement === serviceCostInput) return;
       serviceCostInput.value = valueRaw ? fmtMoney(valueRaw) : '';
     }
@@ -3725,6 +3917,11 @@
         travel_expenses_mode: getTravelExpensesMode(findFixedRow('tr[data-travel-expenses-row="1"]')),
       });
       syncAllFinancialServiceCellExpansions();
+      if (isCommercialRateMasterBlock()) {
+        formRoot.dispatchEvent(new CustomEvent('proposal-commercial-shared-rate-changed', {
+          detail: getCommercialRateStateFromBlock(scope),
+        }));
+      }
     }
 
     function updatePayload(meta) {
@@ -3762,7 +3959,7 @@
       }
       if (rate) rate.value = data.rate_eur_per_day ? fmtMoney(data.rate_eur_per_day) : '';
       if (total) total.value = data.total_eur_without_vat ? fmtMoney(data.total_eur_without_vat) : '';
-      syncDayCells(row, getAssetRows(), data.asset_day_counts || []);
+      syncDayCells(row, getAssetRows(), data.asset_day_counts || [], { readOnly: isSummaryCommercialBlock });
       recalcRowTotal(row);
     }
 
@@ -3793,6 +3990,11 @@
         data.specialist || autofill.specialist || ''
       );
       specialistSelect.value = data.specialist || autofill.specialist || '';
+      if (isSummaryCommercialBlock) {
+        specialistSelect.disabled = true;
+        specialistSelect.tabIndex = -1;
+        specialistSelect.classList.add('readonly-field');
+      }
       specialistTd.appendChild(specialistSelect);
       row.appendChild(specialistTd);
 
@@ -3818,15 +4020,70 @@
         )
         || autofill.professionalStatus
         || '';
+      if (isSummaryCommercialBlock) {
+        statusInput.readOnly = true;
+        statusInput.tabIndex = -1;
+        statusInput.classList.add('readonly-field');
+      }
       statusTd.appendChild(statusInput);
       row.appendChild(statusTd);
 
       const serviceTd = createProposalTableCell();
-      const serviceSelect = document.createElement('select');
-      serviceSelect.className = 'form-select proposal-commercial-service';
-      syncProposalCommercialServiceSelect(serviceSelect, form, data.service_name || '');
-      serviceSelect.value = data.service_name || '';
-      serviceTd.appendChild(serviceSelect);
+      let serviceSelect = null;
+      if (isSummaryCommercialBlock) {
+        const serviceInput = document.createElement('input');
+        serviceInput.type = 'text';
+        serviceInput.className = 'form-control proposal-commercial-service readonly-field';
+        serviceInput.readOnly = true;
+        serviceInput.tabIndex = -1;
+        serviceInput.value = '';
+        serviceTd.appendChild(serviceInput);
+      } else {
+        serviceSelect = document.createElement('select');
+        serviceSelect.className = 'form-select proposal-commercial-service';
+        syncProposalCommercialServiceSelect(serviceSelect, form, data.service_name || '');
+        serviceSelect.value = data.service_name || '';
+        serviceTd.appendChild(serviceSelect);
+        serviceSelect.addEventListener('change', function () {
+          const serviceAutofill = getProposalCommercialAutofill(form, serviceSelect.value || '');
+          titleInput.value = serviceAutofill.jobTitle || '';
+          syncProposalCommercialSpecialistSelect(
+            specialistSelect,
+            form,
+            serviceSelect.value || '',
+            serviceAutofill.specialist || ''
+          );
+          specialistSelect.value = serviceAutofill.specialist || '';
+          statusInput.value = getProposalCommercialSpecialistStatus(
+            form,
+            serviceSelect.value || '',
+            specialistSelect.value || ''
+          ) || serviceAutofill.professionalStatus || '';
+          const rateValue = getProposalCommercialRateValue(
+            form,
+            serviceSelect.value || '',
+            specialistSelect.value || ''
+          );
+          rateInput.value = rateValue ? fmtMoney(rateValue) : '';
+          syncDayCells(
+            row,
+            getAssetRows(),
+            getProposalCommercialDayCounts(
+              form,
+              serviceSelect.value || '',
+              getDayInputs(row).map(function (input) { return input.value || ''; }),
+              { replaceAll: true }
+            )
+          );
+          recalcRowTotal(row);
+          updatePayload({ reason: 'row-edit', rowIndex: getRows().indexOf(row) });
+        });
+        serviceSelect.addEventListener('input', function () {
+          if (!serviceSelect.value) {
+            updatePayload({ reason: 'commercial-field-edit', rowIndex: getRows().indexOf(row) });
+          }
+        });
+      }
       row.appendChild(serviceTd);
 
       const rateTd = createProposalTableCell('proposal-commercial-rate-cell');
@@ -3835,6 +4092,11 @@
       rateInput.className = 'form-control js-money-input proposal-commercial-rate';
       rateInput.inputMode = 'decimal';
       rateInput.value = data.rate_eur_per_day ? fmtMoney(data.rate_eur_per_day) : '';
+      if (isSummaryCommercialBlock) {
+        rateInput.readOnly = true;
+        rateInput.tabIndex = -1;
+        rateInput.classList.add('readonly-field');
+      }
       rateTd.appendChild(rateInput);
       row.appendChild(rateTd);
 
@@ -3849,86 +4111,49 @@
       totalTd.appendChild(totalInput);
       row.appendChild(totalTd);
 
-      syncDayCells(row, getAssetRows(), data.asset_day_counts || []);
+      syncDayCells(row, getAssetRows(), data.asset_day_counts || [], { readOnly: isSummaryCommercialBlock });
 
       [statusInput].forEach(function (input) {
+        if (isSummaryCommercialBlock) return;
         input.addEventListener('change', function () {
           updatePayload({ reason: 'commercial-field-edit', rowIndex: getRows().indexOf(row) });
         });
       });
-      statusInput.addEventListener('input', function () {
-        updatePayload({ reason: 'commercial-field-edit', rowIndex: getRows().indexOf(row) });
-      });
-      specialistSelect.addEventListener('change', function () {
-        const specialistStatus = getProposalCommercialSpecialistStatus(
-          form,
-          serviceSelect.value || '',
-          specialistSelect.value || ''
-        );
-        const rateValue = getProposalCommercialRateValue(
-          form,
-          serviceSelect.value || '',
-          specialistSelect.value || ''
-        );
-        if (specialistStatus) {
-          statusInput.value = specialistStatus;
-        } else if (!(specialistSelect.value || '').trim()) {
-          statusInput.value = '';
-        }
-        if (rateValue) {
-          rateInput.value = fmtMoney(rateValue);
-          recalcRowTotal(row);
-        }
-        updatePayload({ reason: 'commercial-field-edit', rowIndex: getRows().indexOf(row) });
-      });
-      serviceSelect.addEventListener('change', function () {
-        const serviceAutofill = getProposalCommercialAutofill(form, serviceSelect.value || '');
-        titleInput.value = serviceAutofill.jobTitle || '';
-        syncProposalCommercialSpecialistSelect(
-          specialistSelect,
-          form,
-          serviceSelect.value || '',
-          serviceAutofill.specialist || ''
-        );
-        specialistSelect.value = serviceAutofill.specialist || '';
-        statusInput.value = getProposalCommercialSpecialistStatus(
-          form,
-          serviceSelect.value || '',
-          specialistSelect.value || ''
-        ) || serviceAutofill.professionalStatus || '';
-        const rateValue = getProposalCommercialRateValue(
-          form,
-          serviceSelect.value || '',
-          specialistSelect.value || ''
-        );
-        rateInput.value = rateValue ? fmtMoney(rateValue) : '';
-        syncDayCells(
-          row,
-          getAssetRows(),
-          getProposalCommercialDayCounts(
+      if (!isSummaryCommercialBlock) {
+        statusInput.addEventListener('input', function () {
+          updatePayload({ reason: 'commercial-field-edit', rowIndex: getRows().indexOf(row) });
+        });
+        specialistSelect.addEventListener('change', function () {
+          const specialistStatus = getProposalCommercialSpecialistStatus(
             form,
             serviceSelect.value || '',
-            getDayInputs(row).map(function (input) { return input.value || ''; }),
-            { replaceAll: true }
-          )
-        );
-        recalcRowTotal(row);
-        updatePayload({ reason: 'row-edit', rowIndex: getRows().indexOf(row) });
-      });
-      serviceSelect.addEventListener('input', function () {
-        if (!serviceSelect.value) {
+            specialistSelect.value || ''
+          );
+          const rateValue = getProposalCommercialRateValue(
+            form,
+            serviceSelect.value || '',
+            specialistSelect.value || ''
+          );
+          if (specialistStatus) {
+            statusInput.value = specialistStatus;
+          } else if (!(specialistSelect.value || '').trim()) {
+            statusInput.value = '';
+          }
+          if (rateValue) {
+            rateInput.value = fmtMoney(rateValue);
+            recalcRowTotal(row);
+          }
           updatePayload({ reason: 'commercial-field-edit', rowIndex: getRows().indexOf(row) });
-        }
-      });
-
-      rateInput.addEventListener('change', function () {
-        recalcRowTotal(row);
-        updatePayload({ reason: 'commercial-field-edit', rowIndex: getRows().indexOf(row) });
-      });
-      rateInput.addEventListener('input', function () {
-        recalcRowTotal(row);
-        updatePayload({ reason: 'commercial-field-edit', rowIndex: getRows().indexOf(row) });
-      });
+        });
+        rateInput.addEventListener('change', function () {
+          recalcRowTotal(row);
+          updatePayload({ reason: 'commercial-field-edit', rowIndex: getRows().indexOf(row) });
+        });
+        rateInput.addEventListener('input', function () {
+          recalcRowTotal(row);
+          updatePayload({ reason: 'commercial-field-edit', rowIndex: getRows().indexOf(row) });
+        });
+      }
 
       attachMoneyInputs(row);
       recalcRowTotal(row);
@@ -3960,6 +4185,11 @@
         rateSelect.appendChild(option);
       });
       rateSelect.value = getTravelExpensesMode(row);
+      if (isSummaryCommercialBlock) {
+        rateSelect.disabled = true;
+        rateSelect.tabIndex = -1;
+        rateSelect.classList.add('readonly-field');
+      }
       rateTd.appendChild(rateSelect);
       row.appendChild(rateTd);
 
@@ -3973,20 +4203,22 @@
       totalTd.appendChild(totalInput);
       row.appendChild(totalTd);
 
-      syncDayCells(row, getAssetRows(), data.asset_day_counts || []);
+      syncDayCells(row, getAssetRows(), data.asset_day_counts || [], { readOnly: isSummaryCommercialBlock });
 
-      rateSelect.addEventListener('change', function () {
-        row.dataset.travelExpensesMode = normalizeProposalTravelExpensesMode(rateSelect.value) || PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL;
-        if (getTravelExpensesMode(row) === PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL) {
-          row.dataset.preservedActualTotalRaw = '';
-        }
-        const nextValues = getTravelExpensesMode(row) === PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION
-          ? getDayInputs(row).map(function (input) { return input.value || ''; })
-          : [];
-        syncDayCells(row, getAssetRows(), nextValues);
-        recalcTravelRowTotal(row);
-        updatePayload({ reason: 'travel-expenses-mode-change' });
-      });
+      if (!isSummaryCommercialBlock) {
+        rateSelect.addEventListener('change', function () {
+          row.dataset.travelExpensesMode = normalizeProposalTravelExpensesMode(rateSelect.value) || PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL;
+          if (getTravelExpensesMode(row) === PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL) {
+            row.dataset.preservedActualTotalRaw = '';
+          }
+          const nextValues = getTravelExpensesMode(row) === PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION
+            ? getDayInputs(row).map(function (input) { return input.value || ''; })
+            : [];
+          syncDayCells(row, getAssetRows(), nextValues);
+          recalcTravelRowTotal(row);
+          updatePayload({ reason: 'travel-expenses-mode-change' });
+        });
+      }
 
       attachMoneyInputs(row);
       recalcTravelRowTotal(row);
@@ -4074,7 +4306,7 @@
         serviceTd.colSpan = 1;
         const serviceWrap = document.createElement('div');
         serviceWrap.className = 'proposal-commercial-financial-service-wrap';
-        if (config.showCbrLink) {
+        if (config.showCbrLink && isCommercialRateMasterBlock()) {
           const serviceActions = document.createElement('div');
           serviceActions.className = 'proposal-commercial-service-actions';
           const serviceLink = document.createElement('a');
@@ -4130,12 +4362,18 @@
         serviceInput.type = 'text';
         serviceInput.className = 'form-control proposal-commercial-service-text';
         serviceInput.value = config.serviceStateKey ? (state[config.serviceStateKey] || '') : '';
-        serviceInput.addEventListener('input', function () {
-          syncCommercialFinancialRows();
-        });
-        serviceInput.addEventListener('change', function () {
-          syncCommercialFinancialRows();
-        });
+        if (config.showCbrLink && !isCommercialRateMasterBlock()) {
+          serviceInput.readOnly = true;
+          serviceInput.tabIndex = -1;
+          serviceInput.classList.add('readonly-field');
+        } else {
+          serviceInput.addEventListener('input', function () {
+            syncCommercialFinancialRows();
+          });
+          serviceInput.addEventListener('change', function () {
+            syncCommercialFinancialRows();
+          });
+        }
         serviceWrap.appendChild(serviceInput);
         serviceTd.appendChild(serviceWrap);
         row.appendChild(serviceTd);
@@ -4149,12 +4387,18 @@
         rateInput.dataset.moneyPrecision = '4';
         rateInput.inputMode = 'decimal';
         rateInput.value = state.exchange_rate ? formatProposalExchangeRateDisplay(state.exchange_rate) : '';
-        rateInput.addEventListener('input', function () {
-          syncCommercialFinancialRows();
-        });
-        rateInput.addEventListener('change', function () {
-          syncCommercialFinancialRows();
-        });
+        if (!isCommercialRateMasterBlock()) {
+          rateInput.readOnly = true;
+          rateInput.tabIndex = -1;
+          rateInput.classList.add('readonly-field');
+        } else {
+          rateInput.addEventListener('input', function () {
+            syncCommercialFinancialRows();
+          });
+          rateInput.addEventListener('change', function () {
+            syncCommercialFinancialRows();
+          });
+        }
         rateTd.appendChild(rateInput);
       } else if (config.rateMode === 'percent') {
         const rateInput = document.createElement('input');
@@ -4294,28 +4538,36 @@
       updatePayload({ reason: 'row-delete' });
     }
 
-    addBtn.addEventListener('click', function () {
-      const row = createRow({});
-      const firstFixedRow = getRows().find(function (item) { return isFixedRow(item); });
-      if (firstFixedRow) {
-        tbody.insertBefore(row, firstFixedRow);
-      } else {
-        tbody.appendChild(row);
-      }
-      updatePayload({ reason: 'row-add', rowIndex: getEditableRows().length - 1 });
-      row.querySelector('.proposal-commercial-specialist')?.focus();
-    });
+    if (!isSummaryCommercialBlock && addBtn) {
+      addBtn.addEventListener('click', function () {
+        const row = createRow({});
+        const firstFixedRow = getRows().find(function (item) { return isFixedRow(item); });
+        if (firstFixedRow) {
+          tbody.insertBefore(row, firstFixedRow);
+        } else {
+          tbody.appendChild(row);
+        }
+        updatePayload({ reason: 'row-add', rowIndex: getEditableRows().length - 1 });
+        row.querySelector('.proposal-commercial-specialist')?.focus();
+      });
+    }
 
-    upBtn.addEventListener('click', function () { moveSelected('up'); });
-    downBtn.addEventListener('click', function () { moveSelected('down'); });
-    deleteBtn.addEventListener('click', deleteSelected);
+    if (upBtn) {
+      upBtn.addEventListener('click', function () { moveSelected('up'); });
+    }
+    if (downBtn) {
+      downBtn.addEventListener('click', function () { moveSelected('down'); });
+    }
+    if (!isSummaryCommercialBlock && deleteBtn) {
+      deleteBtn.addEventListener('click', deleteSelected);
+    }
 
-    form.addEventListener('proposal-assets-changed', function (event) {
+    formRoot.addEventListener('proposal-assets-changed', function (event) {
       const rows = Array.isArray(event.detail?.rows) ? event.detail.rows : getAssetRows();
       const meta = event.detail?.meta || {};
       renderHeader(rows);
       getRows().forEach(function (row) {
-        if (meta.reason === 'row-add') {
+        if (meta.reason === 'row-add' && !isSummaryCommercialBlock) {
           syncDayCells(
             row,
             rows,
@@ -4336,15 +4588,25 @@
           syncSummaryWithTravelRowValues();
           return;
         }
-        syncDayCells(row, rows, undefined, { readOnly: isFixedRow(row) && !isTravelRow(row) });
+        syncDayCells(row, rows, undefined, { readOnly: isSummaryCommercialBlock || (isFixedRow(row) && !isTravelRow(row)) });
       });
       updatePayload({ reason: 'sync-asset-columns' });
     });
 
-    servicesStore.subscribe(function (detail) {
-      if (detail?.meta?.source === 'commercial-view') return;
-      renderRows(detail?.rows || []);
-    });
+    if (servicesStore) {
+      servicesStore.subscribe(function (detail) {
+        if (detail?.meta?.source === 'commercial-view') return;
+        renderRows(detail?.rows || []);
+      });
+    }
+    if (!scope.dataset.commercialSharedRateBound) {
+      scope.dataset.commercialSharedRateBound = '1';
+      formRoot.addEventListener('proposal-commercial-shared-rate-changed', function () {
+        if (isCommercialRateMasterBlock()) return;
+        applySharedCommercialRateState();
+        syncCommercialFinancialRows();
+      });
+    }
 
     renderHeader(getAssetRows());
     renderRows(parsePayload());
@@ -4363,25 +4625,26 @@
         updatePayload(meta);
       },
     };
-    form.__proposalCommercialTableApi = api;
+    scope.__proposalCommercialTableApi = api;
     return api;
   }
 
   function attachProposalServiceSectionsTable(root) {
     if (!root) return null;
-    const form = root.closest('form[data-proposal-form]') || root;
-    const servicesStore = attachProposalServicesStore(form);
-    const payloadInput = form.querySelector('#proposal-service-sections-payload');
-    const tbody = form.querySelector('#proposal-service-sections-tbody');
-    const addBtn = form.querySelector('#proposal-service-section-add-btn');
-    const actions = form.querySelector('#proposal-service-sections-row-actions');
-    const upBtn = form.querySelector('#proposal-service-section-up-btn');
-    const downBtn = form.querySelector('#proposal-service-section-down-btn');
-    const deleteBtn = form.querySelector('#proposal-service-section-delete-btn');
-    const masterCheck = form.querySelector('#proposal-service-sections-master-check');
+    const scope = getProposalScope(root);
+    const form = scope;
+    const servicesStore = attachProposalServicesStore(scope);
+    const payloadInput = scope.querySelector('#proposal-service-sections-payload');
+    const tbody = scope.querySelector('#proposal-service-sections-tbody');
+    const addBtn = scope.querySelector('#proposal-service-section-add-btn');
+    const actions = scope.querySelector('#proposal-service-sections-row-actions');
+    const upBtn = scope.querySelector('#proposal-service-section-up-btn');
+    const downBtn = scope.querySelector('#proposal-service-section-down-btn');
+    const deleteBtn = scope.querySelector('#proposal-service-section-delete-btn');
+    const masterCheck = scope.querySelector('#proposal-service-sections-master-check');
     if (!payloadInput || !tbody || !addBtn || !actions || !upBtn || !downBtn || !deleteBtn) return null;
-    if (form.dataset.serviceSectionsBound === '1') return form.__proposalServiceSectionsTableApi || null;
-    form.dataset.serviceSectionsBound = '1';
+    if (scope.dataset.serviceSectionsBound === '1') return scope.__proposalServiceSectionsTableApi || null;
+    scope.dataset.serviceSectionsBound = '1';
 
     function parsePayload() {
       if (servicesStore) return servicesStore.getServiceRows();
@@ -4539,19 +4802,12 @@
       syncActions();
     });
 
-    form.querySelector('select[name="type"]')?.addEventListener('change', function () {
-      if (servicesStore) {
-        servicesStore.replaceFromType({ reason: 'sync-services-by-type', source: 'type-change' });
-        return;
-      }
-    });
-
     if (servicesStore) {
       servicesStore.subscribe(function (detail) {
         if (detail?.meta?.source === 'service-view') return;
         renderRows(detail?.serviceRows || []);
       });
-      if (!servicesStore.getRows().length && getProposalTypeId(form)) {
+      if (!servicesStore.getRows().length && getProposalTypeId(scope)) {
         servicesStore.replaceFromType({ reason: 'autofill-service-sections-by-type', source: 'type-change' });
       }
       renderRows(servicesStore.getServiceRows());
@@ -4580,13 +4836,13 @@
         updatePayload(meta);
       },
     };
-    form.__proposalServiceSectionsTableApi = api;
+    scope.__proposalServiceSectionsTableApi = api;
     return api;
   }
 
   function attachProposalServiceTextEditor(root) {
     if (!root) return null;
-    const form = root.closest('form[data-proposal-form]') || root;
+    const form = getProposalScope(root);
     const openBtn = form.querySelector('#proposal-service-text-edit-btn');
     const modal = form.querySelector('#proposal-service-text-modal');
     const closeBtn = form.querySelector('#proposal-service-text-close-btn');
@@ -5316,6 +5572,20 @@
       return addDays(wholeDate, fractionalDays);
     }
 
+    function subtractDecimalMonths(date, months) {
+      const safeMonths = Number.isFinite(months) ? Math.max(months, 0) : 0;
+      const wholeMonths = Math.trunc(safeMonths);
+      const fractionalMonths = safeMonths - wholeMonths;
+      const fractionalDays = Math.round(fractionalMonths * 30);
+      const baseDate = addDays(startOfDay(date), -fractionalDays);
+      const targetYear = baseDate.getFullYear();
+      const targetMonthIndex = baseDate.getMonth() - wholeMonths;
+      const targetMonthStart = new Date(targetYear, targetMonthIndex, 1);
+      const targetMonthEndDay = new Date(targetMonthStart.getFullYear(), targetMonthStart.getMonth() + 1, 0).getDate();
+      const day = Math.min(baseDate.getDate(), targetMonthEndDay);
+      return new Date(targetMonthStart.getFullYear(), targetMonthStart.getMonth(), day);
+    }
+
     function addDecimalWeeks(date, weeks) {
       const safeWeeks = Number.isFinite(weeks) ? Math.max(weeks, 0) : 0;
       return addDays(date, Math.round(safeWeeks * 7));
@@ -5340,8 +5610,22 @@
       return Number.isFinite(value) ? roundProposalDecimal(value).toFixed(1) : '';
     }
 
+    function normalizeProposalDecimalInputValue(input) {
+      if (!input) return null;
+      const parsed = parseProposalDecimal(input.value);
+      input.value = parsed === null ? '' : formatProposalDecimal(parsed);
+      return parsed;
+    }
+
     function getProposalBaseStartDate() {
       return getNearestMonday(addDays(new Date(), 14));
+    }
+
+    function getProposalDefaultEvaluationDate() {
+      const today = new Date();
+      const year = today.getFullYear();
+      const julyFirst = new Date(year, 6, 1);
+      return today < julyFirst ? new Date(year, 0, 1) : new Date(year, 5, 1);
     }
 
     function decimalMonthsBetween(start, end) {
@@ -5394,8 +5678,8 @@
       const finalReportWeeksInput = form.querySelector('[name="final_report_term_weeks"]');
       if (!preliminaryDateInput || !finalDateInput || !serviceTermInput || !finalReportWeeksInput) return;
 
-      const preliminaryMonths = parseProposalDecimal(serviceTermInput.value);
-      const finalWeeks = parseProposalDecimal(finalReportWeeksInput.value);
+      const preliminaryMonths = normalizeProposalDecimalInputValue(serviceTermInput);
+      const finalWeeks = normalizeProposalDecimalInputValue(finalReportWeeksInput);
       if (preliminaryMonths === null || finalWeeks === null) return;
 
       const preliminaryDateValue = String(preliminaryDateInput.value || '').trim();
@@ -5428,7 +5712,7 @@
       if (!preliminaryDateInput || !finalDateInput || !finalReportWeeksInput) return;
 
       const preliminaryDate = parseProposalDate(preliminaryDateInput.value);
-      const finalWeeks = parseProposalDecimal(finalReportWeeksInput.value);
+      const finalWeeks = normalizeProposalDecimalInputValue(finalReportWeeksInput);
       if (!preliminaryDate || finalWeeks === null) return;
       setDateFieldValue(finalDateInput, formatProposalDateIso(addDecimalWeeks(preliminaryDate, finalWeeks)));
     }
@@ -5440,7 +5724,7 @@
       if (!preliminaryDateInput || !finalDateInput || !finalReportWeeksInput) return;
 
       const finalDate = parseProposalDate(finalDateInput.value);
-      const finalWeeks = parseProposalDecimal(finalReportWeeksInput.value);
+      const finalWeeks = normalizeProposalDecimalInputValue(finalReportWeeksInput);
       if (!finalDate || finalWeeks === null) return;
       setDateFieldValue(preliminaryDateInput, formatProposalDateIso(subtractDecimalWeeks(finalDate, finalWeeks)));
     }
@@ -5472,11 +5756,29 @@
     let proposalReportTermsEditMode = false;
 
     function applyProposalReportTermsLockState() {
+      const lockIcons = qa('.js-proposal-report-terms-lock', form);
+      const stageRows = qa('.proposal-stage-terms-row', form);
+      if (stageRows.length) {
+        stageRows.forEach(function (row) {
+          setProposalReadonly(row.querySelector('.proposal-stage-preliminary-report-date'), proposalReportTermsEditMode, { lockPicker: true });
+          setProposalReadonly(row.querySelector('.proposal-stage-final-report-date'), proposalReportTermsEditMode, { lockPicker: true });
+          setProposalReadonly(row.querySelector('.proposal-stage-service-term-months'), !proposalReportTermsEditMode);
+          setProposalReadonly(row.querySelector('.proposal-stage-final-report-term-weeks'), !proposalReportTermsEditMode);
+        });
+        lockIcons.forEach(function (icon) {
+          icon.classList.toggle('bi-lock-fill', !proposalReportTermsEditMode);
+          icon.classList.toggle('bi-unlock-fill', proposalReportTermsEditMode);
+          icon.title = proposalReportTermsEditMode
+            ? 'Заблокировать ввод сроков'
+            : 'Разблокировать ввод сроков';
+        });
+        return;
+      }
+
       const preliminaryDateInput = form.querySelector('input[name="preliminary_report_date"]');
       const finalDateInput = form.querySelector('input[name="final_report_date"]');
       const serviceTermInput = form.querySelector('[name="service_term_months"]');
       const finalReportWeeksInput = form.querySelector('[name="final_report_term_weeks"]');
-      const lockIcons = qa('.js-proposal-report-terms-lock', form);
       if (!preliminaryDateInput || !finalDateInput || !serviceTermInput || !finalReportWeeksInput) return;
 
       if (proposalReportTermsEditMode) {
@@ -5495,6 +5797,879 @@
           ? 'Заблокировать ввод сроков'
           : 'Разблокировать ввод сроков';
       });
+    }
+
+    function attachProposalStageProducts(assetsApi) {
+      const container = form.querySelector('#proposal-products-container');
+      const addBtn = form.querySelector('#proposal-add-product');
+      const metaEl = form.querySelector('#proposal-type-meta');
+      const serviceStagesContainer = form.querySelector('#proposal-service-stages-container');
+      const commercialStagesContainer = form.querySelector('#proposal-commercial-stages-container');
+      const termsTbody = form.querySelector('#proposal-stage-terms-tbody');
+      if (!container || !addBtn || !metaEl || !serviceStagesContainer || !commercialStagesContainer || !termsTbody) return null;
+      if (form.dataset.stageProductsBound === '1') return form.__proposalStageProductsApi || null;
+      form.dataset.stageProductsBound = '1';
+
+      let meta = {};
+      try {
+        meta = JSON.parse(metaEl.textContent || '{}');
+      } catch (error) {
+        meta = {};
+      }
+      const products = Array.isArray(meta.products) ? meta.products : [];
+      const consultingTypes = Array.isArray(meta.consulting_types) ? meta.consulting_types : [];
+      const serviceCategories = Array.isArray(meta.service_categories) ? meta.service_categories : [];
+      const productById = new Map(products.map(function (product) { return [String(product.id), product]; }));
+      form.__proposalStageUidCounter = form.__proposalStageUidCounter || (getProductRowsInitialMaxStageUid() + 1);
+
+      function getProductRowsInitialMaxStageUid() {
+        return Array.from(container.querySelectorAll('.proposal-product-row')).reduce(function (maxValue, row, index) {
+          const raw = String(row.dataset.stageUid || (index + 1));
+          const numeric = Number.parseInt(raw, 10);
+          return Number.isFinite(numeric) ? Math.max(maxValue, numeric) : maxValue;
+        }, 0);
+      }
+
+      function nextStageUid() {
+        const uid = form.__proposalStageUidCounter || 1;
+        form.__proposalStageUidCounter = uid + 1;
+        return String(uid);
+      }
+
+      function getProductRows() {
+        return Array.from(container.querySelectorAll('.proposal-product-row'));
+      }
+
+      function getServiceBlocks() {
+        return Array.from(serviceStagesContainer.querySelectorAll('[data-proposal-stage-kind="service"]'));
+      }
+
+      function getCommercialBlocks() {
+        return Array.from(commercialStagesContainer.querySelectorAll('[data-proposal-stage-kind="commercial"]'));
+      }
+
+      function getSummaryCommercialBlock() {
+        return commercialStagesContainer.querySelector('[data-proposal-stage-kind="commercial-summary"]');
+      }
+
+      function getStageTermRows() {
+        return Array.from(termsTbody.querySelectorAll('.proposal-stage-terms-row'));
+      }
+
+      function getTotalsRow() {
+        return termsTbody.querySelector('.proposal-stage-terms-total-row');
+      }
+
+      function getAssetRows() {
+        return assetsApi ? assetsApi.getSerializedRows() : [];
+      }
+
+      function uniqueValues(items) {
+        const seen = new Set();
+        return items.filter(function (item) {
+          const value = String(item || '').trim();
+          if (!value || seen.has(value)) return false;
+          seen.add(value);
+          return true;
+        });
+      }
+
+      function buildOptions(select, items, placeholder, selectedValue, mapper) {
+        if (!select) return;
+        const normalizedSelected = String(selectedValue || '');
+        select.innerHTML = '';
+        if (placeholder) {
+          const option = document.createElement('option');
+          option.value = '';
+          option.textContent = placeholder;
+          select.appendChild(option);
+        }
+        items.forEach(function (item) {
+          const option = document.createElement('option');
+          const mapped = mapper ? mapper(item) : { value: item, label: item };
+          option.value = String(mapped.value || '');
+          option.textContent = mapped.label || '';
+          select.appendChild(option);
+        });
+        select.value = normalizedSelected;
+        if (select.value !== normalizedSelected) select.value = '';
+      }
+
+      function filteredProducts(consultingType, serviceCategory, serviceSubtype) {
+        return products.filter(function (product) {
+          if (consultingType && product.consulting_type !== consultingType) return false;
+          if (serviceCategory && product.service_category !== serviceCategory) return false;
+          if (serviceSubtype && product.service_subtype !== serviceSubtype) return false;
+          return true;
+        });
+      }
+
+      function resetClonedStageBlock(block) {
+        block.querySelectorAll('tbody').forEach(function (tbody) {
+          tbody.innerHTML = '';
+        });
+        block.querySelectorAll('input[type="hidden"]').forEach(function (input) {
+          if (input.matches('[data-proposal-stage-type]')) {
+            input.value = '';
+            return;
+          }
+          if (input.name === 'service_composition_mode') {
+            input.value = 'sections';
+            return;
+          }
+          if (input.name === 'commercial_totals_payload') {
+            input.value = JSON.stringify(normalizeProposalCommercialTotalsState({}));
+            return;
+          }
+          input.value = '';
+        });
+        block.querySelectorAll('textarea').forEach(function (textarea) {
+          textarea.value = '';
+        });
+        block.querySelectorAll('input:not([type="hidden"])').forEach(function (input) {
+          if (input.classList.contains('proposal-stage-label-input')) return;
+          if (input.type === 'checkbox') {
+            input.checked = false;
+            return;
+          }
+          input.value = '';
+        });
+        delete block.__proposalServiceSectionsTableApi;
+        delete block.__proposalServiceTextEditorApi;
+        delete block.__proposalCommercialTableApi;
+        delete block.dataset.serviceSectionsBound;
+        delete block.dataset.serviceTextEditorBound;
+        delete block.dataset.commercialBound;
+        delete block.dataset.commercialSharedRateBound;
+        delete block.dataset.proposalCommercialRateMaster;
+        delete block.dataset.summarySyncBound;
+      }
+
+      function cloneStageBlock(block) {
+        const clone = block.cloneNode(true);
+        resetClonedStageBlock(clone);
+        return clone;
+      }
+
+      function cloneTermsRow(row) {
+        const clone = row.cloneNode(true);
+        delete clone.dataset.eventsBound;
+        delete clone.dataset.manualDateSource;
+        delete clone.dataset.forceDatesFromTerms;
+        clone.querySelectorAll('input').forEach(function (input) {
+          delete input.dataset.hasPicker;
+          if (!input.classList.contains('proposal-stage-label-input')) {
+            input.value = '';
+          }
+        });
+        return clone;
+      }
+
+      function ensureMirroredBlocks() {
+        let serviceBlocks = getServiceBlocks();
+        while (serviceBlocks.length < getProductRows().length && serviceBlocks.length) {
+          const clone = cloneStageBlock(serviceBlocks[serviceBlocks.length - 1]);
+          serviceStagesContainer.appendChild(clone);
+          serviceBlocks = getServiceBlocks();
+        }
+        while (serviceBlocks.length > getProductRows().length && serviceBlocks.length > 1) {
+          serviceBlocks[serviceBlocks.length - 1].remove();
+          serviceBlocks = getServiceBlocks();
+        }
+
+        let commercialBlocks = getCommercialBlocks();
+        while (commercialBlocks.length < getProductRows().length && commercialBlocks.length) {
+          const clone = cloneStageBlock(commercialBlocks[commercialBlocks.length - 1]);
+          const summaryCommercialBlock = getSummaryCommercialBlock();
+          if (summaryCommercialBlock) {
+            commercialStagesContainer.insertBefore(clone, summaryCommercialBlock);
+          } else {
+            commercialStagesContainer.appendChild(clone);
+          }
+          commercialBlocks = getCommercialBlocks();
+        }
+        while (commercialBlocks.length > getProductRows().length && commercialBlocks.length > 1) {
+          commercialBlocks[commercialBlocks.length - 1].remove();
+          commercialBlocks = getCommercialBlocks();
+        }
+
+        let termRows = getStageTermRows();
+        while (termRows.length < getProductRows().length && termRows.length) {
+          termsTbody.insertBefore(cloneTermsRow(termRows[termRows.length - 1]), getTotalsRow());
+          termRows = getStageTermRows();
+        }
+        while (termRows.length > getProductRows().length && termRows.length > 1) {
+          termRows[termRows.length - 1].remove();
+          termRows = getStageTermRows();
+        }
+      }
+
+      function syncStageLabels() {
+        const productRows = getProductRows();
+        const serviceBlocks = getServiceBlocks();
+        const commercialBlocks = getCommercialBlocks();
+        const termRows = getStageTermRows();
+        const hasMultipleStages = productRows.length > 1;
+        const summaryCommercialBlock = getSummaryCommercialBlock();
+        function buildStageTitle(baseTitle, rank, productId) {
+          if (!hasMultipleStages) return baseTitle;
+          const product = productById.get(String(productId || '').trim()) || null;
+          const shortLabel = String(product?.short_label || '').trim();
+          return shortLabel
+            ? baseTitle + ': Этап ' + rank + ' ' + shortLabel
+            : baseTitle + ': Этап ' + rank;
+        }
+        productRows.forEach(function (row, index) {
+          const rank = index + 1;
+          if (!row.dataset.stageUid) row.dataset.stageUid = nextStageUid();
+          const stageUid = row.dataset.stageUid;
+          const productId = String(row.querySelector('.proposal-product-select')?.value || '').trim();
+          row.querySelector('.proposal-product-badge').textContent = rank;
+          const serviceBlock = serviceBlocks[index];
+          const commercialBlock = commercialBlocks[index];
+          const termRow = termRows[index];
+          [serviceBlock, commercialBlock].forEach(function (block) {
+            if (!block) return;
+            block.dataset.proposalStageKey = stageUid;
+            if (block.dataset.proposalStageKind === 'commercial') {
+              block.dataset.proposalCommercialRateMaster = index === 0 ? '1' : '0';
+            }
+            block.querySelectorAll('.proposal-stage-block-title').forEach(function (title) {
+              if (block.dataset.proposalStageKind === 'service') {
+                title.textContent = buildStageTitle('Состав услуг / техническое задание', rank, productId);
+              } else {
+                title.textContent = buildStageTitle('Коммерческое предложение', rank, productId);
+              }
+            });
+          });
+          if (termRow) {
+            termRow.dataset.proposalStageKey = stageUid;
+            const stageInput = termRow.querySelector('.proposal-stage-label-input');
+            if (stageInput) stageInput.value = 'Этап ' + rank;
+          }
+        });
+        if (summaryCommercialBlock) {
+          summaryCommercialBlock.classList.toggle('d-none', !hasMultipleStages);
+          summaryCommercialBlock.dataset.proposalStageKey = 'summary';
+          summaryCommercialBlock.dataset.proposalCommercialRateMaster = '0';
+          summaryCommercialBlock.querySelectorAll('.proposal-stage-block-title').forEach(function (title) {
+            title.textContent = 'Коммерческое предложение: все этапы';
+          });
+        }
+        getTotalsRow()?.classList.toggle('d-none', productRows.length <= 1);
+      }
+
+      function bindProductRow(row) {
+        if (!row || row.dataset.eventsBound === '1') return;
+        if (!row.dataset.stageUid) row.dataset.stageUid = nextStageUid();
+        row.dataset.eventsBound = '1';
+        const consultingSelect = row.querySelector('.proposal-consulting-select');
+        const categorySelect = row.querySelector('.proposal-service-category-select');
+        const subtypeSelect = row.querySelector('.proposal-service-subtype-select');
+        const productSelect = row.querySelector('.proposal-product-select');
+
+        function syncRow(state) {
+          const selectedProduct = productById.get(String(state?.productId ?? productSelect?.value ?? ''));
+          let consultingValue = String(state?.consultingType ?? consultingSelect?.value ?? '');
+          let categoryValue = String(state?.serviceCategory ?? categorySelect?.value ?? '');
+          let subtypeValue = String(state?.serviceSubtype ?? subtypeSelect?.value ?? '');
+          let productValue = String(state?.productId ?? productSelect?.value ?? '');
+          if (selectedProduct) {
+            consultingValue = selectedProduct.consulting_type || consultingValue;
+            categoryValue = selectedProduct.service_category || categoryValue;
+            subtypeValue = selectedProduct.service_subtype || subtypeValue;
+            productValue = String(selectedProduct.id);
+          }
+          buildOptions(consultingSelect, consultingTypes, '— выберите вид консалтинга —', consultingValue);
+          consultingValue = consultingSelect?.value || '';
+          const categoryOptions = uniqueValues(filteredProducts(consultingValue, '', '').map(function (product) {
+            return product.service_category;
+          }));
+          const orderedCategories = serviceCategories.filter(function (value) { return categoryOptions.includes(value); });
+          const extraCategories = categoryOptions.filter(function (value) { return !orderedCategories.includes(value); });
+          buildOptions(
+            categorySelect,
+            orderedCategories.concat(extraCategories),
+            consultingValue ? '— выберите тип услуги —' : '— выберите вид консалтинга —',
+            categoryValue
+          );
+          categoryValue = categorySelect?.value || '';
+          const subtypeOptions = uniqueValues(filteredProducts(consultingValue, categoryValue, '').map(function (product) {
+            return product.service_subtype;
+          }));
+          buildOptions(
+            subtypeSelect,
+            subtypeOptions,
+            categoryValue ? '— выберите подтип услуги —' : '— выберите тип услуги —',
+            subtypeValue
+          );
+          subtypeValue = subtypeSelect?.value || '';
+          buildOptions(
+            productSelect,
+            filteredProducts(consultingValue, categoryValue, subtypeValue),
+            '— выберите продукт —',
+            productValue,
+            function (product) {
+              return { value: product.id, label: product.label };
+            }
+          );
+          const displayProduct = productById.get(String(productSelect?.value || ''));
+          const productDisplay = row.querySelector('.proposal-product-display');
+          if (productDisplay) {
+            productDisplay.textContent = displayProduct?.short_label || '— выберите продукт —';
+            productDisplay.classList.toggle('is-placeholder', !displayProduct);
+          }
+          row.dataset.selectedConsultingType = consultingValue;
+          row.dataset.selectedServiceCategory = categoryValue;
+          row.dataset.selectedServiceSubtype = subtypeValue;
+          row.dataset.selectedProductId = productSelect?.value || '';
+        }
+
+        consultingSelect?.addEventListener('change', function () {
+          syncRow({ consultingType: consultingSelect.value, serviceCategory: '', serviceSubtype: '', productId: '' });
+          syncStageContent();
+        });
+        categorySelect?.addEventListener('change', function () {
+          syncRow({ consultingType: consultingSelect?.value || '', serviceCategory: categorySelect.value, serviceSubtype: '', productId: '' });
+          syncStageContent();
+        });
+        subtypeSelect?.addEventListener('change', function () {
+          syncRow({ consultingType: consultingSelect?.value || '', serviceCategory: categorySelect?.value || '', serviceSubtype: subtypeSelect.value, productId: '' });
+          syncStageContent();
+        });
+        productSelect?.addEventListener('change', function () {
+          syncRow({ productId: productSelect.value });
+          syncStageContent();
+        });
+
+        syncRow({
+          consultingType: row.dataset.selectedConsultingType || '',
+          serviceCategory: row.dataset.selectedServiceCategory || '',
+          serviceSubtype: row.dataset.selectedServiceSubtype || '',
+          productId: row.dataset.selectedProductId || '',
+        });
+      }
+
+      function bindTermsRows() {
+        getStageTermRows().forEach(function (row) {
+          if (row.dataset.eventsBound === '1') return;
+          row.dataset.eventsBound = '1';
+          row.querySelectorAll('.js-date').forEach(function (input) {
+            initProposalDateInput(input);
+          });
+          const monthsInput = row.querySelector('.proposal-stage-service-term-months');
+          const weeksInput = row.querySelector('.proposal-stage-final-report-term-weeks');
+          normalizeProposalDecimalInputValue(monthsInput);
+          normalizeProposalDecimalInputValue(weeksInput);
+          ['input', 'change'].forEach(function (eventName) {
+            row.querySelector('.proposal-stage-evaluation-date')?.addEventListener(eventName, function () {
+              syncStageEvaluationDates(row.querySelector('.proposal-stage-evaluation-date')?.value || '');
+            });
+            monthsInput?.addEventListener(eventName, function () {
+              syncStageTerms();
+              if (eventName === 'change') normalizeProposalDecimalInputValue(monthsInput);
+            });
+            weeksInput?.addEventListener(eventName, function () {
+              syncStageTerms();
+              if (eventName === 'change') normalizeProposalDecimalInputValue(weeksInput);
+            });
+            row.querySelector('.proposal-stage-preliminary-report-date')?.addEventListener(eventName, function () {
+              if (!proposalReportTermsEditMode) {
+                row.dataset.manualDateSource = 'preliminary';
+                syncStageTerms();
+              }
+            });
+            row.querySelector('.proposal-stage-final-report-date')?.addEventListener(eventName, function () {
+              if (!proposalReportTermsEditMode) {
+                row.dataset.manualDateSource = 'final';
+                syncStageTerms();
+              }
+            });
+          });
+        });
+      }
+
+      function getSharedEvaluationDateValue(preferredValue) {
+        const preferredDate = parseProposalDate(preferredValue);
+        if (preferredDate) return formatProposalDateIso(preferredDate);
+        const firstInput = getStageTermRows()[0]?.querySelector('.proposal-stage-evaluation-date');
+        const firstDate = parseProposalDate(firstInput?.value) || getProposalDefaultEvaluationDate();
+        return formatProposalDateIso(firstDate);
+      }
+
+      function syncStageEvaluationDates(preferredValue) {
+        const sharedValue = getSharedEvaluationDateValue(preferredValue);
+        getStageTermRows().forEach(function (row) {
+          const evaluationInput = row.querySelector('.proposal-stage-evaluation-date');
+          if (evaluationInput) {
+            setDateFieldValue(evaluationInput, sharedValue);
+          }
+        });
+      }
+
+      function ensureStageEditorsInitialized() {
+        getServiceBlocks().forEach(function (block) {
+          attachProposalServiceSectionsTable(block);
+          attachProposalServiceTextEditor(block);
+        });
+        getCommercialBlocks().forEach(function (block) {
+          attachProposalCommercialTable(block, assetsApi);
+        });
+        const summaryCommercialBlock = getSummaryCommercialBlock();
+        if (summaryCommercialBlock) {
+          attachProposalCommercialTable(summaryCommercialBlock, assetsApi);
+        }
+      }
+
+      function parseCommercialTotalsPayload(block) {
+        try {
+          return normalizeProposalCommercialTotalsState(
+            JSON.parse(block?.querySelector('#proposal-commercial-totals-payload')?.value || '{}')
+          );
+        } catch (error) {
+          return normalizeProposalCommercialTotalsState({});
+        }
+      }
+
+      function parseCommercialOfferPayload(block) {
+        try {
+          const data = JSON.parse(block?.querySelector('#proposal-commercial-offer-payload')?.value || '[]');
+          return Array.isArray(data) ? data : [];
+        } catch (error) {
+          return [];
+        }
+      }
+
+      function getSummaryCommercialRowOrder() {
+        const summaryCommercialBlock = getSummaryCommercialBlock();
+        const rows = parseCommercialOfferPayload(summaryCommercialBlock);
+        const order = new Map();
+        rows.forEach(function (row, index) {
+          if (isProposalTravelExpensesRow(row)) return;
+          const key = String(row?.specialist || '').trim() + '\u0000' + String(row?.job_title || '').trim();
+          if (key && !order.has(key)) {
+            order.set(key, index);
+          }
+        });
+        return order;
+      }
+
+      function buildSummaryCommercialRows() {
+        const assetCount = Math.max(getAssetRows().length, 1);
+        const groupedRows = [];
+        const groupedByKey = new Map();
+        const preferredOrder = getSummaryCommercialRowOrder();
+        const travelDayTotals = Array.from({ length: assetCount }, function () { return 0; });
+        let travelTotal = 0;
+        let hasTravelCalculation = false;
+        let hasTravelActual = false;
+        let hasTravelData = false;
+
+        getCommercialBlocks().forEach(function (block) {
+          const api = attachProposalCommercialTable(block, assetsApi);
+          const rows = Array.isArray(api?.getSerializedRows?.()) ? api.getSerializedRows() : [];
+          const totalsState = parseCommercialTotalsPayload(block);
+          const travelMode = normalizeProposalTravelExpensesMode(totalsState.travel_expenses_mode) || PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL;
+          rows.forEach(function (row) {
+            if (isProposalTravelExpensesRow(row)) {
+              const totalValue = parseFloat(rawMoney(row?.total_eur_without_vat || ''));
+              if (Number.isFinite(totalValue)) {
+                travelTotal += totalValue;
+                hasTravelData = true;
+              }
+              if (travelMode === PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION) {
+                hasTravelCalculation = true;
+                (Array.isArray(row?.asset_day_counts) ? row.asset_day_counts : []).slice(0, assetCount).forEach(function (value, index) {
+                  const numericValue = parseFloat(rawMoney(value || ''));
+                  if (Number.isFinite(numericValue)) {
+                    travelDayTotals[index] += numericValue;
+                    hasTravelData = true;
+                  }
+                });
+              } else if (totalValue || String(row?.total_eur_without_vat || '').trim()) {
+                hasTravelActual = true;
+              }
+              return;
+            }
+
+            const specialist = String(row?.specialist || '').trim();
+            const jobTitle = String(row?.job_title || '').trim();
+            const key = specialist + '\u0000' + jobTitle;
+            let bucket = groupedByKey.get(key);
+            if (!bucket) {
+              bucket = {
+                specialist: specialist,
+                job_title: jobTitle,
+                professional_status: String(row?.professional_status || '').trim(),
+                service_name: '',
+                rate_eur_per_day: String(row?.rate_eur_per_day || '').trim(),
+                asset_day_counts: Array.from({ length: assetCount }, function () { return 0; }),
+                total_eur_without_vat: 0,
+              };
+              groupedByKey.set(key, bucket);
+              groupedRows.push(bucket);
+            }
+            (Array.isArray(row?.asset_day_counts) ? row.asset_day_counts : []).slice(0, assetCount).forEach(function (value, index) {
+              const numericValue = parseInt(String(value || '').trim(), 10);
+              if (Number.isFinite(numericValue)) {
+                bucket.asset_day_counts[index] += numericValue;
+              }
+            });
+            const totalValue = parseFloat(rawMoney(row?.total_eur_without_vat || ''));
+            if (Number.isFinite(totalValue)) {
+              bucket.total_eur_without_vat += totalValue;
+            }
+          });
+        });
+
+        const rows = groupedRows.map(function (bucket, index) {
+          return {
+            specialist: bucket.specialist,
+            job_title: bucket.job_title,
+            professional_status: bucket.professional_status,
+            service_name: '',
+            rate_eur_per_day: bucket.rate_eur_per_day,
+            asset_day_counts: bucket.asset_day_counts.map(function (value) { return value > 0 ? String(value) : ''; }),
+            total_eur_without_vat: bucket.total_eur_without_vat > 0 ? bucket.total_eur_without_vat.toFixed(2) : '',
+            __summaryOrderIndex: index,
+          };
+        });
+
+        rows.sort(function (left, right) {
+          const leftKey = String(left?.specialist || '').trim() + '\u0000' + String(left?.job_title || '').trim();
+          const rightKey = String(right?.specialist || '').trim() + '\u0000' + String(right?.job_title || '').trim();
+          const leftOrder = preferredOrder.has(leftKey) ? preferredOrder.get(leftKey) : Number.MAX_SAFE_INTEGER;
+          const rightOrder = preferredOrder.has(rightKey) ? preferredOrder.get(rightKey) : Number.MAX_SAFE_INTEGER;
+          if (leftOrder !== rightOrder) return leftOrder - rightOrder;
+          return (left.__summaryOrderIndex || 0) - (right.__summaryOrderIndex || 0);
+        });
+
+        const serializedRows = rows.map(function (row) {
+          return {
+            specialist: row.specialist,
+            job_title: row.job_title,
+            professional_status: row.professional_status,
+            service_name: row.service_name,
+            rate_eur_per_day: row.rate_eur_per_day,
+            asset_day_counts: row.asset_day_counts,
+            total_eur_without_vat: row.total_eur_without_vat,
+          };
+        });
+
+        const travelMode = (
+          hasTravelCalculation && !hasTravelActual
+            ? PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION
+            : PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL
+        );
+        if (hasTravelData) {
+          serializedRows.push({
+            specialist: '',
+            job_title: '',
+            professional_status: '',
+            service_name: PROPOSAL_TRAVEL_EXPENSES_LABEL,
+            rate_eur_per_day: '',
+            asset_day_counts: travelMode === PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION
+              ? travelDayTotals.map(function (value) { return value > 0 ? fmtMoney(value.toFixed(2)) : ''; })
+              : Array.from({ length: assetCount }, function () { return ''; }),
+            total_eur_without_vat: travelTotal > 0 ? travelTotal.toFixed(2) : '',
+          });
+        }
+
+        return {
+          rows: serializedRows,
+          travelMode: travelMode,
+        };
+      }
+
+      function syncSummaryCommercialBlock() {
+        const summaryCommercialBlock = getSummaryCommercialBlock();
+        const hasMultipleStages = getProductRows().length > 1;
+        if (!summaryCommercialBlock) return;
+        summaryCommercialBlock.classList.toggle('d-none', !hasMultipleStages);
+        if (!hasMultipleStages) return;
+        const summaryApi = attachProposalCommercialTable(summaryCommercialBlock, assetsApi);
+        if (!summaryApi) return;
+        const summaryPayload = buildSummaryCommercialRows();
+        const totalsInput = summaryCommercialBlock.querySelector('#proposal-commercial-totals-payload');
+        const totalsState = parseCommercialTotalsPayload(summaryCommercialBlock);
+        totalsState.travel_expenses_mode = summaryPayload.travelMode;
+        if (totalsInput) {
+          totalsInput.value = JSON.stringify(normalizeProposalCommercialTotalsState(totalsState));
+        }
+        summaryApi.replaceRows(summaryPayload.rows, { reason: 'summary-sync' });
+      }
+
+      function bindSummaryCommercialSync() {
+        getCommercialBlocks().forEach(function (block) {
+          if (block.dataset.summarySyncBound === '1') return;
+          block.dataset.summarySyncBound = '1';
+          block.addEventListener('proposal-commercial-changed', function () {
+            syncSummaryCommercialBlock();
+          });
+        });
+      }
+
+      function syncStageTerms() {
+        const termRows = getStageTermRows();
+        const states = termRows.map(function (row) {
+          const monthsInput = row.querySelector('.proposal-stage-service-term-months');
+          const weeksInput = row.querySelector('.proposal-stage-final-report-term-weeks');
+          const months = normalizeProposalDecimalInputValue(monthsInput);
+          const weeks = normalizeProposalDecimalInputValue(weeksInput);
+          return {
+            row: row,
+            monthsInput: monthsInput,
+            preliminaryInput: row.querySelector('.proposal-stage-preliminary-report-date'),
+            weeksInput: weeksInput,
+            finalInput: row.querySelector('.proposal-stage-final-report-date'),
+            months: months,
+            weeks: weeks,
+            preliminaryDate: parseProposalDate(row.querySelector('.proposal-stage-preliminary-report-date')?.value),
+            finalDate: parseProposalDate(row.querySelector('.proposal-stage-final-report-date')?.value),
+            shouldForceDatesFromTerms: row.dataset.forceDatesFromTerms === '1',
+            manualDateSource: String(row.dataset.manualDateSource || '').trim(),
+            calculatedPreliminaryDate: null,
+            calculatedFinalDate: null,
+          };
+        });
+
+        function applyStateDates(state) {
+          setDateFieldValue(
+            state.preliminaryInput,
+            state.calculatedPreliminaryDate ? formatProposalDateIso(state.calculatedPreliminaryDate) : ''
+          );
+          setDateFieldValue(
+            state.finalInput,
+            state.calculatedFinalDate ? formatProposalDateIso(state.calculatedFinalDate) : ''
+          );
+        }
+
+        function computeForwardDates(startDate, state) {
+          if (state.months === null) {
+            state.calculatedPreliminaryDate = null;
+            state.calculatedFinalDate = null;
+            return startDate;
+          }
+          state.calculatedPreliminaryDate = addDecimalMonths(startDate, state.months);
+          if (state.weeks === null) {
+            state.calculatedFinalDate = null;
+            return state.calculatedPreliminaryDate;
+          }
+          state.calculatedFinalDate = addDecimalWeeks(state.calculatedPreliminaryDate, state.weeks);
+          return state.calculatedFinalDate;
+        }
+
+        if (proposalReportTermsEditMode) {
+          let startDate = form.__proposalStageBaseStartDate || getProposalBaseStartDate();
+          states.forEach(function (state) {
+            startDate = computeForwardDates(startDate, state);
+            applyStateDates(state);
+            delete state.row.dataset.forceDatesFromTerms;
+            delete state.row.dataset.manualDateSource;
+          });
+        } else {
+          let baseStartDate = form.__proposalStageBaseStartDate || getProposalBaseStartDate();
+          const manualIndex = states.findIndex(function (state) {
+            if (state.manualDateSource === 'preliminary') return !!state.preliminaryDate && state.months !== null;
+            if (state.manualDateSource === 'final') return !!state.finalDate && state.weeks !== null;
+            return false;
+          });
+
+          if (manualIndex >= 0) {
+            const manualState = states[manualIndex];
+            let manualStageStartDate = null;
+            if (manualState.manualDateSource === 'preliminary') {
+              manualState.calculatedPreliminaryDate = manualState.preliminaryDate;
+              manualState.calculatedFinalDate = manualState.weeks !== null
+                ? addDecimalWeeks(manualState.preliminaryDate, manualState.weeks)
+                : null;
+              manualStageStartDate = manualState.preliminaryDate && manualState.months !== null
+                ? subtractDecimalMonths(manualState.preliminaryDate, manualState.months)
+                : null;
+            } else {
+              manualState.calculatedFinalDate = manualState.finalDate;
+              manualState.calculatedPreliminaryDate = manualState.weeks !== null
+                ? subtractDecimalWeeks(manualState.finalDate, manualState.weeks)
+                : null;
+              manualStageStartDate = manualState.calculatedPreliminaryDate && manualState.months !== null
+                ? subtractDecimalMonths(manualState.calculatedPreliminaryDate, manualState.months)
+                : null;
+            }
+
+            let rollingStartDate = manualStageStartDate;
+
+            for (let index = manualIndex - 1; index >= 0; index -= 1) {
+              const state = states[index];
+              state.calculatedFinalDate = rollingStartDate;
+              state.calculatedPreliminaryDate = rollingStartDate && state.weeks !== null
+                ? subtractDecimalWeeks(rollingStartDate, state.weeks)
+                : null;
+              rollingStartDate = state.calculatedPreliminaryDate && state.months !== null
+                ? subtractDecimalMonths(state.calculatedPreliminaryDate, state.months)
+                : rollingStartDate;
+            }
+
+            if (rollingStartDate) {
+              baseStartDate = rollingStartDate;
+              form.__proposalStageBaseStartDate = baseStartDate;
+            }
+
+            let forwardStartDate = manualState.calculatedFinalDate || manualState.calculatedPreliminaryDate || manualStageStartDate || baseStartDate;
+            for (let index = manualIndex + 1; index < states.length; index += 1) {
+              const state = states[index];
+              forwardStartDate = computeForwardDates(forwardStartDate, state);
+            }
+
+            states.forEach(applyStateDates);
+          } else {
+            let startDate = baseStartDate;
+            states.forEach(function (state) {
+              const shouldComputeFromTerms = state.shouldForceDatesFromTerms || (!state.preliminaryDate && !state.finalDate);
+              if (shouldComputeFromTerms) {
+                startDate = computeForwardDates(startDate, state);
+                applyStateDates(state);
+              } else {
+                startDate = state.finalDate || state.preliminaryDate || startDate;
+              }
+            });
+          }
+
+          states.forEach(function (state) {
+            delete state.row.dataset.forceDatesFromTerms;
+            delete state.row.dataset.manualDateSource;
+          });
+        }
+        const totalsRow = getTotalsRow();
+        if (!totalsRow) return;
+        const totalMonths = termRows.reduce(function (sum, row) {
+          return sum + (parseProposalDecimal(row.querySelector('.proposal-stage-service-term-months')?.value) || 0);
+        }, 0);
+        const totalWeeks = termRows.reduce(function (sum, row) {
+          return sum + (parseProposalDecimal(row.querySelector('.proposal-stage-final-report-term-weeks')?.value) || 0);
+        }, 0);
+        const totalMonthsInput = totalsRow.querySelector('.proposal-stage-total-service-term-months');
+        const totalWeeksInput = totalsRow.querySelector('.proposal-stage-total-final-report-term-weeks');
+        if (totalMonthsInput) totalMonthsInput.value = termRows.length > 1 ? formatProposalDecimal(totalMonths) : '';
+        if (totalWeeksInput) totalWeeksInput.value = termRows.length > 1 ? formatProposalDecimal(totalWeeks) : '';
+      }
+
+      function syncStageContent() {
+        ensureMirroredBlocks();
+        syncStageLabels();
+        ensureStageEditorsInitialized();
+        bindSummaryCommercialSync();
+        bindTermsRows();
+        getProductRows().forEach(function (row, index) {
+          const productId = String(row.querySelector('.proposal-product-select')?.value || '').trim();
+          const serviceBlock = getServiceBlocks()[index];
+          const commercialBlock = getCommercialBlocks()[index];
+          const termsRow = getStageTermRows()[index];
+          [serviceBlock, commercialBlock].forEach(function (block) {
+            if (!block) return;
+            const typeInput = block.querySelector('[data-proposal-stage-type]');
+            const previousProductId = String(typeInput?.value || '').trim();
+            if (typeInput) typeInput.value = productId;
+            const store = attachProposalServicesStore(block);
+            if (store && productId && (productId !== previousProductId || !store.getRows().length)) {
+              store.replaceFromType({ reason: 'stage-product-change', source: 'type-change' });
+            }
+          });
+          if (termsRow) {
+            const termEntry = getProposalTypicalServiceTermEntry(serviceBlock || row);
+            const evaluationInput = termsRow.querySelector('.proposal-stage-evaluation-date');
+            const monthsInput = termsRow.querySelector('.proposal-stage-service-term-months');
+            const weeksInput = termsRow.querySelector('.proposal-stage-final-report-term-weeks');
+            const previousProductId = String(termsRow.dataset.productId || '');
+            if (evaluationInput && (!String(evaluationInput.value || '').trim() || productId !== String(termsRow.dataset.productId || ''))) {
+              setDateFieldValue(evaluationInput, getSharedEvaluationDateValue());
+            }
+            if (termEntry && monthsInput && weeksInput) {
+              if (!String(monthsInput.value || '').trim() || productId !== previousProductId) {
+                monthsInput.value = formatProposalDecimal(parseProposalDecimal(termEntry.preliminary_report_months) || 0);
+              }
+              if (!String(weeksInput.value || '').trim() || productId !== previousProductId) {
+                weeksInput.value = formatProposalDecimal(parseProposalDecimal(termEntry.final_report_weeks) || 0);
+              }
+            }
+            if (productId !== previousProductId) {
+              termsRow.dataset.forceDatesFromTerms = '1';
+            }
+            termsRow.dataset.productId = productId;
+          }
+        });
+        syncStageEvaluationDates();
+        syncStageTerms();
+        applyProposalReportTermsLockState();
+        syncSummaryCommercialBlock();
+        form.dispatchEvent(new CustomEvent('proposal-stage-products-changed'));
+      }
+
+      addBtn.addEventListener('click', function () {
+        const firstRow = getProductRows()[0];
+        const lastRow = getProductRows()[getProductRows().length - 1];
+        const clone = lastRow ? lastRow.cloneNode(true) : null;
+        if (!clone) return;
+        const firstProductId = String(
+          firstRow?.querySelector('.proposal-product-select')?.value
+          || firstRow?.dataset?.selectedProductId
+          || ''
+        ).trim();
+        const copiedState = firstProductId ? {
+          consultingType: String(
+            firstRow?.querySelector('.proposal-consulting-select')?.value
+            || firstRow?.dataset?.selectedConsultingType
+            || ''
+          ).trim(),
+          serviceCategory: String(
+            firstRow?.querySelector('.proposal-service-category-select')?.value
+            || firstRow?.dataset?.selectedServiceCategory
+            || ''
+          ).trim(),
+          serviceSubtype: String(
+            firstRow?.querySelector('.proposal-service-subtype-select')?.value
+            || firstRow?.dataset?.selectedServiceSubtype
+            || ''
+          ).trim(),
+        } : null;
+        clone.dataset.stageUid = nextStageUid();
+        clone.dataset.selectedConsultingType = copiedState?.consultingType || '';
+        clone.dataset.selectedServiceCategory = copiedState?.serviceCategory || '';
+        clone.dataset.selectedServiceSubtype = copiedState?.serviceSubtype || '';
+        clone.dataset.selectedProductId = '';
+        delete clone.dataset.eventsBound;
+        container.appendChild(clone);
+        bindProductRow(clone);
+        syncStageContent();
+      });
+
+      container.addEventListener('click', function (event) {
+        const removeBtn = event.target.closest('.proposal-product-remove');
+        if (!removeBtn) return;
+        const rows = getProductRows();
+        const row = removeBtn.closest('.proposal-product-row');
+        if (!row) return;
+        if (rows.length === 1) {
+          row.dataset.selectedConsultingType = '';
+          row.dataset.selectedServiceCategory = '';
+          row.dataset.selectedServiceSubtype = '';
+          row.dataset.selectedProductId = '';
+          delete row.dataset.eventsBound;
+          row.querySelectorAll('select').forEach(function (select) { select.value = ''; });
+          bindProductRow(row);
+        } else {
+          row.remove();
+        }
+        syncStageContent();
+      });
+
+      getProductRows().forEach(bindProductRow);
+      syncStageContent();
+
+      const api = {
+        sync: syncStageContent,
+      };
+      form.__proposalStageProductsApi = api;
+      return api;
     }
 
     function initCompositeProposalField(options) {
@@ -5565,7 +6740,7 @@
       form.addEventListener('proposal-asset-owner-changed', syncSuffixFromAssetOwner);
       form.addEventListener('proposal-customer-changed', syncSuffixFromAssetOwner);
       form.querySelector('[name="asset_owner_matches_customer"]')?.addEventListener('change', syncSuffixFromAssetOwner);
-      form.querySelector('select[name="type"]')?.addEventListener('change', function () {
+      form.addEventListener('proposal-stage-products-changed', function () {
         syncPrefixFromType(true);
       });
 
@@ -5574,6 +6749,7 @@
       syncCombinedValue();
     }
 
+    attachProposalNumberDisplay(form);
     attachGroupSelectDisplay(form);
     attachReportLanguagesDropdown(form);
     attachCountryIdentifierSync(form);
@@ -5607,18 +6783,13 @@
     [
       'registration_date',
       'asset_owner_registration_date',
-      'evaluation_date',
-      'preliminary_report_date',
-      'final_report_date',
     ].forEach(function (fieldName) {
       initProposalDateInput(form.querySelector('input[name="' + fieldName + '"]'));
     });
     const assetsApi = attachProposalAssetsTable(form);
-    attachProposalServiceSectionsTable(form);
-    attachProposalServiceTextEditor(form);
+    const stageProductsApi = attachProposalStageProducts(assetsApi);
     const legalEntitiesApi = attachProposalLegalEntitiesTable(form);
     const objectsApi = attachProposalObjectsTable(form);
-    attachProposalCommercialTable(form, assetsApi);
     attachProposalAssetsToLegalEntitiesSync(form, assetsApi, legalEntitiesApi);
     attachProposalLegalEntitiesToObjectsSync(form, legalEntitiesApi, objectsApi);
     form.querySelector('[name="advance_percent"]')?.addEventListener('input', syncFinalReportPercent);
@@ -5626,36 +6797,8 @@
     qa('.js-proposal-report-terms-lock', form).forEach(function (icon) {
       icon.addEventListener('click', function () {
         proposalReportTermsEditMode = !proposalReportTermsEditMode;
-        applyProposalReportTermsLockState();
+        stageProductsApi?.sync();
       });
-    });
-    form.querySelector('select[name="type"]')?.addEventListener('change', function () {
-      syncProposalServiceTermMonths(true);
-      syncProposalReportDates(true);
-    });
-    form.querySelector('[name="service_term_months"]')?.addEventListener('input', function () {
-      syncProposalReportDates(true);
-    });
-    form.querySelector('[name="service_term_months"]')?.addEventListener('change', function () {
-      syncProposalReportDates(true);
-    });
-    form.querySelector('[name="final_report_term_weeks"]')?.addEventListener('input', function () {
-      syncProposalReportDates(true);
-    });
-    form.querySelector('[name="final_report_term_weeks"]')?.addEventListener('change', function () {
-      syncProposalReportDates(true);
-    });
-    form.querySelector('input[name="preliminary_report_date"]')?.addEventListener('input', function () {
-      if (!proposalReportTermsEditMode) syncProposalFinalDateFromPreliminary();
-    });
-    form.querySelector('input[name="preliminary_report_date"]')?.addEventListener('change', function () {
-      if (!proposalReportTermsEditMode) syncProposalFinalDateFromPreliminary();
-    });
-    form.querySelector('input[name="final_report_date"]')?.addEventListener('input', function () {
-      if (!proposalReportTermsEditMode) syncProposalPreliminaryDateFromFinal();
-    });
-    form.querySelector('input[name="final_report_date"]')?.addEventListener('change', function () {
-      if (!proposalReportTermsEditMode) syncProposalPreliminaryDateFromFinal();
     });
     form.querySelector('[name="asset_owner_matches_customer"]')?.addEventListener('change', function () {
       syncAssetOwnerFromCustomer('customer-sync');
@@ -5683,9 +6826,6 @@
         assetsApi?.fillEmptyRowsFromDefaults();
       }
     });
-    syncProposalServiceTermMonths(false);
-    applyProposalReportTermsLockState();
-    syncProposalReportDates(false);
     ['asset_owner', 'asset_owner_registration_number', 'asset_owner_registration_date'].forEach(function (fieldName) {
       form.querySelector('[name="' + fieldName + '"]')?.addEventListener('change', function () {
         form.dispatchEvent(new CustomEvent('proposal-asset-owner-changed', { detail: { reason: 'owner-change' } }));
@@ -5700,6 +6840,8 @@
     syncFinalReportPercent();
     syncAssetOwnerFromCustomer('customer-sync');
     assetsApi?.fillEmptyRowsFromDefaults();
+      applyProposalReportTermsLockState();
+    stageProductsApi?.sync();
   }
 
   function initProposalDispatchForm() {

--- a/core/static/core/js/ui-prefs-restore.js
+++ b/core/static/core/js/ui-prefs-restore.js
@@ -80,25 +80,51 @@
     });
   }
 
-  /* ── Main tab (saved preference; URL hash takes priority) */
+  /* ── Main tab (saved preference; URL hash fallback) */
+
+  function getMainTabLinks() {
+    return Array.from(document.querySelectorAll('#sidebar a[data-bs-toggle="tab"][href^="#"]'));
+  }
+
+  function syncMainTabHash(href) {
+    if (!href || href.charAt(0) !== '#') return;
+    if (!window.history || typeof window.history.replaceState !== 'function') return;
+    var nextUrl = window.location.pathname + window.location.search + href;
+    if (window.location.hash === href) return;
+    window.history.replaceState(null, '', nextUrl);
+  }
 
   function restoreMainTab() {
-    if (window.location.hash) return;
-    var tab = P.get('main:tab', null);
-    if (!tab) return;
-    var link = document.querySelector('a[href="' + tab + '"][data-bs-toggle="tab"]');
-    if (link && window.bootstrap) {
+    if (!window.bootstrap) return;
+    var savedTab = P.get('main:tab', null);
+    var targetTab = savedTab || window.location.hash;
+    var link = targetTab
+      ? document.querySelector('#sidebar a[href="' + targetTab + '"][data-bs-toggle="tab"]')
+      : null;
+
+    if (!link) {
+      link = getMainTabLinks()[0] || null;
+    }
+
+    if (link) {
       window.bootstrap.Tab.getOrCreateInstance(link).show();
     }
   }
 
   function bindMainTabs() {
-    document.querySelectorAll('#sidebar a[data-bs-toggle="tab"]').forEach(function (el) {
-      if (el.__prefBound) return;
-      el.__prefBound = true;
-      el.addEventListener('shown.bs.tab', function () {
-        P.set('main:tab', el.getAttribute('href'));
-      });
+    if (document.__mainTabsPrefBound) return;
+    document.__mainTabsPrefBound = true;
+
+    document.addEventListener('shown.bs.tab', function (event) {
+      var el = event.target;
+      if (!el || typeof el.getAttribute !== 'function') return;
+      var href = el.getAttribute('href');
+      if (!href || href.charAt(0) !== '#') return;
+      var pane = document.getElementById(href.slice(1));
+      var mainContent = document.querySelector('main > .tab-content');
+      if (!pane || !mainContent || pane.parentElement !== mainContent) return;
+      P.set('main:tab', href);
+      syncMainTabHash(href);
     });
   }
 
@@ -116,10 +142,16 @@
     bindMainTabs();
   }
 
-  document.addEventListener('DOMContentLoaded', function () {
+  function init() {
     restoreAll();
     bindAll();
-  });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
 
   document.body.addEventListener('htmx:afterSettle', function () {
     restoreSidebar();

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -130,7 +130,7 @@
 
         <!-- Подключение статических модулей -->
         {% load static %}
-        <script defer src="{% static 'core/js/ui-prefs-restore.js' %}?v=20260420-2"></script>
+        <script defer src="{% static 'core/js/ui-prefs-restore.js' %}?v=20260423-2"></script>
         <script defer src="{% static 'core/js/selectable-tables.js' %}"></script>
         <script defer src="{% static 'core/js/policy-panels.js' %}"></script>
         <script defer src="{% static 'core/js/classifiers-panels.js' %}?v=20260422-1"></script>

--- a/core/tests.py
+++ b/core/tests.py
@@ -23,7 +23,7 @@ from core.cloud_storage import (
 from core.oidc import IMCOAuth2Validator
 from core.oidc_settings import oidc_pkce_required
 from core.models import CloudStorageSettings
-from policy_app.models import DEPARTMENT_HEAD_GROUP
+from policy_app.models import DEPARTMENT_HEAD_GROUP, EXPERT_GROUP
 from users_app.models import Employee
 
 User = get_user_model()
@@ -211,3 +211,20 @@ class HomePagePermissionsTests(TestCase):
         self.assertNotContains(response, '<span class="link-text">Логи</span>', html=False)
         self.assertNotContains(response, 'section id="templates"', html=False)
         self.assertNotContains(response, 'section id="debugger"', html=False)
+
+    def test_expert_does_not_get_classifiers_section_markup(self):
+        user = User.objects.create_user(
+            username="expert-home",
+            email="expert-home@example.com",
+            password="Secret123!",
+            is_staff=True,
+        )
+        expert_group, _ = Group.objects.get_or_create(name=EXPERT_GROUP)
+        user.groups.add(expert_group)
+        self.client.force_login(user)
+
+        response = self.client.get(reverse("home"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, '<span class="link-text">Справочники</span>', html=False)
+        self.assertNotContains(response, 'section id="classifiers"', html=False)

--- a/policy_app/forms.py
+++ b/policy_app/forms.py
@@ -38,6 +38,42 @@ def _coerce_positive_int(value):
     return parsed if parsed > 0 else None
 
 
+def _service_goal_report_product_option_label(product):
+    short_name = str(getattr(product, "short_name", "") or "").strip()
+    display_name = str(getattr(product, "display_name", "") or "").strip()
+    if short_name and display_name and display_name != short_name:
+        return f"{short_name} {display_name}"
+    return short_name or display_name
+
+
+def _policy_product_short_label(product):
+    short_name = str(getattr(product, "short_name", "") or "").strip()
+    display_name = str(getattr(product, "display_name", "") or "").strip()
+    return short_name or display_name
+
+
+class PolicyProductSelect(forms.Select):
+    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
+        option = super().create_option(name, value, label, selected, index, subindex=subindex, attrs=attrs)
+        instance = getattr(value, "instance", None)
+        if instance is not None:
+            option_attrs = option.setdefault("attrs", {})
+            option_attrs["data-short-label"] = _policy_product_short_label(instance)
+        return option
+
+
+def _configure_policy_product_field(field):
+    field.queryset = Product.objects.order_by("position", "id")
+    field.label_from_instance = _service_goal_report_product_option_label
+    widget_attrs = dict(getattr(field.widget, "attrs", {}) or {})
+    classes = [part for part in str(widget_attrs.get("class", "") or "").split() if part]
+    if "policy-product-select" not in classes:
+        classes.append("policy-product-select")
+    widget_attrs["class"] = " ".join(classes)
+    field.widget = PolicyProductSelect(attrs=widget_attrs)
+    field.widget.choices = field.choices
+
+
 class CommaDecimalField(forms.DecimalField):
     def to_python(self, value):
         if isinstance(value, str):
@@ -449,6 +485,7 @@ class TypicalSectionForm(forms.ModelForm):
 
     def __init__(self, *args, request_user=None, **kwargs):
         super().__init__(*args, **kwargs)
+        _configure_policy_product_field(self.fields["product"])
         self.fields["expertise_dir"].queryset = ExpertiseDirection.objects.order_by("position", "id")
         self.fields["expertise_dir"].label_from_instance = (
             lambda obj: f"{obj.short_name} {obj.name}"
@@ -474,6 +511,7 @@ class SectionStructureForm(forms.ModelForm):
 
     def __init__(self, *args, request_user=None, **kwargs):
         super().__init__(*args, **kwargs)
+        _configure_policy_product_field(self.fields["product"])
         self.fields["section"].label_from_instance = (
             lambda obj: f"{obj.code}: {obj.name_ru or obj.name_en}"
         )
@@ -496,6 +534,10 @@ class ServiceGoalReportForm(forms.ModelForm):
         queryset=Product.objects.all(),
         widget=forms.Select(attrs={"class": "form-select"}),
     )
+
+    def __init__(self, *args, request_user=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        _configure_policy_product_field(self.fields["product"])
 
     class Meta:
         model = ServiceGoalReport
@@ -548,7 +590,7 @@ class TypicalServiceCompositionForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["product"].label_from_instance = lambda obj: obj.short_name
+        _configure_policy_product_field(self.fields["product"])
         self.fields["section"].label_from_instance = lambda obj: obj.name_ru
 
         product_id = None
@@ -660,6 +702,10 @@ class TypicalServiceTermForm(forms.ModelForm):
                 "placeholder": "0",
             }),
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        _configure_policy_product_field(self.fields["product"])
 
 
 class ExpertiseDirectionForm(forms.ModelForm):
@@ -980,7 +1026,7 @@ class TariffForm(forms.ModelForm):
     def __init__(self, *args, request_user=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.request_user = request_user
-        self.fields["product"].label_from_instance = lambda obj: obj.short_name
+        _configure_policy_product_field(self.fields["product"])
         self.fields["section"].label_from_instance = (
             lambda obj: f"{obj.code}: {obj.name_ru or obj.name_en}"
         )

--- a/policy_app/templates/policy_app/service_goal_report_form.html
+++ b/policy_app/templates/policy_app/service_goal_report_form.html
@@ -19,6 +19,11 @@
     <div class="mb-3">
       <label class="form-label">Продукт</label>
       {{ form.product }}
+      {% if form.product.errors %}
+        <div class="invalid-feedback d-block">
+          {{ form.product.errors|join:", " }}
+        </div>
+      {% endif %}
     </div>
     <div class="mb-3">
       <label class="form-label">Цели оказания услуг</label>

--- a/policy_app/tests.py
+++ b/policy_app/tests.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from classifiers_app.models import OKVCurrency
 from experts_app.models import ExpertSpecialty
 from group_app.models import GroupMember, OrgUnit
-from policy_app.forms import ProductForm
+from policy_app.forms import ProductForm, ServiceGoalReportForm
 from policy_app.models import (
     ConsultingDirection,
     ConsultingDirectionType,
@@ -374,6 +374,15 @@ class TypicalSectionViewsTests(TestCase):
         section = TypicalSection.objects.get(code="SEC-2")
         self.assertTrue(section.exclude_from_tkp_autofill)
 
+    def test_section_form_renders_product_options_with_display_name(self):
+        response = self.client.get(reverse("section_form_create"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<select name="product"', html=False)
+        self.assertContains(response, "policy-product-select")
+        self.assertContains(response, 'data-short-label="SEC"', html=False)
+        self.assertContains(response, "SEC Sections")
+
     def test_section_csv_upload_accepts_rows_without_legacy_executor_column(self):
         csv_file = SimpleUploadedFile(
             "sections.csv",
@@ -390,6 +399,36 @@ class TypicalSectionViewsTests(TestCase):
         self.assertEqual(response.json()["created"], 1)
         self.assertEqual(response.json()["warnings"], [])
         self.assertTrue(TypicalSection.objects.filter(code="SEC-3").exists())
+
+
+class SectionStructureViewsTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="policy-structures-admin",
+            password="secret123",
+            is_staff=True,
+        )
+        self.client.force_login(self.user)
+        self.product = Product.objects.create(
+            short_name="STR",
+            name_en="Structure",
+            display_name="Structure System",
+            name_ru="Структура",
+            consulting_type="Горный",
+            service_category="Инжиниринг",
+            service_subtype="По международным стандартам",
+            position=1,
+        )
+
+    def test_structure_form_renders_product_options_with_display_name(self):
+        response = self.client.get(reverse("structure_form_create"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<select name="product"', html=False)
+        self.assertContains(response, "policy-product-select")
+        self.assertContains(response, 'data-short-label="STR"', html=False)
+        self.assertContains(response, "STR Structure System")
 
 
 class ServiceGoalReportViewsTests(TestCase):
@@ -447,6 +486,19 @@ class ServiceGoalReportViewsTests(TestCase):
         self.assertEqual(item.service_goal_genitive, "Подготовки документов")
         self.assertEqual(item.report_title, "Отчет по документам")
         self.assertEqual(item.position, 1)
+
+    def test_service_goal_report_form_renders_product_picker_with_display_name(self):
+        response = self.client.get(reverse("service_goal_report_form_create"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<select name="product"', html=False)
+        self.assertContains(response, "policy-product-select")
+        self.assertContains(response, 'data-short-label="TAX"', html=False)
+        self.assertContains(response, "TAX Tax")
+
+        form = ServiceGoalReportForm()
+        labels = [label for _, label in form.fields["product"].choices]
+        self.assertIn("TAX Tax", labels)
 
     def test_move_up_reorders_globally_across_table(self):
         other_product = Product.objects.create(
@@ -606,6 +658,15 @@ class TypicalServiceCompositionViewsTests(TestCase):
         self.assertEqual(item.service_composition_editor_state, editor_state)
         self.assertEqual(item.position, 1)
 
+    def test_typical_service_composition_form_renders_product_options_with_display_name(self):
+        response = self.client.get(reverse("typical_service_composition_form_create"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<select name="product"', html=False)
+        self.assertContains(response, "policy-product-select")
+        self.assertContains(response, 'data-short-label="TAX2"', html=False)
+        self.assertContains(response, "TAX2 Tax 2")
+
     def test_create_typical_service_composition_rejects_section_from_other_product(self):
         response = self.client.post(
             reverse("typical_service_composition_form_create"),
@@ -714,6 +775,15 @@ class TypicalServiceTermViewsTests(TestCase):
         self.assertEqual(item.preliminary_report_months, Decimal("2.5"))
         self.assertEqual(item.final_report_weeks, 4)
         self.assertEqual(item.position, 1)
+
+    def test_typical_service_term_form_renders_product_options_with_display_name(self):
+        response = self.client.get(reverse("typical_service_term_form_create"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<select name="product"', html=False)
+        self.assertContains(response, "policy-product-select")
+        self.assertContains(response, 'data-short-label="TERM"', html=False)
+        self.assertContains(response, "TERM Terms")
 
     def test_create_typical_service_term_accepts_comma_decimal(self):
         response = self.client.post(
@@ -962,6 +1032,15 @@ class TariffViewsTests(TestCase):
         tariff = Tariff.objects.get()
         self.assertEqual(tariff.service_hours, 12)
         self.assertEqual(tariff.service_days_tkp, 7)
+
+    def test_tariff_form_renders_product_options_with_display_name(self):
+        response = self.client.get(reverse("tariff_form_create"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<select name="product"', html=False)
+        self.assertContains(response, "policy-product-select")
+        self.assertContains(response, 'data-short-label="TAR"', html=False)
+        self.assertContains(response, "TAR Tariff product")
 
     def test_move_up_normalizes_positions_before_reorder(self):
         first = Tariff.objects.create(

--- a/projects_app/migrations/0053_remove_project_registration_identity_unique.py
+++ b/projects_app/migrations/0053_remove_project_registration_identity_unique.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("projects_app", "0052_projectregistrationproduct_and_ranked_products"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="projectregistration",
+            name="project_registration_identity_unique",
+        ),
+    ]

--- a/projects_app/models.py
+++ b/projects_app/models.py
@@ -135,12 +135,6 @@ class ProjectRegistration(models.Model):
         ordering = ["position", "id"]
         verbose_name = "Регистрация проекта"
         verbose_name_plural = "Регистрация проекта"
-        constraints = [
-            models.UniqueConstraint(
-                fields=("number", "group_member", "agreement_type", "agreement_number"),
-                name="project_registration_identity_unique",
-            ),
-        ]
 
     def __str__(self):
         base = f"{self.formatted_number}{self.group_alpha2}"

--- a/projects_app/tests.py
+++ b/projects_app/tests.py
@@ -201,6 +201,40 @@ class ProjectRegistrationFormTests(TestCase):
         self.assertEqual(registration.short_uid, "000100RU")
         self.assertTrue(registration.display_identifier.startswith("0001 "))
 
+    def test_form_allows_duplicate_project_identity_values_and_keeps_project_id_unique(self):
+        first = ProjectRegistration.objects.create(
+            number=4444,
+            group_member=self.group_member,
+            type=self.product,
+            agreement_type=ProjectRegistration.AgreementType.MAIN,
+            name="Проект Дубль 1",
+            status="Не начат",
+        )
+
+        form = ProjectRegistrationForm(
+            data={
+                "number": 4444,
+                "group_member": self.group_member.pk,
+                "agreement_type": "MAIN",
+                "type_id": [self.product.pk],
+                "name": "Проект Дубль 2",
+                "status": "Не начат",
+                "deadline": "2026-01-10",
+                "year": 2026,
+            }
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        duplicate = form.save()
+        duplicate.refresh_from_db()
+
+        self.assertEqual(first.number, duplicate.number)
+        self.assertEqual(first.group_member_id, duplicate.group_member_id)
+        self.assertEqual(first.agreement_type, duplicate.agreement_type)
+        self.assertEqual(first.agreement_number, duplicate.agreement_number)
+        self.assertNotEqual(first.pk, duplicate.pk)
+        self.assertNotEqual(first.short_uid, duplicate.short_uid)
+
     def test_cleaned_type_ids_keep_ranked_order_without_duplicates(self):
         form = ProjectRegistrationForm()
         bound_form = ProjectRegistrationForm(
@@ -378,6 +412,42 @@ class ProjectRegistrationRegistrySyncTests(TestCase):
         self.assertEqual(project.type_short_display, "DD")
         self.assertEqual(
             list(project.product_links.order_by("rank").values_list("product_id", flat=True)),
+            [self.product.pk],
+        )
+
+    def test_manual_registration_save_allows_duplicate_identity_values(self):
+        first = ProjectRegistration.objects.create(
+            number=4444,
+            group_member=self.group_member,
+            agreement_type=ProjectRegistration.AgreementType.MAIN,
+            agreement_number="IMCM/4444",
+            type=self.product,
+            name="Проект Альфа",
+            status="Не начат",
+            year=2026,
+            position=1,
+        )
+
+        response = self._post_registration()
+
+        self.assertEqual(response.status_code, 200)
+        duplicates = list(
+            ProjectRegistration.objects
+            .filter(
+                number=4444,
+                group_member=self.group_member,
+                agreement_type=ProjectRegistration.AgreementType.MAIN,
+                agreement_number="IMCM/4444",
+                type=self.product,
+            )
+            .order_by("id")
+        )
+        self.assertEqual(len(duplicates), 2)
+        self.assertNotEqual(duplicates[0].pk, duplicates[1].pk)
+        self.assertNotEqual(duplicates[0].short_uid, duplicates[1].short_uid)
+        self.assertEqual(first.short_uid, duplicates[0].short_uid)
+        self.assertEqual(
+            list(duplicates[1].product_links.order_by("rank").values_list("product_id", flat=True)),
             [self.product.pk],
         )
 

--- a/proposals_app/forms.py
+++ b/proposals_app/forms.py
@@ -23,6 +23,7 @@ from .models import (
     ProposalLegalEntity,
     ProposalObject,
     ProposalRegistration,
+    ProposalRegistrationProduct,
     ProposalTemplate,
     ProposalVariable,
 )
@@ -283,13 +284,39 @@ def _default_proposal_evaluation_date(today=None):
     return date(today.year, 6, 1)
 
 
+def _proposal_request_list(data, key):
+    if hasattr(data, "getlist"):
+        return [str(value or "") for value in data.getlist(key)]
+    value = data.get(key, [])
+    if isinstance(value, (list, tuple)):
+        return [str(item or "") for item in value]
+    return [str(value or "")]
+
+
+def _format_stage_date(value):
+    if not value:
+        return ""
+    if isinstance(value, str):
+        return value
+    return value.strftime("%d.%m.%Y")
+
+
 class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
     number = forms.IntegerField(
         label="Номер",
         required=True,
-        min_value=3333,
+        min_value=0,
         max_value=9999,
-        widget=forms.NumberInput(attrs={"min": 3333, "max": 9999, "placeholder": "3333-9999"}),
+        widget=forms.NumberInput(
+            attrs={
+                "id": "proposal-number-input",
+                "min": 0,
+                "max": 9999,
+                "step": 1,
+                "placeholder": "0001",
+                "autocomplete": "off",
+            }
+        ),
     )
     group_member = forms.ModelChoiceField(
         label="Группа",
@@ -525,6 +552,7 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
         min_value=0,
         widget=forms.NumberInput(attrs={"min": 0, "step": 1}),
     )
+    type_ids = forms.CharField(required=False, widget=forms.HiddenInput())
     assets_payload = forms.CharField(
         required=False,
         widget=forms.HiddenInput(attrs={"id": "proposal-assets-payload"}),
@@ -544,6 +572,14 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
     commercial_totals_payload = forms.CharField(
         required=False,
         widget=forms.HiddenInput(attrs={"id": "proposal-commercial-totals-payload"}),
+    )
+    summary_commercial_offer_payload = forms.CharField(
+        required=False,
+        widget=forms.HiddenInput(attrs={"id": "proposal-summary-commercial-offer-payload"}),
+    )
+    summary_commercial_totals_payload = forms.CharField(
+        required=False,
+        widget=forms.HiddenInput(attrs={"id": "proposal-summary-commercial-totals-payload"}),
     )
     service_sections_payload = forms.CharField(
         required=False,
@@ -635,9 +671,22 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
         if self.data:
             data = self.data.copy()
             for field_name in self._decimal_text_fields:
-                value = data.get(field_name, "")
-                if value:
-                    data[field_name] = str(value).replace("\u00a0", "").replace(" ", "").replace(",", ".")
+                if hasattr(data, "getlist"):
+                    values = data.getlist(field_name)
+                    if values:
+                        data.setlist(
+                            field_name,
+                            [str(value or "").replace("\u00a0", "").replace(" ", "").replace(",", ".") for value in values],
+                        )
+                else:
+                    value = data.get(field_name, "")
+                    if isinstance(value, (list, tuple)):
+                        data[field_name] = [
+                            str(item or "").replace("\u00a0", "").replace(" ", "").replace(",", ".")
+                            for item in value
+                        ]
+                    elif value:
+                        data[field_name] = str(value).replace("\u00a0", "").replace(" ", "").replace(",", ".")
             self.data = data
         for field in self.fields.values():
             _apply_russian_error_messages(field)
@@ -650,7 +699,7 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
             self.fields["evaluation_date"].initial = _default_proposal_evaluation_date()
         self.fields["type"].queryset = Product.objects.order_by("position", "id")
         self.fields["type"].label_from_instance = lambda obj: obj.short_name
-        self.fields["type"].required = True
+        self.fields["type"].required = False
         self.fields["type"].empty_label = "— Не выбрано —"
         self.fields["name"].required = True
         self.fields["year"].required = not bool(self.instance and self.instance.pk)
@@ -854,6 +903,29 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
                 totals_payload,
                 ensure_ascii=False,
             )
+        if self.instance and self.instance.pk and "summary_commercial_offer_payload" not in self.data:
+            self.fields["summary_commercial_offer_payload"].initial = json.dumps(
+                self._serialize_instance_commercial_rows(),
+                ensure_ascii=False,
+            )
+        elif "summary_commercial_offer_payload" not in self.data:
+            self.fields["summary_commercial_offer_payload"].initial = "[]"
+        if self.instance and self.instance.pk and "summary_commercial_totals_payload" not in self.data:
+            summary_totals_payload = {
+                "discount_percent": "5",
+                "rub_total_service_text": "Курс евро Банка России на текущую дату:",
+                "discounted_total_service_text": "Размер скидки:",
+                **dict(self.instance.commercial_totals_json or {}),
+            }
+            self.fields["summary_commercial_totals_payload"].initial = json.dumps(
+                self._merge_stage_commercial_totals_payload(summary_totals_payload),
+                ensure_ascii=False,
+            )
+        elif "summary_commercial_totals_payload" not in self.data:
+            self.fields["summary_commercial_totals_payload"].initial = json.dumps(
+                self._merge_stage_commercial_totals_payload({}),
+                ensure_ascii=False,
+            )
         if self.instance and self.instance.pk and "service_sections_payload" not in self.data:
             self.fields["service_sections_payload"].initial = json.dumps(
                 [
@@ -925,6 +997,304 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
                 "final_report_percent",
                 self.instance.final_report_percent,
             )
+        self.stage_rows = self._build_stage_rows()
+        self.summary_commercial_row = self._build_summary_commercial_row()
+
+    def _default_stage_commercial_totals_payload(self):
+        payload = {
+            "discount_percent": "5",
+            "rub_total_service_text": get_cbr_eur_rate_text(),
+            "discounted_total_service_text": "Размер скидки:",
+            "travel_expenses_mode": PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL,
+        }
+        eur_rate = get_cbr_eur_rate_for_today()
+        if eur_rate is not None:
+            payload["exchange_rate"] = format(eur_rate.quantize(Decimal("0.0001")), "f")
+        return payload
+
+    def _merge_stage_commercial_totals_payload(self, payload):
+        return {
+            **self._default_stage_commercial_totals_payload(),
+            **(payload or {}),
+        }
+
+    def _serialize_instance_commercial_rows(self):
+        if not self.instance or not self.instance.pk:
+            return []
+        return [
+            {
+                "specialist": item.specialist or "",
+                "job_title": item.job_title or "",
+                "professional_status": item.professional_status or "",
+                "service_name": item.service_name or "",
+                "rate_eur_per_day": str(item.rate_eur_per_day or ""),
+                "asset_day_counts": list(item.asset_day_counts or []),
+                "total_eur_without_vat": str(item.total_eur_without_vat or ""),
+            }
+            for item in self.instance.commercial_offers.all()
+        ]
+
+    def _build_summary_commercial_row(self):
+        offer_payload = ""
+        totals_payload = ""
+        if self.is_bound:
+            offer_payload = str(self.data.get("summary_commercial_offer_payload") or "").strip()
+            totals_payload = str(self.data.get("summary_commercial_totals_payload") or "").strip()
+        if not offer_payload:
+            offer_payload = str(self.fields["summary_commercial_offer_payload"].initial or "[]")
+        if not totals_payload:
+            totals_payload = str(
+                self.fields["summary_commercial_totals_payload"].initial
+                or json.dumps(self._merge_stage_commercial_totals_payload({}), ensure_ascii=False)
+            )
+        return {
+            "commercial_offer_payload": offer_payload or "[]",
+            "commercial_totals_payload": totals_payload,
+        }
+
+    def _empty_stage_row(self, rank=1):
+        return {
+            "rank": rank,
+            "consulting_type": "",
+            "service_category": "",
+            "service_subtype": "",
+            "product_id": "",
+            "product_short_label": "",
+            "service_sections_payload": "[]",
+            "service_sections_editor_state": "[]",
+            "service_customer_tz_editor_state": "",
+            "service_composition_customer_tz": "",
+            "service_composition_mode": "sections",
+            "service_composition": "",
+            "commercial_offer_payload": "[]",
+            "commercial_totals_payload": json.dumps(
+                self._merge_stage_commercial_totals_payload({}),
+                ensure_ascii=False,
+            ),
+            "evaluation_date": _format_stage_date(self.fields["evaluation_date"].initial),
+            "service_term_months": "",
+            "preliminary_report_date": "",
+            "final_report_term_weeks": "",
+            "final_report_date": "",
+        }
+
+    def _build_stage_rows_from_bound_data(self):
+        field_names = (
+            "type_consulting",
+            "type_service_category",
+            "type_service_subtype",
+            "type",
+            "service_sections_payload",
+            "service_sections_editor_state",
+            "service_customer_tz_editor_state",
+            "service_composition_customer_tz",
+            "service_composition_mode",
+            "service_composition",
+            "commercial_offer_payload",
+            "commercial_totals_payload",
+            "evaluation_date",
+            "service_term_months",
+            "preliminary_report_date",
+            "final_report_term_weeks",
+            "final_report_date",
+        )
+        rows_map = {name: _proposal_request_list(self.data, name) for name in field_names}
+        product_ids = {
+            int(raw)
+            for raw in rows_map["type"]
+            if str(raw or "").strip().isdigit()
+        }
+        product_map = {
+            str(product.pk): product
+            for product in Product.objects.filter(pk__in=product_ids)
+        }
+        row_count = max([len(values) for values in rows_map.values()] or [0], default=0)
+        row_count = max(row_count, 1)
+        rows = []
+        for index in range(row_count):
+            product_id = (rows_map["type"][index] if index < len(rows_map["type"]) else "").strip()
+            product = product_map.get(product_id)
+            row = {
+                "rank": len(rows) + 1,
+                "consulting_type": (rows_map["type_consulting"][index] if index < len(rows_map["type_consulting"]) else "").strip(),
+                "service_category": (
+                    rows_map["type_service_category"][index] if index < len(rows_map["type_service_category"]) else ""
+                ).strip(),
+                "service_subtype": (
+                    rows_map["type_service_subtype"][index] if index < len(rows_map["type_service_subtype"]) else ""
+                ).strip(),
+                "product_id": product_id,
+                "product_short_label": (getattr(product, "short_name", "") or "").strip(),
+                "service_sections_payload": (
+                    rows_map["service_sections_payload"][index] if index < len(rows_map["service_sections_payload"]) else "[]"
+                ),
+                "service_sections_editor_state": (
+                    rows_map["service_sections_editor_state"][index]
+                    if index < len(rows_map["service_sections_editor_state"])
+                    else "[]"
+                ),
+                "service_customer_tz_editor_state": (
+                    rows_map["service_customer_tz_editor_state"][index]
+                    if index < len(rows_map["service_customer_tz_editor_state"])
+                    else ""
+                ),
+                "service_composition_customer_tz": (
+                    rows_map["service_composition_customer_tz"][index]
+                    if index < len(rows_map["service_composition_customer_tz"])
+                    else ""
+                ),
+                "service_composition_mode": (
+                    rows_map["service_composition_mode"][index]
+                    if index < len(rows_map["service_composition_mode"])
+                    else "sections"
+                ).strip()
+                or "sections",
+                "service_composition": (
+                    rows_map["service_composition"][index] if index < len(rows_map["service_composition"]) else ""
+                ),
+                "commercial_offer_payload": (
+                    rows_map["commercial_offer_payload"][index]
+                    if index < len(rows_map["commercial_offer_payload"])
+                    else "[]"
+                ),
+                "commercial_totals_payload": (
+                    rows_map["commercial_totals_payload"][index]
+                    if index < len(rows_map["commercial_totals_payload"])
+                    else json.dumps(self._merge_stage_commercial_totals_payload({}), ensure_ascii=False)
+                ),
+                "evaluation_date": (
+                    rows_map["evaluation_date"][index] if index < len(rows_map["evaluation_date"]) else ""
+                ).strip(),
+                "service_term_months": (
+                    rows_map["service_term_months"][index] if index < len(rows_map["service_term_months"]) else ""
+                ).strip(),
+                "preliminary_report_date": (
+                    rows_map["preliminary_report_date"][index]
+                    if index < len(rows_map["preliminary_report_date"])
+                    else ""
+                ).strip(),
+                "final_report_term_weeks": (
+                    rows_map["final_report_term_weeks"][index]
+                    if index < len(rows_map["final_report_term_weeks"])
+                    else ""
+                ).strip(),
+                "final_report_date": (
+                    rows_map["final_report_date"][index] if index < len(rows_map["final_report_date"]) else ""
+                ).strip(),
+            }
+            has_data = any(
+                row[key]
+                for key in (
+                    "consulting_type",
+                    "service_category",
+                    "service_subtype",
+                    "product_id",
+                    "service_composition",
+                    "service_composition_customer_tz",
+                    "evaluation_date",
+                    "service_term_months",
+                    "preliminary_report_date",
+                    "final_report_term_weeks",
+                    "final_report_date",
+                )
+            )
+            if has_data or row_count == 1:
+                rows.append(row)
+        return rows or [self._empty_stage_row()]
+
+    def _build_stage_rows_from_instance(self):
+        instance = self.instance
+        if not instance or not instance.pk:
+            return [self._empty_stage_row()]
+
+        ordered_products = list(instance.ordered_products())
+        product_map = {str(product.pk): product for product in ordered_products if getattr(product, "pk", None)}
+        stored_stages = list(instance.stage_payloads_json or [])
+        if stored_stages:
+            normalized_rows = []
+            for index, payload in enumerate(stored_stages, start=1):
+                payload = payload if isinstance(payload, dict) else {}
+                product_id = str(payload.get("product_id") or "")
+                product = product_map.get(product_id)
+                normalized_rows.append(
+                    {
+                        "rank": index,
+                        "consulting_type": (getattr(product, "consulting_type_display", "") or "").strip(),
+                        "service_category": (getattr(product, "service_category_display", "") or "").strip(),
+                        "service_subtype": (getattr(product, "service_subtype_display", "") or "").strip(),
+                        "product_id": product_id,
+                        "product_short_label": (getattr(product, "short_name", "") or "").strip(),
+                        "service_sections_payload": json.dumps(payload.get("service_sections_json") or [], ensure_ascii=False),
+                        "service_sections_editor_state": json.dumps(
+                            payload.get("service_sections_editor_state") or [],
+                            ensure_ascii=False,
+                        ),
+                        "service_customer_tz_editor_state": json.dumps(
+                            payload.get("service_customer_tz_editor_state") or {},
+                            ensure_ascii=False,
+                        )
+                        if payload.get("service_customer_tz_editor_state")
+                        else "",
+                        "service_composition_customer_tz": str(payload.get("service_composition_customer_tz") or ""),
+                        "service_composition_mode": str(payload.get("service_composition_mode") or "sections") or "sections",
+                        "service_composition": str(payload.get("service_composition") or ""),
+                        "commercial_offer_payload": json.dumps(
+                            payload.get("commercial_offer_payload") or [],
+                            ensure_ascii=False,
+                        ),
+                        "commercial_totals_payload": json.dumps(
+                            self._merge_stage_commercial_totals_payload(payload.get("commercial_totals_json") or {}),
+                            ensure_ascii=False,
+                        ),
+                        "evaluation_date": str(payload.get("evaluation_date") or ""),
+                        "service_term_months": str(payload.get("service_term_months") or ""),
+                        "preliminary_report_date": str(payload.get("preliminary_report_date") or ""),
+                        "final_report_term_weeks": str(payload.get("final_report_term_weeks") or ""),
+                        "final_report_date": str(payload.get("final_report_date") or ""),
+                    }
+                )
+            if normalized_rows:
+                return normalized_rows
+
+        product = ordered_products[-1] if ordered_products else getattr(instance, "type", None)
+        commercial_rows = self._serialize_instance_commercial_rows()
+        return [
+            {
+                "rank": 1,
+                "consulting_type": (getattr(product, "consulting_type_display", "") or "").strip(),
+                "service_category": (getattr(product, "service_category_display", "") or "").strip(),
+                "service_subtype": (getattr(product, "service_subtype_display", "") or "").strip(),
+                "product_id": str(getattr(product, "pk", "") or ""),
+                "product_short_label": (getattr(product, "short_name", "") or "").strip(),
+                "service_sections_payload": json.dumps(instance.service_sections_json or [], ensure_ascii=False),
+                "service_sections_editor_state": json.dumps(instance.service_sections_editor_state or [], ensure_ascii=False),
+                "service_customer_tz_editor_state": json.dumps(
+                    instance.service_customer_tz_editor_state or {},
+                    ensure_ascii=False,
+                )
+                if instance.service_customer_tz_editor_state
+                else "",
+                "service_composition_customer_tz": instance.service_composition_customer_tz or "",
+                "service_composition_mode": instance.service_composition_mode or "sections",
+                "service_composition": instance.service_composition or "",
+                "commercial_offer_payload": json.dumps(commercial_rows, ensure_ascii=False),
+                "commercial_totals_payload": json.dumps(
+                    self._merge_stage_commercial_totals_payload(instance.commercial_totals_json or {}),
+                    ensure_ascii=False,
+                ),
+                "evaluation_date": _format_stage_date(instance.evaluation_date),
+                "service_term_months": str(instance.service_term_months or ""),
+                "preliminary_report_date": _format_stage_date(instance.preliminary_report_date),
+                "final_report_term_weeks": str(instance.final_report_term_weeks or ""),
+                "final_report_date": _format_stage_date(instance.final_report_date),
+            }
+        ]
+
+    def _build_stage_rows(self):
+        if self.is_bound:
+            return self._build_stage_rows_from_bound_data()
+        rows = self._build_stage_rows_from_instance()
+        return rows or [self._empty_stage_row()]
 
     def clean_group_member(self):
         member = self.cleaned_data.get("group_member")
@@ -952,6 +1322,591 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
         ) or Decimal("0")
         result = Decimal("100") - advance - preliminary
         return result.quantize(Decimal("0.01"))
+
+    def _parse_stage_date(self, value, *, row_index, field_label):
+        raw = str(value or "").strip()
+        if not raw:
+            return None
+        parsed = _parse_proposal_form_date(raw)
+        if parsed is None:
+            raise forms.ValidationError(f"Этап {row_index}: поле «{field_label}» заполнено некорректно.")
+        return parsed
+
+    def _parse_stage_decimal(self, value, *, row_index, field_label):
+        raw = str(value or "").strip()
+        if not raw:
+            return None
+        return self._parse_payload_decimal(raw, f"Этап {row_index}: поле «{field_label}» заполнено некорректно.")
+
+    def _load_stage_json(self, raw, *, row_index, field_label, expected_type, default):
+        raw = str(raw or "").strip()
+        if not raw:
+            return default
+        try:
+            value = json.loads(raw)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            raise forms.ValidationError(f"Этап {row_index}: поле «{field_label}» передано в некорректном формате.")
+        if not isinstance(value, expected_type):
+            raise forms.ValidationError(f"Этап {row_index}: поле «{field_label}» передано в некорректном формате.")
+        return value
+
+    def _normalize_stage_service_sections(self, raw, *, row_index, product=None):
+        items = self._load_stage_json(
+            raw,
+            row_index=row_index,
+            field_label="Состав услуг / техническое задание",
+            expected_type=list,
+            default=[],
+        )
+        sections_by_name = {}
+        if product is not None:
+            for section in TypicalSection.objects.filter(product=product).order_by("position", "id"):
+                name_ru = (section.name_ru or "").strip()
+                if name_ru and name_ru not in sections_by_name:
+                    sections_by_name[name_ru] = (section.code or "").strip()
+        normalized = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            service_name = str(item.get("service_name") or "").strip()
+            code = str(item.get("code") or "").strip()
+            if not service_name and not code:
+                continue
+            normalized.append(
+                {
+                    "service_name": service_name,
+                    "code": sections_by_name.get(service_name, "") or code,
+                }
+            )
+        return normalized
+
+    def _normalize_stage_editor_state(self, raw, *, row_index):
+        items = self._load_stage_json(
+            raw,
+            row_index=row_index,
+            field_label="Состояние редактора состава услуг",
+            expected_type=list,
+            default=[],
+        )
+        normalized = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            normalized.append(
+                {
+                    "code": str(item.get("code") or "").strip(),
+                    "service_name": str(item.get("service_name") or "").strip(),
+                    "html": str(item.get("html") or "").strip(),
+                    "plain_text": str(item.get("plain_text") or "").strip(),
+                }
+            )
+        return normalized
+
+    def _normalize_stage_customer_tz_state(self, raw, *, row_index):
+        value = self._load_stage_json(
+            raw,
+            row_index=row_index,
+            field_label="Состояние редактора ТЗ Заказчика",
+            expected_type=dict,
+            default={},
+        )
+        return {
+            "html": str(value.get("html") or "").strip(),
+            "plain_text": str(value.get("plain_text") or "").strip(),
+        }
+
+    def _load_summary_json(self, raw, *, field_label, expected_type, default):
+        raw = str(raw or "").strip()
+        if not raw:
+            return default
+        try:
+            value = json.loads(raw)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            raise forms.ValidationError(f"Сводный блок: поле «{field_label}» передано в некорректном формате.")
+        if not isinstance(value, expected_type):
+            raise forms.ValidationError(f"Сводный блок: поле «{field_label}» передано в некорректном формате.")
+        return value
+
+    def _normalize_stage_commercial_rows(self, raw, *, row_index, totals_raw=""):
+        items = self._load_stage_json(
+            raw,
+            row_index=row_index,
+            field_label="Коммерческое предложение",
+            expected_type=list,
+            default=[],
+        )
+        travel_expenses_mode = self._normalize_stage_commercial_totals(
+            totals_raw,
+            row_index=row_index,
+        ).get("travel_expenses_mode")
+        normalized = []
+        for index, item in enumerate(items, start=1):
+            if not isinstance(item, dict):
+                continue
+            specialist = str(item.get("specialist") or "").strip()
+            job_title = str(item.get("job_title") or "").strip()
+            professional_status = str(item.get("professional_status") or "").strip()
+            service_name = str(item.get("service_name") or "").strip()
+            rate_raw = str(item.get("rate_eur_per_day") or "").strip()
+            total_raw = str(item.get("total_eur_without_vat") or "").strip()
+            asset_day_counts = item.get("asset_day_counts") or []
+            if not isinstance(asset_day_counts, list):
+                asset_day_counts = []
+            is_travel_expenses_row = is_proposal_travel_expenses_name(service_name)
+            cleaned_day_counts = []
+            if is_travel_expenses_row and travel_expenses_mode == PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION:
+                for day_idx, raw_value in enumerate(asset_day_counts, start=1):
+                    value = str(raw_value or "").strip()
+                    if not value:
+                        cleaned_day_counts.append("")
+                        continue
+                    parsed_amount = self._parse_payload_decimal(
+                        value,
+                        f"Этап {row_index}: значение по активу #{day_idx} заполнено некорректно.",
+                    )
+                    if parsed_amount is not None and parsed_amount < 0:
+                        raise forms.ValidationError(
+                            f"Этап {row_index}: значение по активу #{day_idx} не может быть отрицательным."
+                        )
+                    cleaned_day_counts.append(self._serialize_payload_decimal(parsed_amount))
+            else:
+                for day_idx, raw_value in enumerate(asset_day_counts, start=1):
+                    value = str(raw_value or "").strip()
+                    if not value:
+                        cleaned_day_counts.append("")
+                        continue
+                    try:
+                        parsed_int = int(value)
+                    except (TypeError, ValueError):
+                        raise forms.ValidationError(
+                            f"Этап {row_index}: значение дня #{day_idx} заполнено некорректно."
+                        )
+                    if parsed_int < 0:
+                        raise forms.ValidationError(
+                            f"Этап {row_index}: значение дня #{day_idx} не может быть отрицательным."
+                        )
+                    cleaned_day_counts.append(parsed_int)
+            row_has_data = any(
+                [
+                    specialist,
+                    job_title,
+                    professional_status,
+                    service_name,
+                    rate_raw,
+                    total_raw,
+                    any(value != "" for value in cleaned_day_counts),
+                ]
+            )
+            if not row_has_data:
+                continue
+            rate_value = self._parse_payload_decimal(
+                rate_raw,
+                f"Этап {row_index}: поле «Ставка, евро / день» заполнено некорректно.",
+            )
+            total_value = self._parse_payload_decimal(
+                total_raw,
+                f"Этап {row_index}: поле «Итого, евро без НДС» заполнено некорректно.",
+            )
+            if is_travel_expenses_row:
+                rate_value = None
+                if travel_expenses_mode == PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION:
+                    total_value = sum(
+                        (
+                            Decimal(str(value))
+                            for value in cleaned_day_counts
+                            if value not in (None, "")
+                        ),
+                        Decimal("0"),
+                    )
+                else:
+                    cleaned_day_counts = ["" for _ in cleaned_day_counts]
+            normalized.append(
+                {
+                    "position": index,
+                    "specialist": specialist,
+                    "job_title": job_title,
+                    "professional_status": professional_status,
+                    "service_name": service_name,
+                    "rate_eur_per_day": rate_value,
+                    "asset_day_counts": cleaned_day_counts,
+                    "total_eur_without_vat": total_value,
+                }
+            )
+        return normalized
+
+    def _normalize_stage_commercial_totals(self, raw, *, row_index):
+        value = self._load_stage_json(
+            raw,
+            row_index=row_index,
+            field_label="Итоги коммерческого предложения",
+            expected_type=dict,
+            default={},
+        )
+        return self._merge_stage_commercial_totals_payload(
+            {
+                "exchange_rate": str(value.get("exchange_rate") or "").strip(),
+                "discount_percent": str(value.get("discount_percent") or "").strip(),
+                "contract_total": str(value.get("contract_total") or "").strip(),
+                "contract_total_auto": str(value.get("contract_total_auto") or "").strip(),
+                "rub_total_service_text": str(value.get("rub_total_service_text") or "").strip(),
+                "discounted_total_service_text": str(value.get("discounted_total_service_text") or "").strip(),
+                "travel_expenses_mode": str(value.get("travel_expenses_mode") or "").strip()
+                or PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL,
+            }
+        )
+
+    def _normalize_summary_commercial_rows(self, raw, *, totals_raw=""):
+        items = self._load_summary_json(
+            raw,
+            field_label="Коммерческое предложение",
+            expected_type=list,
+            default=[],
+        )
+        travel_expenses_mode = self._normalize_summary_commercial_totals(
+            totals_raw,
+        ).get("travel_expenses_mode")
+        normalized = []
+        for index, item in enumerate(items, start=1):
+            if not isinstance(item, dict):
+                continue
+            specialist = str(item.get("specialist") or "").strip()
+            job_title = str(item.get("job_title") or "").strip()
+            professional_status = str(item.get("professional_status") or "").strip()
+            service_name = str(item.get("service_name") or "").strip()
+            rate_raw = str(item.get("rate_eur_per_day") or "").strip()
+            total_raw = str(item.get("total_eur_without_vat") or "").strip()
+            asset_day_counts = item.get("asset_day_counts") or []
+            if not isinstance(asset_day_counts, list):
+                asset_day_counts = []
+            is_travel_expenses_row = is_proposal_travel_expenses_name(service_name)
+            cleaned_day_counts = []
+            if is_travel_expenses_row and travel_expenses_mode == PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION:
+                for day_idx, raw_value in enumerate(asset_day_counts, start=1):
+                    value = str(raw_value or "").strip()
+                    if not value:
+                        cleaned_day_counts.append("")
+                        continue
+                    parsed_amount = self._parse_payload_decimal(
+                        value,
+                        f"Сводный блок: значение по подстолбцу #{day_idx} заполнено некорректно.",
+                    )
+                    if parsed_amount is not None and parsed_amount < 0:
+                        raise forms.ValidationError(
+                            f"Сводный блок: значение по подстолбцу #{day_idx} не может быть отрицательным."
+                        )
+                    cleaned_day_counts.append(self._serialize_payload_decimal(parsed_amount))
+            else:
+                for day_idx, raw_value in enumerate(asset_day_counts, start=1):
+                    value = str(raw_value or "").strip()
+                    if not value:
+                        cleaned_day_counts.append("")
+                        continue
+                    try:
+                        parsed_int = int(value)
+                    except (TypeError, ValueError):
+                        raise forms.ValidationError(
+                            f"Сводный блок: значение дня #{day_idx} заполнено некорректно."
+                        )
+                    if parsed_int < 0:
+                        raise forms.ValidationError(
+                            f"Сводный блок: значение дня #{day_idx} не может быть отрицательным."
+                        )
+                    cleaned_day_counts.append(parsed_int)
+            row_has_data = any(
+                [
+                    specialist,
+                    job_title,
+                    professional_status,
+                    service_name,
+                    rate_raw,
+                    total_raw,
+                    any(value != "" for value in cleaned_day_counts),
+                ]
+            )
+            if not row_has_data:
+                continue
+            rate_value = self._parse_payload_decimal(
+                rate_raw,
+                "Сводный блок: поле «Ставка, евро / день» заполнено некорректно.",
+            )
+            total_value = self._parse_payload_decimal(
+                total_raw,
+                "Сводный блок: поле «Итого, евро без НДС» заполнено некорректно.",
+            )
+            if is_travel_expenses_row:
+                rate_value = None
+                if travel_expenses_mode == PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION:
+                    total_value = sum(
+                        (
+                            Decimal(str(value))
+                            for value in cleaned_day_counts
+                            if value not in (None, "")
+                        ),
+                        Decimal("0"),
+                    )
+                else:
+                    cleaned_day_counts = ["" for _ in cleaned_day_counts]
+            normalized.append(
+                {
+                    "position": index,
+                    "specialist": specialist,
+                    "job_title": job_title,
+                    "professional_status": professional_status,
+                    "service_name": service_name,
+                    "rate_eur_per_day": rate_value,
+                    "asset_day_counts": cleaned_day_counts,
+                    "total_eur_without_vat": total_value,
+                }
+            )
+        return normalized
+
+    def _normalize_summary_commercial_totals(self, raw):
+        value = self._load_summary_json(
+            raw,
+            field_label="Итоги коммерческого предложения",
+            expected_type=dict,
+            default={},
+        )
+        return self._merge_stage_commercial_totals_payload(
+            {
+                "exchange_rate": str(value.get("exchange_rate") or "").strip(),
+                "discount_percent": str(value.get("discount_percent") or "").strip(),
+                "contract_total": str(value.get("contract_total") or "").strip(),
+                "contract_total_auto": str(value.get("contract_total_auto") or "").strip(),
+                "rub_total_service_text": str(value.get("rub_total_service_text") or "").strip(),
+                "discounted_total_service_text": str(value.get("discounted_total_service_text") or "").strip(),
+                "travel_expenses_mode": str(value.get("travel_expenses_mode") or "").strip()
+                or PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL,
+            }
+        )
+
+    def _build_summary_commercial_fallback(self, stage_payloads):
+        asset_count = max(
+            [len(item.get("asset_day_counts") or []) for stage in stage_payloads for item in stage["commercial_offer_payload"]],
+            default=0,
+        )
+        asset_count = max(asset_count, 1)
+        grouped_rows = {}
+        travel_total = Decimal("0")
+        travel_day_totals = [Decimal("0") for _ in range(asset_count)]
+        has_travel_calculation = False
+        has_travel_actual = False
+
+        for stage in stage_payloads:
+            travel_mode = (
+                str((stage.get("commercial_totals_json") or {}).get("travel_expenses_mode") or "").strip()
+                or PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL
+            )
+            for item in stage["commercial_offer_payload"]:
+                is_travel_row = is_proposal_travel_expenses_name(item.get("service_name") or "")
+                day_values = list(item.get("asset_day_counts") or [])[:asset_count]
+                while len(day_values) < asset_count:
+                    day_values.append("")
+                if is_travel_row:
+                    total_value = item.get("total_eur_without_vat") or Decimal("0")
+                    if not isinstance(total_value, Decimal):
+                        total_value = self._parse_payload_decimal(
+                            total_value,
+                            "Сводный блок: поле «Итого, евро без НДС» заполнено некорректно.",
+                        ) or Decimal("0")
+                    travel_total += total_value
+                    if travel_mode == PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION:
+                        has_travel_calculation = True
+                        for index, raw_value in enumerate(day_values):
+                            if raw_value in (None, ""):
+                                continue
+                            travel_day_totals[index] += Decimal(str(raw_value))
+                    else:
+                        has_travel_actual = True
+                    continue
+
+                key = (
+                    str(item.get("specialist") or "").strip(),
+                    str(item.get("job_title") or "").strip(),
+                )
+                bucket = grouped_rows.get(key)
+                if bucket is None:
+                    bucket = {
+                        "position": len(grouped_rows) + 1,
+                        "specialist": key[0],
+                        "job_title": key[1],
+                        "professional_status": str(item.get("professional_status") or "").strip(),
+                        "service_name": "",
+                        "rate_eur_per_day": item.get("rate_eur_per_day"),
+                        "asset_day_counts": [0 for _ in range(asset_count)],
+                        "total_eur_without_vat": Decimal("0"),
+                    }
+                    grouped_rows[key] = bucket
+                for index, raw_value in enumerate(day_values):
+                    if raw_value in (None, ""):
+                        continue
+                    bucket["asset_day_counts"][index] += int(raw_value)
+                total_value = item.get("total_eur_without_vat") or Decimal("0")
+                if not isinstance(total_value, Decimal):
+                    total_value = self._parse_payload_decimal(
+                        total_value,
+                        "Сводный блок: поле «Итого, евро без НДС» заполнено некорректно.",
+                    ) or Decimal("0")
+                bucket["total_eur_without_vat"] += total_value
+
+        summary_rows = []
+        for bucket in grouped_rows.values():
+            summary_rows.append(
+                {
+                    "position": bucket["position"],
+                    "specialist": bucket["specialist"],
+                    "job_title": bucket["job_title"],
+                    "professional_status": bucket["professional_status"],
+                    "service_name": "",
+                    "rate_eur_per_day": bucket["rate_eur_per_day"],
+                    "asset_day_counts": [value if value else "" for value in bucket["asset_day_counts"]],
+                    "total_eur_without_vat": bucket["total_eur_without_vat"],
+                }
+            )
+
+        travel_mode = (
+            PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION
+            if has_travel_calculation and not has_travel_actual
+            else PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL
+        )
+        if has_travel_calculation or has_travel_actual or travel_total > 0:
+            summary_rows.append(
+                {
+                    "position": len(summary_rows) + 1,
+                    "specialist": "",
+                    "job_title": "",
+                    "professional_status": "",
+                    "service_name": PROPOSAL_TRAVEL_EXPENSES_LABEL,
+                    "rate_eur_per_day": None,
+                    "asset_day_counts": (
+                        [self._serialize_payload_decimal(value) if value else "" for value in travel_day_totals]
+                        if travel_mode == PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION
+                        else ["" for _ in range(asset_count)]
+                    ),
+                    "total_eur_without_vat": travel_total,
+                }
+            )
+
+        return summary_rows, travel_mode
+
+    def _parse_summary_service_cost(self, totals):
+        contract_total = str((totals or {}).get("contract_total") or "").strip()
+        if not contract_total:
+            return None
+        return self._parse_payload_decimal(
+            contract_total,
+            "Сводный блок: поле «Стоимость услуг» заполнено некорректно.",
+        )
+
+    def _collect_stage_payloads(self):
+        stage_payloads = []
+        cleaned_product_ids = []
+        seen_product_ids = set()
+        for row in self.stage_rows:
+            rank = int(row.get("rank") or len(stage_payloads) + 1)
+            row_has_data = any(
+                str(row.get(key) or "").strip()
+                for key in (
+                    "consulting_type",
+                    "service_category",
+                    "service_subtype",
+                    "product_id",
+                    "service_composition",
+                    "service_composition_customer_tz",
+                    "evaluation_date",
+                    "service_term_months",
+                    "preliminary_report_date",
+                    "final_report_term_weeks",
+                    "final_report_date",
+                )
+            )
+            product_raw = str(row.get("product_id") or "").strip()
+            if not product_raw:
+                if row_has_data:
+                    raise forms.ValidationError(f"Этап {rank}: выберите продукт.")
+                continue
+            try:
+                product_id = int(product_raw)
+            except (TypeError, ValueError):
+                raise forms.ValidationError(f"Этап {rank}: выбран некорректный продукт.")
+            product = Product.objects.filter(pk=product_id).first()
+            if product is None:
+                raise forms.ValidationError(f"Этап {rank}: выбранный продукт не найден.")
+            if product_id in seen_product_ids:
+                raise forms.ValidationError(f"Этап {rank}: продукт уже выбран для другого этапа.")
+            seen_product_ids.add(product_id)
+            cleaned_product_ids.append(product_id)
+
+            service_composition_mode = str(row.get("service_composition_mode") or "sections").strip() or "sections"
+            if service_composition_mode not in {"sections", "customer_tz"}:
+                service_composition_mode = "sections"
+            service_composition_customer_tz = str(row.get("service_composition_customer_tz") or "").strip()
+
+            stage_payloads.append(
+                {
+                    "rank": rank,
+                    "product": product,
+                    "product_id": product_id,
+                    "service_sections_json": self._normalize_stage_service_sections(
+                        row.get("service_sections_payload"),
+                        row_index=rank,
+                        product=product,
+                    ),
+                    "service_sections_editor_state": self._normalize_stage_editor_state(
+                        row.get("service_sections_editor_state"),
+                        row_index=rank,
+                    ),
+                    "service_customer_tz_editor_state": self._normalize_stage_customer_tz_state(
+                        row.get("service_customer_tz_editor_state"),
+                        row_index=rank,
+                    ),
+                    "service_composition_customer_tz": service_composition_customer_tz,
+                    "service_composition_mode": service_composition_mode,
+                    "service_composition": (
+                        service_composition_customer_tz
+                        if service_composition_mode == "customer_tz"
+                        else str(row.get("service_composition") or "").strip()
+                    ),
+                    "commercial_offer_payload": self._normalize_stage_commercial_rows(
+                        row.get("commercial_offer_payload"),
+                        row_index=rank,
+                        totals_raw=row.get("commercial_totals_payload"),
+                    ),
+                    "commercial_totals_json": self._normalize_stage_commercial_totals(
+                        row.get("commercial_totals_payload"),
+                        row_index=rank,
+                    ),
+                    "evaluation_date": self._parse_stage_date(
+                        row.get("evaluation_date"),
+                        row_index=rank,
+                        field_label="Дата оценки",
+                    ),
+                    "service_term_months": self._parse_stage_decimal(
+                        row.get("service_term_months"),
+                        row_index=rank,
+                        field_label="Срок подготовки Предварительного отчёта, мес.",
+                    ),
+                    "preliminary_report_date": self._parse_stage_date(
+                        row.get("preliminary_report_date"),
+                        row_index=rank,
+                        field_label="Дата Предварительного отчёта",
+                    ),
+                    "final_report_term_weeks": self._parse_stage_decimal(
+                        row.get("final_report_term_weeks"),
+                        row_index=rank,
+                        field_label="Срок подготовки Итогового отчёта, нед.",
+                    ),
+                    "final_report_date": self._parse_stage_date(
+                        row.get("final_report_date"),
+                        row_index=rank,
+                        field_label="Дата Итогового отчёта",
+                    ),
+                }
+            )
+        self.cleaned_type_ids = cleaned_product_ids
+        self.cleaned_stage_payloads = stage_payloads
+        if not cleaned_product_ids:
+            self.add_error("type_ids", "Укажите хотя бы один продукт.")
 
     def clean(self):
         cleaned = super().clean()
@@ -1000,23 +1955,147 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
         if cleaned.get("service_composition_mode") == "customer_tz":
             cleaned["service_composition"] = cleaned.get("service_composition_customer_tz") or ""
 
+        try:
+            self._collect_stage_payloads()
+        except forms.ValidationError as error:
+            self.add_error("type_ids", error)
+            return cleaned
+
+        if getattr(self, "cleaned_stage_payloads", None) and len(self.cleaned_stage_payloads) > 1:
+            summary_offer_raw = str(cleaned.get("summary_commercial_offer_payload") or "").strip()
+            summary_totals_raw = str(cleaned.get("summary_commercial_totals_payload") or "").strip()
+            if summary_offer_raw:
+                self.cleaned_commercial_offers = self._normalize_summary_commercial_rows(
+                    summary_offer_raw,
+                    totals_raw=summary_totals_raw,
+                )
+            else:
+                self.cleaned_commercial_offers, inferred_travel_mode = self._build_summary_commercial_fallback(
+                    self.cleaned_stage_payloads
+                )
+                if not summary_totals_raw:
+                    summary_totals_raw = json.dumps(
+                        {
+                            **(self.cleaned_stage_payloads[-1]["commercial_totals_json"] or {}),
+                            "travel_expenses_mode": inferred_travel_mode,
+                        },
+                        ensure_ascii=False,
+                    )
+            self.cleaned_commercial_totals = (
+                self._normalize_summary_commercial_totals(summary_totals_raw)
+                if summary_totals_raw
+                else self._merge_stage_commercial_totals_payload({})
+            )
+            if not str(self.cleaned_commercial_totals.get("travel_expenses_mode") or "").strip():
+                _, inferred_travel_mode = self._build_summary_commercial_fallback(self.cleaned_stage_payloads)
+                self.cleaned_commercial_totals["travel_expenses_mode"] = inferred_travel_mode
+            summary_service_cost = self._parse_summary_service_cost(self.cleaned_commercial_totals)
+            cleaned["service_cost"] = summary_service_cost
+
+        if getattr(self, "cleaned_stage_payloads", None):
+            last_stage = self.cleaned_stage_payloads[-1]
+            cleaned["type"] = last_stage["product"]
+            cleaned["service_composition_mode"] = last_stage["service_composition_mode"]
+            cleaned["service_composition"] = last_stage["service_composition"]
+            cleaned["service_composition_customer_tz"] = last_stage["service_composition_customer_tz"]
+            cleaned["evaluation_date"] = last_stage["evaluation_date"]
+            cleaned["service_term_months"] = last_stage["service_term_months"]
+            cleaned["preliminary_report_date"] = last_stage["preliminary_report_date"]
+            cleaned["final_report_term_weeks"] = last_stage["final_report_term_weeks"]
+            cleaned["final_report_date"] = last_stage["final_report_date"]
+
         return cleaned
 
     def save(self, commit=True):
         instance = super().save(commit=False)
-        instance.service_sections_json = [
+        stage_payloads = list(getattr(self, "cleaned_stage_payloads", []))
+        last_stage = stage_payloads[-1] if stage_payloads else None
+        if last_stage:
+            instance.type = last_stage["product"]
+            instance.service_sections_json = list(last_stage["service_sections_json"])
+            instance.service_sections_editor_state = list(last_stage["service_sections_editor_state"])
+            instance.service_customer_tz_editor_state = dict(last_stage["service_customer_tz_editor_state"])
+            instance.service_composition_customer_tz = last_stage["service_composition_customer_tz"]
+            instance.service_composition_mode = last_stage["service_composition_mode"]
+            instance.service_composition = last_stage["service_composition"]
+            instance.commercial_totals_json = dict(last_stage["commercial_totals_json"])
+            instance.evaluation_date = last_stage["evaluation_date"]
+            instance.service_term_months = last_stage["service_term_months"]
+            instance.preliminary_report_date = last_stage["preliminary_report_date"]
+            instance.final_report_term_weeks = last_stage["final_report_term_weeks"]
+            instance.final_report_date = last_stage["final_report_date"]
+            self.cleaned_service_sections = list(last_stage["service_sections_json"])
+            self.cleaned_service_sections_editor_state = list(last_stage["service_sections_editor_state"])
+            self.cleaned_service_customer_tz_editor_state = dict(last_stage["service_customer_tz_editor_state"])
+            if len(stage_payloads) == 1:
+                instance.commercial_totals_json = dict(last_stage["commercial_totals_json"])
+                self.cleaned_commercial_offers = list(last_stage["commercial_offer_payload"])
+                self.cleaned_commercial_totals = dict(last_stage["commercial_totals_json"])
+            else:
+                instance.commercial_totals_json = dict(getattr(self, "cleaned_commercial_totals", {}) or {})
+        else:
+            instance.service_sections_json = [
+                {
+                    "service_name": item["service_name"],
+                    "code": item["code"],
+                }
+                for item in getattr(self, "cleaned_service_sections", [])
+            ]
+            instance.service_sections_editor_state = getattr(self, "cleaned_service_sections_editor_state", [])
+            instance.service_customer_tz_editor_state = getattr(self, "cleaned_service_customer_tz_editor_state", {})
+            instance.commercial_totals_json = getattr(self, "cleaned_commercial_totals", {})
+        instance.stage_payloads_json = [
             {
-                "service_name": item["service_name"],
-                "code": item["code"],
+                "rank": item["rank"],
+                "product_id": item["product_id"],
+                "service_sections_json": list(item["service_sections_json"]),
+                "service_sections_editor_state": list(item["service_sections_editor_state"]),
+                "service_customer_tz_editor_state": dict(item["service_customer_tz_editor_state"]),
+                "service_composition_customer_tz": item["service_composition_customer_tz"],
+                "service_composition_mode": item["service_composition_mode"],
+                "service_composition": item["service_composition"],
+                "commercial_offer_payload": [
+                    {
+                        "position": offer.get("position") or index,
+                        "specialist": offer.get("specialist") or "",
+                        "job_title": offer.get("job_title") or "",
+                        "professional_status": offer.get("professional_status") or "",
+                        "service_name": offer.get("service_name") or "",
+                        "rate_eur_per_day": str(offer.get("rate_eur_per_day") or ""),
+                        "asset_day_counts": list(offer.get("asset_day_counts") or []),
+                        "total_eur_without_vat": str(offer.get("total_eur_without_vat") or ""),
+                    }
+                    for index, offer in enumerate(item["commercial_offer_payload"], start=1)
+                ],
+                "commercial_totals_json": dict(item["commercial_totals_json"]),
+                "evaluation_date": _format_stage_date(item["evaluation_date"]),
+                "service_term_months": str(item["service_term_months"] or ""),
+                "preliminary_report_date": _format_stage_date(item["preliminary_report_date"]),
+                "final_report_term_weeks": str(item["final_report_term_weeks"] or ""),
+                "final_report_date": _format_stage_date(item["final_report_date"]),
             }
-            for item in getattr(self, "cleaned_service_sections", [])
+            for item in stage_payloads
         ]
-        instance.service_sections_editor_state = getattr(self, "cleaned_service_sections_editor_state", [])
-        instance.service_customer_tz_editor_state = getattr(self, "cleaned_service_customer_tz_editor_state", {})
-        instance.commercial_totals_json = getattr(self, "cleaned_commercial_totals", {})
         if commit:
             instance.save()
+            self._save_ranked_products(instance)
         return instance
+
+    def _save_ranked_products(self, proposal):
+        product_ids = list(getattr(self, "cleaned_type_ids", []))
+        ProposalRegistrationProduct.objects.filter(proposal=proposal).delete()
+        if not product_ids:
+            return
+        ProposalRegistrationProduct.objects.bulk_create(
+            [
+                ProposalRegistrationProduct(
+                    proposal=proposal,
+                    product_id=product_id,
+                    rank=rank,
+                )
+                for rank, product_id in enumerate(product_ids, start=1)
+            ]
+        )
 
     def clean_service_sections_editor_state(self):
         raw = (self.cleaned_data.get("service_sections_editor_state") or "").strip()
@@ -1636,16 +2715,18 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
             [
                 ProposalCommercialOffer(
                     proposal=proposal,
-                    position=item["position"],
+                    position=item.get("position") or index,
                     specialist=item["specialist"],
                     job_title=item["job_title"],
                     professional_status=item["professional_status"],
                     service_name=item["service_name"],
-                    rate_eur_per_day=item["rate_eur_per_day"],
+                    rate_eur_per_day=(None if item.get("rate_eur_per_day") in ("", None) else item.get("rate_eur_per_day")),
                     asset_day_counts=item["asset_day_counts"],
-                    total_eur_without_vat=item["total_eur_without_vat"],
+                    total_eur_without_vat=(
+                        None if item.get("total_eur_without_vat") in ("", None) else item.get("total_eur_without_vat")
+                    ),
                 )
-                for item in items
+                for index, item in enumerate(items, start=1)
             ]
         )
 

--- a/proposals_app/migrations/0042_proposalregistration_stage_payloads_and_products.py
+++ b/proposals_app/migrations/0042_proposalregistration_stage_payloads_and_products.py
@@ -1,0 +1,49 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("policy_app", "0040_backfill_consulting_catalog_refs"),
+        ("proposals_app", "0041_proposalregistration_workspace_file_id"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="proposalregistration",
+            name="stage_payloads_json",
+            field=models.JSONField(blank=True, default=list, verbose_name="Данные этапов ТКП"),
+        ),
+        migrations.CreateModel(
+            name="ProposalRegistrationProduct",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("rank", models.PositiveIntegerField(default=1, verbose_name="Ранг")),
+                (
+                    "product",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="proposal_registration_links",
+                        to="policy_app.product",
+                        verbose_name="Продукт",
+                    ),
+                ),
+                (
+                    "proposal",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="product_links",
+                        to="proposals_app.proposalregistration",
+                        verbose_name="ТКП",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Продукт ТКП",
+                "verbose_name_plural": "Продукты ТКП",
+                "ordering": ["rank", "id"],
+                "unique_together": {("proposal", "product")},
+            },
+        ),
+    ]

--- a/proposals_app/migrations/0043_alter_proposalregistration_number_range.py
+++ b/proposals_app/migrations/0043_alter_proposalregistration_number_range.py
@@ -1,0 +1,19 @@
+from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("proposals_app", "0042_proposalregistration_stage_payloads_and_products"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="proposalregistration",
+            name="number",
+            field=models.PositiveIntegerField(
+                validators=[MinValueValidator(0), MaxValueValidator(9999)],
+                verbose_name="Номер",
+            ),
+        ),
+    ]

--- a/proposals_app/migrations/0044_alter_proposalregistration_status.py
+++ b/proposals_app/migrations/0044_alter_proposalregistration_status.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("proposals_app", "0043_alter_proposalregistration_number_range"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="proposalregistration",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("preliminary", "Предварительное"),
+                    ("final", "Итоговое"),
+                    ("sent", "Отправленное"),
+                    ("completed", "Завершённое"),
+                    ("not_held", "Несостоявшееся"),
+                ],
+                db_index=True,
+                default="final",
+                max_length=20,
+                verbose_name="Статус",
+            ),
+        ),
+    ]

--- a/proposals_app/models.py
+++ b/proposals_app/models.py
@@ -24,11 +24,12 @@ class ProposalRegistration(models.Model):
         FINAL = "final", "Итоговое"
         SENT = "sent", "Отправленное"
         COMPLETED = "completed", "Завершённое"
+        NOT_HELD = "not_held", "Несостоявшееся"
 
     position = models.PositiveIntegerField(default=0, db_index=True, verbose_name="Позиция")
     number = models.PositiveIntegerField(
         verbose_name="Номер",
-        validators=[MinValueValidator(3333), MaxValueValidator(9999)],
+        validators=[MinValueValidator(0), MaxValueValidator(9999)],
     )
     group = models.CharField("Группа", max_length=2, default="RU", db_index=True)
     group_member = models.ForeignKey(
@@ -113,6 +114,7 @@ class ProposalRegistration(models.Model):
     )
     service_composition_mode = models.CharField("Режим состава услуг", max_length=20, blank=True, default="sections")
     commercial_totals_json = models.JSONField("Итоги коммерческого предложения", default=dict, blank=True)
+    stage_payloads_json = models.JSONField("Данные этапов ТКП", default=list, blank=True)
     evaluation_date = models.DateField("Дата оценки", null=True, blank=True)
     service_term_months = models.DecimalField(
         "Срок подготовки Предварительного отчёта, мес.",
@@ -258,6 +260,10 @@ class ProposalRegistration(models.Model):
         return f"{self.short_uid} — {self.get_kind_display()}"
 
     @property
+    def formatted_number(self):
+        return f"{int(self.number or 0):04d}"
+
+    @property
     def contact_short_name(self):
         parts = [part for part in str(self.contact_full_name or "").strip().split() if part]
         if not parts:
@@ -350,6 +356,66 @@ class ProposalRegistration(models.Model):
         if not self.short_uid or self._needs_uid_refresh():
             self.short_uid = self._build_short_uid()
         super().save(*args, **kwargs)
+
+    def _ordered_product_links(self):
+        prefetched = getattr(self, "_prefetched_objects_cache", {})
+        if "product_links" in prefetched:
+            return list(prefetched["product_links"])
+        if not self.pk:
+            return []
+        return list(
+            self.product_links.select_related("product").order_by("rank", "id")
+        )
+
+    def ordered_products(self):
+        links = self._ordered_product_links()
+        if links:
+            return [link.product for link in links if getattr(link, "product_id", None)]
+        return [self.type] if self.type else []
+
+    @property
+    def ordered_product_ids(self):
+        return [product.pk for product in self.ordered_products() if getattr(product, "pk", None)]
+
+    @property
+    def product_rank_map(self):
+        return {product_id: index for index, product_id in enumerate(self.ordered_product_ids, start=1)}
+
+    @property
+    def primary_product(self):
+        products = self.ordered_products()
+        return products[0] if products else None
+
+    @property
+    def last_product(self):
+        products = self.ordered_products()
+        return products[-1] if products else None
+
+
+class ProposalRegistrationProduct(models.Model):
+    proposal = models.ForeignKey(
+        ProposalRegistration,
+        on_delete=models.CASCADE,
+        related_name="product_links",
+        verbose_name="ТКП",
+    )
+    product = models.ForeignKey(
+        Product,
+        on_delete=models.PROTECT,
+        related_name="proposal_registration_links",
+        verbose_name="Продукт",
+    )
+    rank = models.PositiveIntegerField("Ранг", default=1)
+
+    class Meta:
+        app_label = "proposals_app"
+        ordering = ["rank", "id"]
+        verbose_name = "Продукт ТКП"
+        verbose_name_plural = "Продукты ТКП"
+        unique_together = [("proposal", "product")]
+
+    def __str__(self):
+        return f"{self.proposal.short_uid} — {self.product.short_name} (#{self.rank})"
 
 
 class ProposalAsset(models.Model):

--- a/proposals_app/templates/proposals_app/_proposal_stage_commercial_block.html
+++ b/proposals_app/templates/proposals_app/_proposal_stage_commercial_block.html
@@ -1,0 +1,59 @@
+<div class="col-12 proposal-stage-commercial-block{% if is_summary and form.stage_rows|length <= 1 %} d-none{% endif %}"
+     data-proposal-stage-root="1"
+     data-proposal-stage-kind="{% if is_summary %}commercial-summary{% else %}commercial{% endif %}"
+     data-proposal-stage-key="{% if is_summary %}summary{% else %}{{ stage.rank }}{% endif %}"
+     {% if is_summary %}data-proposal-commercial-summary="1"{% endif %}>
+  {% if not is_summary %}
+    <input type="hidden" data-proposal-stage-type value="{{ stage.product_id }}">
+  {% endif %}
+  <label class="form-label mb-2 proposal-stage-block-title">
+    {% if is_summary %}
+      Коммерческое предложение: все этапы
+    {% else %}
+      Коммерческое предложение{% if form.stage_rows|length > 1 %}: Этап {{ stage.rank }}{% if stage.product_short_label %} {{ stage.product_short_label }}{% endif %}{% endif %}
+    {% endif %}
+  </label>
+  <input type="hidden" name="{% if is_summary %}summary_commercial_offer_payload{% else %}commercial_offer_payload{% endif %}" id="proposal-commercial-offer-payload" value="{{ stage.commercial_offer_payload }}">
+  <input type="hidden" name="{% if is_summary %}summary_commercial_totals_payload{% else %}commercial_totals_payload{% endif %}" id="proposal-commercial-totals-payload" value="{{ stage.commercial_totals_payload }}">
+  <div class="proposal-assets-editor proposal-commercial-editor">
+    <div class="table-responsive">
+      <table class="table table-sm align-middle mb-2 proposal-assets-table proposal-commercial-table" id="proposal-commercial-table">
+        <thead id="proposal-commercial-thead"></thead>
+        <tbody id="proposal-commercial-tbody"></tbody>
+      </table>
+    </div>
+    {% if not is_summary %}
+      <div class="d-flex align-items-stretch gap-2 mt-3">
+        <button type="button" id="proposal-commercial-add-btn" class="btn btn-sm proposal-asset-add-btn d-flex align-items-center">
+          <i class="bi bi-plus-circle me-2"></i>Добавить строку
+        </button>
+        <div id="proposal-commercial-row-actions" class="d-none">
+          <div class="btn-group">
+            <button type="button" id="proposal-commercial-up-btn" class="btn btn-outline-primary btn-sm" title="Переместить вверх" aria-label="Переместить вверх">
+              <i class="bi bi-arrow-up-square"></i>
+            </button>
+            <button type="button" id="proposal-commercial-down-btn" class="btn btn-outline-primary btn-sm" title="Переместить вниз" aria-label="Переместить вниз">
+              <i class="bi bi-arrow-down-square"></i>
+            </button>
+            <button type="button" id="proposal-commercial-delete-btn" class="btn btn-outline-danger btn-sm" title="Удалить" aria-label="Удалить">
+              <i class="bi bi-x-square"></i>
+            </button>
+          </div>
+        </div>
+      </div>
+    {% else %}
+      <div class="d-flex align-items-stretch gap-2 mt-3">
+        <div id="proposal-commercial-row-actions" class="d-flex">
+          <div class="btn-group">
+            <button type="button" id="proposal-commercial-up-btn" class="btn btn-outline-primary btn-sm" title="Переместить вверх" aria-label="Переместить вверх">
+              <i class="bi bi-arrow-up-square"></i>
+            </button>
+            <button type="button" id="proposal-commercial-down-btn" class="btn btn-outline-primary btn-sm" title="Переместить вниз" aria-label="Переместить вниз">
+              <i class="bi bi-arrow-down-square"></i>
+            </button>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+</div>

--- a/proposals_app/templates/proposals_app/_proposal_stage_service_block.html
+++ b/proposals_app/templates/proposals_app/_proposal_stage_service_block.html
@@ -1,0 +1,143 @@
+<div class="col-12 proposal-stage-service-block"
+     data-proposal-stage-root="1"
+     data-proposal-stage-kind="service"
+     data-proposal-stage-key="{{ stage.rank }}">
+  <input type="hidden" data-proposal-stage-type value="{{ stage.product_id }}">
+  <label class="form-label mb-2 proposal-stage-block-title">
+    Состав услуг / техническое задание{% if form.stage_rows|length > 1 %}: Этап {{ stage.rank }}{% if stage.product_short_label %} {{ stage.product_short_label }}{% endif %}{% endif %}
+  </label>
+  <input type="hidden" name="service_sections_payload" id="proposal-service-sections-payload" value="{{ stage.service_sections_payload }}">
+  <input type="hidden" name="service_sections_editor_state" id="proposal-service-sections-editor-state" value="{{ stage.service_sections_editor_state }}">
+  <input type="hidden" name="service_customer_tz_editor_state" id="proposal-service-customer-tz-editor-state" value="{{ stage.service_customer_tz_editor_state }}">
+  <input type="hidden" name="service_composition_customer_tz" id="proposal-service-composition-customer-tz" value="{{ stage.service_composition_customer_tz }}">
+  <input type="hidden" name="service_composition_mode" id="proposal-service-composition-mode" value="{{ stage.service_composition_mode }}">
+  <div class="proposal-assets-editor proposal-service-sections-editor">
+    <div class="table-responsive">
+      <table class="table table-sm align-middle mb-2 proposal-assets-table proposal-service-sections-table" id="proposal-service-sections-table">
+        <thead>
+          <tr>
+            <th class="w-checkbox proposal-assets-check-col">
+              <div class="form-check proposal-asset-check-wrap">
+                <input type="checkbox" class="form-check-input proposal-service-sections-master-check" id="proposal-service-sections-master-check">
+              </div>
+            </th>
+            <th class="proposal-service-section-name-header"><span class="proposal-service-section-header-text">Наименование раздела (услуги)</span></th>
+            <th><span class="proposal-service-section-header-text">Код</span></th>
+          </tr>
+        </thead>
+        <tbody id="proposal-service-sections-tbody"></tbody>
+      </table>
+    </div>
+    <div class="d-flex align-items-stretch gap-2 mt-3">
+      <button type="button" id="proposal-service-section-add-btn" class="btn btn-sm proposal-asset-add-btn d-flex align-items-center">
+        <i class="bi bi-plus-circle me-2"></i>Добавить услугу
+      </button>
+      <button type="button" id="proposal-service-text-edit-btn" class="btn btn-sm proposal-asset-add-btn">
+        <i class="bi bi-pencil-square me-1"></i>Редактировать ТЗ
+      </button>
+      <div id="proposal-service-sections-row-actions" class="d-none">
+        <div class="btn-group">
+          <button type="button" id="proposal-service-section-up-btn" class="btn btn-outline-primary btn-sm" title="Переместить вверх" aria-label="Переместить вверх">
+            <i class="bi bi-arrow-up-square"></i>
+          </button>
+          <button type="button" id="proposal-service-section-down-btn" class="btn btn-outline-primary btn-sm" title="Переместить вниз" aria-label="Переместить вниз">
+            <i class="bi bi-arrow-down-square"></i>
+          </button>
+          <button type="button" id="proposal-service-section-delete-btn" class="btn btn-outline-danger btn-sm" title="Удалить" aria-label="Удалить">
+            <i class="bi bi-x-square"></i>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="proposal-service-text-modal d-none" id="proposal-service-text-modal" aria-hidden="true">
+    <div class="proposal-service-text-modal__backdrop"></div>
+    <div class="proposal-service-text-modal__dialog">
+      <div class="proposal-service-text-modal__header">
+        <h5 class="mb-0 proposal-stage-block-title">Состав услуг / техническое задание{% if form.stage_rows|length > 1 %}: Этап {{ stage.rank }}{% if stage.product_short_label %} {{ stage.product_short_label }}{% endif %}{% endif %}</h5>
+        <button type="button" class="btn-close" id="proposal-service-text-close-btn" aria-label="Закрыть"></button>
+      </div>
+      <div class="proposal-service-text-modal__toolbar">
+        <div class="proposal-service-text-toolbar" id="proposal-service-text-toolbar">
+          <div class="proposal-service-text-toolbar__group">
+            <select class="form-select form-select-sm proposal-service-text-toolbar__select" data-format="font" aria-label="Шрифт">
+              <option value="calibri" selected>Calibri</option>
+              <option value="cambria">Cambria</option>
+              <option value="sans">Sans Serif</option>
+              <option value="serif">Serif</option>
+              <option value="monospace">Monospace</option>
+              <option value="georgia">Georgia</option>
+              <option value="times-new-roman">Times New Roman</option>
+            </select>
+          </div>
+          <div class="proposal-service-text-toolbar__group">
+            <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-format="bold" aria-label="Жирный">
+              <i class="bi bi-type-bold"></i>
+            </button>
+            <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-format="italic" aria-label="Курсив">
+              <i class="bi bi-type-italic"></i>
+            </button>
+            <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-format="underline" aria-label="Подчеркнутый">
+              <i class="bi bi-type-underline"></i>
+            </button>
+          </div>
+          <div class="proposal-service-text-toolbar__group">
+            <div class="proposal-service-text-toolbar__color-combo">
+              <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn proposal-service-text-toolbar__btn--combo" data-apply-color="color" aria-label="Применить цвет текста" title="Применить цвет текста">
+                <i class="bi bi-palette"></i>
+              </button>
+              <label class="proposal-service-text-toolbar__color" title="Выбрать цвет текста" aria-label="Выбрать цвет текста">
+                <input type="color" value="#000000" data-color-source="color">
+                <span class="proposal-service-text-toolbar__color-swatch" data-color-preview="color" style="background:#000000;"></span>
+              </label>
+            </div>
+            <div class="proposal-service-text-toolbar__color-combo">
+              <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn proposal-service-text-toolbar__btn--combo" data-apply-color="background" aria-label="Применить цвет фона" title="Применить цвет фона">
+                <i class="bi bi-paint-bucket"></i>
+              </button>
+              <label class="proposal-service-text-toolbar__color" title="Выбрать цвет фона" aria-label="Выбрать цвет фона">
+                <input type="color" value="#ffffff" data-color-source="background">
+                <span class="proposal-service-text-toolbar__color-swatch" data-color-preview="background" style="background:#ffffff;"></span>
+              </label>
+            </div>
+          </div>
+          <div class="proposal-service-text-toolbar__group">
+            <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-format="list" data-value="ordered" data-list="ordered" aria-label="Нумерованный список">
+              <i class="bi bi-list-ol"></i>
+            </button>
+            <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-format="list" data-value="bullet" data-list="bullet" aria-label="Маркированный список">
+              <i class="bi bi-list-ul"></i>
+            </button>
+          </div>
+          <div class="proposal-service-text-toolbar__group">
+            <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-format="align" data-value="" data-align="" aria-label="Выключка по ширине">
+              <i class="bi bi-justify"></i>
+            </button>
+            <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-format="align" data-value="center" data-align="center" aria-label="По центру">
+              <i class="bi bi-text-center"></i>
+            </button>
+          </div>
+          <div class="proposal-service-text-toolbar__group">
+            <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-action="clean" aria-label="Очистить форматирование">
+              <i class="bi bi-eraser"></i>
+            </button>
+          </div>
+          <div class="form-check form-switch proposal-service-mode-toggle-wrap mb-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="proposal-service-mode-toggle" {% if stage.service_composition_mode == "customer_tz" %}checked{% endif %}>
+            <label class="form-check-label" for="proposal-service-mode-toggle">Вставить ТЗ Заказчика</label>
+          </div>
+        </div>
+      </div>
+      <div class="proposal-service-text-modal__body">
+        <div class="proposal-service-text-modal__cards" id="proposal-service-text-cards"></div>
+      </div>
+      <div class="proposal-service-text-modal__footer">
+        <button type="button" class="btn btn-primary btn-sm" id="proposal-service-text-save-btn">Сохранить</button>
+        <button type="button" class="btn btn-outline-secondary btn-sm" id="proposal-service-text-cancel-btn">Отмена</button>
+      </div>
+    </div>
+  </div>
+  <div class="d-none">
+    <textarea name="service_composition">{{ stage.service_composition }}</textarea>
+  </div>
+</div>

--- a/proposals_app/templates/proposals_app/proposal_form_page.html
+++ b/proposals_app/templates/proposals_app/proposal_form_page.html
@@ -24,11 +24,15 @@
         hx-target="#proposals-pane"
         hx-swap="outerHTML">
     {% csrf_token %}
+    {{ form.type_ids }}
 
     <div class="row g-3">
       <div class="col-2">
         <label class="form-label">{{ form.number.label }}</label>
-        {{ form.number }}
+        <div class="number-input-shell">
+          {{ form.number }}
+          <div class="number-input-display" id="proposal-number-display" aria-hidden="true"></div>
+        </div>
       </div>
       <div class="col-4">
         <label class="form-label">{{ form.group_member.label }}</label>
@@ -50,11 +54,60 @@
         {{ form.year }}
       </div>
 
-      <div class="col-3">
-        <label class="form-label">{{ form.type.label }}</label>
-        {{ form.type }}
+      <div class="col-12">
+        <label class="form-label">Тип</label>
+        <script type="application/json" id="proposal-type-meta">{{ proposal_type_meta_json|safe }}</script>
+        <div class="proposal-type-block">
+          <div class="proposal-type-card">
+            <div class="proposal-type-head">
+              <span aria-hidden="true"></span>
+              <div class="row g-2 proposal-type-head-labels">
+                <div class="col-12 col-xl-3"><span class="form-label mb-0 proposal-type-head-field-label">Вид консалтинга</span></div>
+                <div class="col-12 col-xl-3"><span class="form-label mb-0 proposal-type-head-field-label">Тип услуги</span></div>
+                <div class="col-12 col-xl-3"><span class="form-label mb-0 proposal-type-head-field-label">Подтип услуги</span></div>
+                <div class="col-12 col-xl-3"><span class="form-label mb-0 proposal-type-head-field-label">Продукт</span></div>
+              </div>
+              <span aria-hidden="true"></span>
+            </div>
+            <div id="proposal-products-container" class="proposal-products-container">
+              {% for stage in form.stage_rows %}
+                <div class="proposal-product-row"
+                     data-selected-product-id="{{ stage.product_id|default:'' }}"
+                     data-selected-consulting-type="{{ stage.consulting_type|default:'' }}"
+                     data-selected-service-category="{{ stage.service_category|default:'' }}"
+                     data-selected-service-subtype="{{ stage.service_subtype|default:'' }}">
+                  <div class="proposal-product-row-inner">
+                    <span class="badge rounded-circle d-flex align-items-center justify-content-center proposal-product-badge">{{ stage.rank }}</span>
+                    <div class="row g-2 flex-grow-1 proposal-product-fields">
+                      <div class="col-12 col-xl-3">
+                        <select name="type_consulting" class="form-select proposal-consulting-select"></select>
+                      </div>
+                      <div class="col-12 col-xl-3">
+                        <select name="type_service_category" class="form-select proposal-service-category-select"></select>
+                      </div>
+                      <div class="col-12 col-xl-3">
+                        <select name="type_service_subtype" class="form-select proposal-service-subtype-select"></select>
+                      </div>
+                      <div class="col-12 col-xl-3">
+                        <div class="proposal-product-select-shell">
+                          <select name="type" class="form-select proposal-product-select"></select>
+                          <div class="proposal-product-display" aria-hidden="true"></div>
+                        </div>
+                      </div>
+                    </div>
+                    <button type="button" class="btn btn-sm proposal-product-remove" title="Удалить" aria-label="Удалить этап">&times;</button>
+                  </div>
+                </div>
+              {% endfor %}
+            </div>
+          </div>
+          <button type="button" id="proposal-add-product" class="btn proposal-add-product-btn">
+            <i class="bi bi-plus-circle me-2"></i>Добавить продукт
+          </button>
+        </div>
       </div>
-      <div class="col-9">
+
+      <div class="col-12">
         <label class="form-label">{{ form.name.label }}</label>
         {{ form.name }}
       </div>
@@ -162,149 +215,11 @@
                  id="proposal-purpose-suffix">
         </div>
       </div>
-      <div class="col-12">
-        <label class="form-label mb-2">Состав услуг / техническое задание</label>
-        {{ form.service_sections_payload }}
-        {{ form.service_sections_editor_state }}
-        {{ form.service_customer_tz_editor_state }}
-        {{ form.service_composition_customer_tz }}
-        {{ form.service_composition_mode }}
-        <div class="proposal-assets-editor proposal-service-sections-editor">
-          <div class="table-responsive">
-            <table class="table table-sm align-middle mb-2 proposal-assets-table proposal-service-sections-table" id="proposal-service-sections-table">
-              <thead>
-                <tr>
-                  <th class="w-checkbox proposal-assets-check-col">
-                    <div class="form-check proposal-asset-check-wrap">
-                      <input type="checkbox" class="form-check-input proposal-service-sections-master-check" id="proposal-service-sections-master-check">
-                    </div>
-                  </th>
-                  <th class="proposal-service-section-name-header"><span class="proposal-service-section-header-text">Наименование раздела (услуги)</span></th>
-                  <th><span class="proposal-service-section-header-text">Код</span></th>
-                </tr>
-              </thead>
-              <tbody id="proposal-service-sections-tbody"></tbody>
-            </table>
-          </div>
-          <div class="d-flex align-items-stretch gap-2 mt-3">
-            <button type="button" id="proposal-service-section-add-btn" class="btn btn-sm proposal-asset-add-btn d-flex align-items-center">
-              <i class="bi bi-plus-circle me-2"></i>Добавить услугу
-            </button>
-            <button type="button" id="proposal-service-text-edit-btn" class="btn btn-sm proposal-asset-add-btn">
-              <i class="bi bi-pencil-square me-1"></i>Редактировать ТЗ
-            </button>
-            <div id="proposal-service-sections-row-actions" class="d-none">
-              <div class="btn-group">
-                <button type="button" id="proposal-service-section-up-btn" class="btn btn-outline-primary btn-sm" title="Переместить вверх" aria-label="Переместить вверх">
-                  <i class="bi bi-arrow-up-square"></i>
-                </button>
-                <button type="button" id="proposal-service-section-down-btn" class="btn btn-outline-primary btn-sm" title="Переместить вниз" aria-label="Переместить вниз">
-                  <i class="bi bi-arrow-down-square"></i>
-                </button>
-                <button type="button" id="proposal-service-section-delete-btn" class="btn btn-outline-danger btn-sm" title="Удалить" aria-label="Удалить">
-                  <i class="bi bi-x-square"></i>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="proposal-service-text-modal d-none" id="proposal-service-text-modal" aria-hidden="true">
-          <div class="proposal-service-text-modal__backdrop"></div>
-          <div class="proposal-service-text-modal__dialog">
-            <div class="proposal-service-text-modal__header">
-              <h5 class="mb-0">Состав услуг / техническое задание</h5>
-              <button type="button" class="btn-close" id="proposal-service-text-close-btn" aria-label="Закрыть"></button>
-            </div>
-            <div class="proposal-service-text-modal__toolbar">
-              <div class="proposal-service-text-toolbar" id="proposal-service-text-toolbar">
-                <div class="proposal-service-text-toolbar__group">
-                  <select class="form-select form-select-sm proposal-service-text-toolbar__select" data-format="font" aria-label="Шрифт">
-                    <option value="calibri" selected>Calibri</option>
-                    <option value="cambria">Cambria</option>
-                    <option value="sans">Sans Serif</option>
-                    <option value="serif">Serif</option>
-                    <option value="monospace">Monospace</option>
-                    <option value="georgia">Georgia</option>
-                    <option value="times-new-roman">Times New Roman</option>
-                  </select>
-                </div>
-                <div class="proposal-service-text-toolbar__group">
-                  <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-format="bold" aria-label="Жирный">
-                    <i class="bi bi-type-bold"></i>
-                  </button>
-                  <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-format="italic" aria-label="Курсив">
-                    <i class="bi bi-type-italic"></i>
-                  </button>
-                  <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-format="underline" aria-label="Подчеркнутый">
-                    <i class="bi bi-type-underline"></i>
-                  </button>
-                </div>
-                <div class="proposal-service-text-toolbar__group">
-                  <div class="proposal-service-text-toolbar__color-combo">
-                    <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn proposal-service-text-toolbar__btn--combo" data-apply-color="color" aria-label="Применить цвет текста" title="Применить цвет текста">
-                      <i class="bi bi-palette"></i>
-                    </button>
-                    <label class="proposal-service-text-toolbar__color" title="Выбрать цвет текста" aria-label="Выбрать цвет текста">
-                      <input type="color" value="#000000" data-color-source="color">
-                      <span class="proposal-service-text-toolbar__color-swatch" data-color-preview="color" style="background:#000000;"></span>
-                    </label>
-                  </div>
-                  <div class="proposal-service-text-toolbar__color-combo">
-                    <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn proposal-service-text-toolbar__btn--combo" data-apply-color="background" aria-label="Применить цвет фона" title="Применить цвет фона">
-                      <i class="bi bi-paint-bucket"></i>
-                    </button>
-                    <label class="proposal-service-text-toolbar__color" title="Выбрать цвет фона" aria-label="Выбрать цвет фона">
-                      <input type="color" value="#ffffff" data-color-source="background">
-                      <span class="proposal-service-text-toolbar__color-swatch" data-color-preview="background" style="background:#ffffff;"></span>
-                    </label>
-                  </div>
-                </div>
-                <div class="proposal-service-text-toolbar__group">
-                  <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-list="ordered" aria-label="Нумерованный список">
-                    <img src="{% static 'core/icons/list-1-2.svg' %}" alt="" class="proposal-service-text-toolbar__icon">
-                  </button>
-                  <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-list="bullet" aria-label="Маркированный список">
-                    <img src="{% static 'core/icons/list-ul.svg' %}" alt="" class="proposal-service-text-toolbar__icon">
-                  </button>
-                </div>
-                <div class="proposal-service-text-toolbar__group">
-                  <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-align="justify" aria-label="По ширине">
-                    <img src="{% static 'core/icons/text-align-justify.svg' %}" alt="" class="proposal-service-text-toolbar__icon">
-                  </button>
-                  <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-align="left" aria-label="По левому краю">
-                    <img src="{% static 'core/icons/text-align-left.svg' %}" alt="" class="proposal-service-text-toolbar__icon">
-                  </button>
-                  <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-align="center" aria-label="По центру">
-                    <img src="{% static 'core/icons/text-align-center.svg' %}" alt="" class="proposal-service-text-toolbar__icon">
-                  </button>
-                  <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-align="right" aria-label="По правому краю">
-                    <img src="{% static 'core/icons/text-align-right.svg' %}" alt="" class="proposal-service-text-toolbar__icon">
-                  </button>
-                </div>
-                <div class="proposal-service-text-toolbar__group">
-                  <button type="button" class="btn btn-light btn-sm proposal-service-text-toolbar__btn" data-action="clean" aria-label="Очистить форматирование">
-                    <i class="bi bi-eraser"></i>
-                  </button>
-                </div>
-                <div class="form-check form-switch proposal-service-mode-toggle-wrap">
-                  <input class="form-check-input" type="checkbox" role="switch" id="proposal-service-mode-toggle">
-                  <label class="form-check-label" for="proposal-service-mode-toggle">Вставить ТЗ Заказчика</label>
-                </div>
-              </div>
-            </div>
-            <div class="proposal-service-text-modal__body">
-              <div class="proposal-service-text-modal__cards" id="proposal-service-text-cards"></div>
-            </div>
-            <div class="proposal-service-text-modal__footer">
-              <button type="button" class="btn btn-primary btn-sm" id="proposal-service-text-save-btn">Сохранить</button>
-              <button type="button" class="btn btn-outline-secondary btn-sm" id="proposal-service-text-cancel-btn">Отмена</button>
-            </div>
-          </div>
-        </div>
-      </div>
 
-      <div class="d-none">
-        {{ form.service_composition }}
+      <div id="proposal-service-stages-container" class="proposal-stage-blocks-container">
+        {% for stage in form.stage_rows %}
+          {% include "proposals_app/_proposal_stage_service_block.html" with stage=stage %}
+        {% endfor %}
       </div>
 
       <div class="col-12">
@@ -429,38 +344,75 @@
         </div>
       </div>
 
-      <div class="col">
-        <label class="form-label">{{ form.evaluation_date.label }}</label>
-        {{ form.evaluation_date }}
+      <div class="col-12">
+        <label class="form-label mb-2">Сроки</label>
+        <div class="proposal-assets-editor proposal-terms-editor">
+          <div class="table-responsive">
+            <table class="table table-sm align-middle mb-0 proposal-assets-table proposal-terms-table">
+              <thead>
+                <tr>
+                  <th class="proposal-terms-stage-col">Этапы</th>
+                  <th>{{ form.evaluation_date.label }}</th>
+                  <th>
+                    {{ form.service_term_months.label }}
+                    <i class="bi bi-lock-fill ms-1 js-proposal-report-terms-lock" role="button" title="Разблокировать ввод сроков"></i>
+                  </th>
+                  <th>{{ form.preliminary_report_date.label }}</th>
+                  <th>
+                    {{ form.final_report_term_weeks.label }}
+                    <i class="bi bi-lock-fill ms-1 js-proposal-report-terms-lock" role="button" title="Разблокировать ввод сроков"></i>
+                  </th>
+                  <th>{{ form.final_report_date.label }}</th>
+                </tr>
+              </thead>
+              <tbody id="proposal-stage-terms-tbody">
+                {% for stage in form.stage_rows %}
+                  <tr class="proposal-stage-terms-row" data-proposal-stage-key="{{ stage.rank }}">
+                    <td class="proposal-terms-stage-col">
+                      <input type="text" class="form-control readonly-field proposal-stage-label-input" value="Этап {{ stage.rank }}" readonly tabindex="-1">
+                    </td>
+                    <td>
+                      <input type="text" name="evaluation_date" class="form-control js-date proposal-stage-evaluation-date" value="{{ stage.evaluation_date }}">
+                    </td>
+                    <td>
+                      <input type="number" name="service_term_months" min="0" step="0.1" class="form-control readonly-field proposal-stage-service-term-months" value="{{ stage.service_term_months|floatformat:'1' }}" readonly tabindex="-1">
+                    </td>
+                    <td>
+                      <input type="text" name="preliminary_report_date" class="form-control js-date proposal-stage-preliminary-report-date" value="{{ stage.preliminary_report_date }}">
+                    </td>
+                    <td>
+                      <input type="number" name="final_report_term_weeks" min="0" step="0.1" class="form-control readonly-field proposal-stage-final-report-term-weeks" value="{{ stage.final_report_term_weeks|floatformat:'1' }}" readonly tabindex="-1">
+                    </td>
+                    <td>
+                      <input type="text" name="final_report_date" class="form-control js-date proposal-stage-final-report-date" value="{{ stage.final_report_date }}">
+                    </td>
+                  </tr>
+                {% endfor %}
+                <tr class="proposal-stage-terms-total-row{% if form.stage_rows|length <= 1 %} d-none{% endif %}">
+                  <td class="proposal-terms-stage-col">
+                    <input type="text" class="form-control readonly-field proposal-stage-label-input" value="Итого" readonly tabindex="-1">
+                  </td>
+                  <td>
+                    <input type="text" class="form-control readonly-field proposal-stage-total-evaluation-date" value="" readonly tabindex="-1">
+                  </td>
+                  <td>
+                    <input type="number" class="form-control readonly-field proposal-stage-total-service-term-months" value="" readonly tabindex="-1">
+                  </td>
+                  <td>
+                    <input type="text" class="form-control readonly-field proposal-stage-total-preliminary-report-date" value="" readonly tabindex="-1">
+                  </td>
+                  <td>
+                    <input type="number" class="form-control readonly-field proposal-stage-total-final-report-term-weeks" value="" readonly tabindex="-1">
+                  </td>
+                  <td>
+                    <input type="text" class="form-control readonly-field proposal-stage-total-final-report-date" value="" readonly tabindex="-1">
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
       </div>
-      <div class="col">
-        <label class="form-label">
-          {{ form.service_term_months.label }}
-          <i class="bi bi-lock-fill ms-1 js-proposal-report-terms-lock"
-             role="button"
-             title="Разблокировать ввод сроков"></i>
-        </label>
-        {{ form.service_term_months }}
-      </div>
-      <div class="col">
-        <label class="form-label">{{ form.preliminary_report_date.label }}</label>
-        {{ form.preliminary_report_date }}
-      </div>
-      <div class="col">
-        <label class="form-label">
-          {{ form.final_report_term_weeks.label }}
-          <i class="bi bi-lock-fill ms-1 js-proposal-report-terms-lock"
-             role="button"
-             title="Разблокировать ввод сроков"></i>
-        </label>
-        {{ form.final_report_term_weeks }}
-      </div>
-      <div class="col">
-        <label class="form-label">{{ form.final_report_date.label }}</label>
-        {{ form.final_report_date }}
-      </div>
-
-      <div class="w-100"></div>
 
       <div class="col-3">
         <label class="form-label">{{ form.report_languages.label }}</label>
@@ -509,36 +461,11 @@
       </div>
       <div class="w-100"></div>
 
-      <div class="col-12">
-        <label class="form-label mb-2">Коммерческое предложение</label>
-        {{ form.commercial_offer_payload }}
-        {{ form.commercial_totals_payload }}
-        <div class="proposal-assets-editor proposal-commercial-editor">
-          <div class="table-responsive">
-            <table class="table table-sm align-middle mb-2 proposal-assets-table proposal-commercial-table" id="proposal-commercial-table">
-              <thead id="proposal-commercial-thead"></thead>
-              <tbody id="proposal-commercial-tbody"></tbody>
-            </table>
-          </div>
-          <div class="d-flex align-items-stretch gap-2 mt-3">
-            <button type="button" id="proposal-commercial-add-btn" class="btn btn-sm proposal-asset-add-btn d-flex align-items-center">
-              <i class="bi bi-plus-circle me-2"></i>Добавить строку
-            </button>
-            <div id="proposal-commercial-row-actions" class="d-none">
-              <div class="btn-group">
-                <button type="button" id="proposal-commercial-up-btn" class="btn btn-outline-primary btn-sm" title="Переместить вверх" aria-label="Переместить вверх">
-                  <i class="bi bi-arrow-up-square"></i>
-                </button>
-                <button type="button" id="proposal-commercial-down-btn" class="btn btn-outline-primary btn-sm" title="Переместить вниз" aria-label="Переместить вниз">
-                  <i class="bi bi-arrow-down-square"></i>
-                </button>
-                <button type="button" id="proposal-commercial-delete-btn" class="btn btn-outline-danger btn-sm" title="Удалить" aria-label="Удалить">
-                  <i class="bi bi-x-square"></i>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
+      <div id="proposal-commercial-stages-container" class="proposal-stage-blocks-container">
+        {% for stage in form.stage_rows %}
+          {% include "proposals_app/_proposal_stage_commercial_block.html" with stage=stage %}
+        {% endfor %}
+        {% include "proposals_app/_proposal_stage_commercial_block.html" with stage=form.summary_commercial_row is_summary=True %}
       </div>
 
       <div class="col-4">
@@ -563,6 +490,7 @@
         {{ form.advance_term_days }}
       </div>
       <div class="w-100"></div>
+
       <div class="col-4">
         <label class="form-label">{{ form.preliminary_report_percent.label }}</label>
         <div class="proposal-inline-percent">
@@ -595,7 +523,7 @@
         <ul class="mb-0">
           {% for field, errors in form.errors.items %}
             {% for err in errors %}
-              <li>{{ field }}: {{ err }}</li>
+              <li>{% if field == "type_ids" %}Тип{% else %}{{ field }}{% endif %}: {{ err }}</li>
             {% endfor %}
           {% endfor %}
           {% for err in form.non_field_errors %}

--- a/proposals_app/templates/proposals_app/proposals_partial.html
+++ b/proposals_app/templates/proposals_app/proposals_partial.html
@@ -115,7 +115,7 @@
                 </div>
               {% endif %}
             </td>
-            <td data-col="number">{{ proposal.number }}</td>
+            <td data-col="number">{{ proposal.formatted_number }}</td>
             <td data-col="group">{{ proposal.group_display }}</td>
             <td class="text-center p-0 proposal-quick-edit-col" style="width:1%;">
               {% if request.user.is_authenticated and request.user.is_staff %}
@@ -277,7 +277,7 @@
                 </div>
               {% endif %}
             </td>
-            <td>{{ proposal.number }}</td>
+            <td>{{ proposal.formatted_number }}</td>
             <td>{{ proposal.group_display }}</td>
             <td class="text-center p-0 proposal-quick-edit-col" style="width:1%;">
               {% if request.user.is_authenticated and request.user.is_staff %}

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -13,6 +13,7 @@ from urllib.parse import parse_qs, quote, urlparse
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.http import QueryDict
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -61,6 +62,7 @@ from .models import (
     ProposalLegalEntity,
     ProposalObject,
     ProposalRegistration,
+    ProposalRegistrationProduct,
     ProposalTemplate,
     ProposalVariable,
 )
@@ -1098,6 +1100,52 @@ class ProposalDispatchSendTests(TestCase):
             f"IMCM/{self.successful_proposal.number}",
         )
 
+    def test_dispatch_transfer_to_contract_handles_duplicate_existing_main_contracts(self):
+        first_project = ProjectRegistration.objects.create(
+            number=self.successful_proposal.number,
+            group_member=self.successful_proposal.group_member,
+            agreement_type=ProjectRegistration.AgreementType.MAIN,
+            agreement_number=f"IMCM/{self.successful_proposal.number}",
+            type=self.product,
+            name="Уже существует 1",
+            year=2026,
+            position=1,
+        )
+        ProjectRegistration.objects.create(
+            number=self.successful_proposal.number,
+            group_member=self.successful_proposal.group_member,
+            agreement_type=ProjectRegistration.AgreementType.MAIN,
+            agreement_number=f"IMCM/{self.successful_proposal.number}",
+            type=self.product,
+            name="Уже существует 2",
+            year=2026,
+            position=2,
+        )
+
+        response = self.client.post(
+            reverse("proposal_dispatch_transfer_to_contract"),
+            {"proposal_ids[]": [self.successful_proposal.pk]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["created"], 0)
+        self.assertEqual(payload["existing"], 1)
+        self.assertEqual(
+            ProjectRegistration.objects.filter(
+                number=self.successful_proposal.number,
+                group_member=self.successful_proposal.group_member,
+                agreement_type=ProjectRegistration.AgreementType.MAIN,
+                agreement_number=f"IMCM/{self.successful_proposal.number}",
+            ).count(),
+            2,
+        )
+        self.assertEqual(
+            ProjectRegistration.objects.get(pk=first_project.pk).agreement_number,
+            f"IMCM/{self.successful_proposal.number}",
+        )
+
     @override_settings(PROPOSAL_SYSTEM_FROM_EMAIL="ai@imcmontanai.ru")
     @patch("proposals_app.services.send_notification_email")
     def test_dispatch_send_updates_only_successfully_sent_rows(self, mocked_send_notification_email):
@@ -1808,6 +1856,16 @@ class ProposalRegistrationFormTests(TestCase):
         self.assertIsNotNone(currency_id)
         self.assertEqual(form.fields["currency"].queryset.get(pk=currency_id).code_alpha, "RUB")
 
+    def test_number_field_matches_zero_padded_project_range(self):
+        form = ProposalRegistrationForm()
+
+        self.assertEqual(form.fields["number"].min_value, 0)
+        self.assertEqual(form.fields["number"].max_value, 9999)
+        self.assertEqual(form.fields["number"].widget.attrs["id"], "proposal-number-input")
+        self.assertEqual(form.fields["number"].widget.attrs["min"], 0)
+        self.assertEqual(form.fields["number"].widget.attrs["max"], 9999)
+        self.assertEqual(form.fields["number"].widget.attrs["placeholder"], "0001")
+
     def test_bound_form_ignores_invalid_country_ids_when_building_region_choices(self):
         form = ProposalRegistrationForm(
             data=self._base_form_payload(
@@ -2053,7 +2111,7 @@ class ProposalRegistrationFormTests(TestCase):
         form = ProposalRegistrationForm(data={})
 
         self.assertFalse(form.is_valid())
-        self.assertEqual(form.errors["type"][0], "Обязательное поле.")
+        self.assertEqual(form.errors["number"][0], "Обязательное поле.")
 
     def test_form_uses_russian_integer_error_message(self):
         form = ProposalRegistrationForm(data=self._base_form_payload(number="abc"))
@@ -2083,6 +2141,21 @@ class ProposalRegistrationFormTests(TestCase):
         self.assertEqual(option_by_value["completed"]["label"], "Завершённое")
         self.assertTrue(option_by_value["sent"]["attrs"].get("disabled"))
         self.assertTrue(option_by_value["completed"]["attrs"].get("disabled"))
+
+    def test_form_includes_not_held_status_after_completed(self):
+        form = ProposalRegistrationForm()
+
+        choices = list(form.fields["status"].choices)
+        self.assertEqual(
+            choices,
+            [
+                ("preliminary", "Предварительное"),
+                ("final", "Итоговое"),
+                ("sent", "Отправленное"),
+                ("completed", "Завершённое"),
+                ("not_held", "Несостоявшееся"),
+            ],
+        )
 
     def test_form_rejects_manual_selection_of_non_editable_status(self):
         form = ProposalRegistrationForm(
@@ -3394,6 +3467,539 @@ class ProposalRegistrationFormTests(TestCase):
         )
 
 
+    def test_form_saves_ranked_products_and_uses_summary_commercial_payload_for_multistage(self):
+        group_member = GroupMember.objects.create(
+            short_name="IMC Montan",
+            country_name="Россия",
+            country_code="643",
+            country_alpha2="RU",
+            position=1,
+        )
+        first_product = Product.objects.create(
+            short_name="STAGE-1",
+            name_en="Stage One",
+            name_ru="Этап 1",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=1,
+        )
+        second_product = Product.objects.create(
+            short_name="STAGE-2",
+            name_en="Stage Two",
+            name_ru="Этап 2",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Оптимизация",
+            position=2,
+        )
+        totals_payload = json.dumps(
+            {
+                "exchange_rate": "95.1000",
+                "discount_percent": "5",
+                "contract_total": "1000",
+                "contract_total_auto": "1000",
+                "rub_total_service_text": "Курс ЦБ",
+                "discounted_total_service_text": "Скидка",
+                "travel_expenses_mode": "actual",
+            },
+            ensure_ascii=False,
+        )
+        payload = QueryDict("", mutable=True)
+        payload.update(
+            {
+                "number": "3333",
+                "group_member": str(group_member.pk),
+                "name": "Мультиэтапное ТКП",
+                "kind": ProposalRegistration.ProposalKind.REGULAR,
+                "status": ProposalRegistration.ProposalStatus.FINAL,
+                "year": "2026",
+            }
+        )
+        payload.setlist("type", [str(first_product.pk), str(second_product.pk)])
+        payload.setlist(
+            "type_consulting",
+            [first_product.consulting_type_display, second_product.consulting_type_display],
+        )
+        payload.setlist(
+            "type_service_category",
+            [first_product.service_category_display, second_product.service_category_display],
+        )
+        payload.setlist(
+            "type_service_subtype",
+            [first_product.service_subtype_display, second_product.service_subtype_display],
+        )
+        payload.setlist(
+            "service_sections_payload",
+            [
+                json.dumps([{"service_name": "Этап 1", "code": "1"}], ensure_ascii=False),
+                json.dumps([{"service_name": "Этап 2", "code": "2"}], ensure_ascii=False),
+            ],
+        )
+        payload.setlist("service_sections_editor_state", ["[]", "[]"])
+        payload.setlist("service_customer_tz_editor_state", ["", ""])
+        payload.setlist("service_composition_customer_tz", ["", ""])
+        payload.setlist("service_composition_mode", ["sections", "sections"])
+        payload.setlist("service_composition", ["ТЗ этапа 1", "ТЗ этапа 2"])
+        payload.setlist(
+            "commercial_offer_payload",
+            [
+                "[]",
+                json.dumps(
+                    [
+                        {
+                            "specialist": "Эксперт",
+                            "job_title": "Руководитель",
+                            "professional_status": "Senior",
+                            "service_name": "Этап 2",
+                            "rate_eur_per_day": "500",
+                            "asset_day_counts": ["2"],
+                            "total_eur_without_vat": "1000",
+                        }
+                    ],
+                    ensure_ascii=False,
+                ),
+            ],
+        )
+        payload.setlist("commercial_totals_payload", [totals_payload, totals_payload])
+        payload["summary_commercial_offer_payload"] = json.dumps(
+            [
+                {
+                    "specialist": "Эксперт",
+                    "job_title": "Руководитель",
+                    "professional_status": "Senior",
+                    "service_name": "",
+                    "rate_eur_per_day": "500",
+                    "asset_day_counts": ["2"],
+                    "total_eur_without_vat": "1000",
+                }
+            ],
+            ensure_ascii=False,
+        )
+        payload["summary_commercial_totals_payload"] = totals_payload
+        payload.setlist("evaluation_date", ["01.01.2026", "05.02.2026"])
+        payload.setlist("service_term_months", ["1.0", "2.0"])
+        payload.setlist("preliminary_report_date", ["15.01.2026", "15.04.2026"])
+        payload.setlist("final_report_term_weeks", ["2.0", "3.0"])
+        payload.setlist("final_report_date", ["29.01.2026", "06.05.2026"])
+
+        form = ProposalRegistrationForm(data=payload)
+
+        self.assertTrue(form.is_valid(), form.errors)
+        proposal = form.save(commit=False)
+        proposal.save()
+        form._save_ranked_products(proposal)
+        form.save_commercial_offers(proposal)
+        proposal.refresh_from_db()
+
+        self.assertEqual(proposal.type_id, second_product.pk)
+        self.assertEqual(
+            list(ProposalRegistrationProduct.objects.filter(proposal=proposal).order_by("rank").values_list("product_id", flat=True)),
+            [first_product.pk, second_product.pk],
+        )
+        self.assertEqual(proposal.ordered_product_ids, [first_product.pk, second_product.pk])
+        self.assertEqual(proposal.service_sections_json, [{"service_name": "Этап 2", "code": "2"}])
+        self.assertEqual(str(proposal.service_term_months), "2.0")
+        self.assertEqual(str(proposal.final_report_term_weeks), "3.0")
+        self.assertEqual(proposal.stage_payloads_json[-1]["product_id"], second_product.pk)
+        self.assertEqual(proposal.stage_payloads_json[-1]["service_composition"], "ТЗ этапа 2")
+        self.assertEqual(proposal.commercial_offers.count(), 1)
+        self.assertEqual(proposal.commercial_offers.first().specialist, "Эксперт")
+        self.assertEqual(proposal.commercial_offers.first().service_name, "")
+        self.assertEqual(proposal.commercial_totals_json["contract_total"], "1000")
+        self.assertEqual(str(proposal.service_cost), "1000.00")
+
+    def test_form_rehydrates_stage_rows_from_saved_stage_payloads(self):
+        group_member = GroupMember.objects.create(
+            short_name="IMC Montan",
+            country_name="Россия",
+            country_code="643",
+            country_alpha2="RU",
+            position=1,
+        )
+        first_product = Product.objects.create(
+            short_name="A",
+            name_en="Alpha",
+            name_ru="Альфа",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=1,
+        )
+        second_product = Product.objects.create(
+            short_name="B",
+            name_en="Beta",
+            name_ru="Бета",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Оптимизация",
+            position=2,
+        )
+        proposal = ProposalRegistration.objects.create(
+            number=3333,
+            group_member=group_member,
+            type=second_product,
+            name="ТКП",
+            year=2026,
+            stage_payloads_json=[
+                {
+                    "rank": 1,
+                    "product_id": first_product.pk,
+                    "service_sections_json": [{"service_name": "Альфа", "code": "A"}],
+                    "service_sections_editor_state": [],
+                    "service_customer_tz_editor_state": {},
+                    "service_composition_customer_tz": "",
+                    "service_composition_mode": "sections",
+                    "service_composition": "ТЗ 1",
+                    "commercial_offer_payload": [],
+                    "commercial_totals_json": {"discount_percent": "5"},
+                    "evaluation_date": "01.01.2026",
+                    "service_term_months": "1.0",
+                    "preliminary_report_date": "15.01.2026",
+                    "final_report_term_weeks": "2.0",
+                    "final_report_date": "29.01.2026",
+                },
+                {
+                    "rank": 2,
+                    "product_id": second_product.pk,
+                    "service_sections_json": [{"service_name": "Бета", "code": "B"}],
+                    "service_sections_editor_state": [],
+                    "service_customer_tz_editor_state": {},
+                    "service_composition_customer_tz": "",
+                    "service_composition_mode": "sections",
+                    "service_composition": "ТЗ 2",
+                    "commercial_offer_payload": [],
+                    "commercial_totals_json": {"discount_percent": "5"},
+                    "evaluation_date": "05.02.2026",
+                    "service_term_months": "2.0",
+                    "preliminary_report_date": "15.04.2026",
+                    "final_report_term_weeks": "3.0",
+                    "final_report_date": "06.05.2026",
+                },
+            ],
+        )
+        ProposalRegistrationProduct.objects.bulk_create(
+            [
+                ProposalRegistrationProduct(proposal=proposal, product=first_product, rank=1),
+                ProposalRegistrationProduct(proposal=proposal, product=second_product, rank=2),
+            ]
+        )
+
+        form = ProposalRegistrationForm(instance=proposal)
+
+        self.assertEqual(len(form.stage_rows), 2)
+        self.assertEqual(form.stage_rows[0]["product_id"], str(first_product.pk))
+        self.assertEqual(form.stage_rows[1]["product_id"], str(second_product.pk))
+        self.assertEqual(form.stage_rows[0]["product_short_label"], "A")
+        self.assertEqual(form.stage_rows[1]["product_short_label"], "B")
+        self.assertEqual(form.stage_rows[1]["service_composition"], "ТЗ 2")
+        self.assertEqual(form.stage_rows[1]["final_report_date"], "06.05.2026")
+
+    def test_resolve_variables_uses_summary_payload_after_multistage_save(self):
+        group_member = GroupMember.objects.create(
+            short_name="IMC Montan",
+            country_name="Россия",
+            country_code="643",
+            country_alpha2="RU",
+            position=1,
+        )
+        first_product = Product.objects.create(
+            short_name="FIRST",
+            name_en="First Product",
+            name_ru="Первый продукт",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=1,
+        )
+        second_product = Product.objects.create(
+            short_name="LAST",
+            name_en="Last Product",
+            name_ru="Последний продукт",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Оптимизация",
+            position=2,
+        )
+        ServiceGoalReport.objects.create(
+            product=first_product,
+            service_goal="Цель первого этапа",
+            service_goal_genitive="Подготовки первого этапа",
+            report_title="ТКП этап 1",
+            position=1,
+        )
+        ServiceGoalReport.objects.create(
+            product=second_product,
+            service_goal="Цель второго этапа",
+            service_goal_genitive="Подготовки второго этапа",
+            report_title="ТКП этап 2",
+            position=1,
+        )
+        totals_payload = json.dumps(
+            {
+                "exchange_rate": "95.1000",
+                "discount_percent": "0",
+                "contract_total": "1000",
+                "contract_total_auto": "1000",
+                "rub_total_service_text": "Курс ЦБ",
+                "discounted_total_service_text": "Скидка",
+                "travel_expenses_mode": "actual",
+            },
+            ensure_ascii=False,
+        )
+        payload = QueryDict("", mutable=True)
+        payload.update(
+            {
+                "number": "3333",
+                "group_member": str(group_member.pk),
+                "name": "Экспорт по последнему этапу",
+                "kind": ProposalRegistration.ProposalKind.REGULAR,
+                "status": ProposalRegistration.ProposalStatus.FINAL,
+                "year": "2026",
+            }
+        )
+        payload.setlist("type", [str(first_product.pk), str(second_product.pk)])
+        payload.setlist(
+            "type_consulting",
+            [first_product.consulting_type_display, second_product.consulting_type_display],
+        )
+        payload.setlist(
+            "type_service_category",
+            [first_product.service_category_display, second_product.service_category_display],
+        )
+        payload.setlist(
+            "type_service_subtype",
+            [first_product.service_subtype_display, second_product.service_subtype_display],
+        )
+        payload.setlist(
+            "service_sections_payload",
+            [
+                json.dumps([{"service_name": "Этап 1 услуга", "code": "S1"}], ensure_ascii=False),
+                json.dumps([{"service_name": "Этап 2 услуга", "code": "S2"}], ensure_ascii=False),
+            ],
+        )
+        payload.setlist(
+            "service_sections_editor_state",
+            [
+                json.dumps([{"html": "<p>Scope 1</p>", "plain_text": "Scope 1"}], ensure_ascii=False),
+                json.dumps([{"html": "<p><strong>Scope 2</strong></p>", "plain_text": "Scope 2"}], ensure_ascii=False),
+            ],
+        )
+        payload.setlist("service_customer_tz_editor_state", ["", ""])
+        payload.setlist("service_composition_customer_tz", ["", ""])
+        payload.setlist("service_composition_mode", ["sections", "sections"])
+        payload.setlist("service_composition", ["Описание этапа 1", "Описание этапа 2"])
+        payload.setlist(
+            "commercial_offer_payload",
+            [
+                json.dumps(
+                    [
+                        {
+                            "specialist": "Stage 1",
+                            "job_title": "Роль 1",
+                            "professional_status": "A",
+                            "service_name": "Этап 1 услуга",
+                            "rate_eur_per_day": "100",
+                            "asset_day_counts": ["1"],
+                            "total_eur_without_vat": "100",
+                        }
+                    ],
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    [
+                        {
+                            "specialist": "Stage 2",
+                            "job_title": "Роль 2",
+                            "professional_status": "B",
+                            "service_name": "Этап 2 услуга",
+                            "rate_eur_per_day": "200",
+                            "asset_day_counts": ["2"],
+                            "total_eur_without_vat": "400",
+                        }
+                    ],
+                    ensure_ascii=False,
+                ),
+            ],
+        )
+        payload.setlist("commercial_totals_payload", [totals_payload, totals_payload])
+        payload["summary_commercial_offer_payload"] = json.dumps(
+            [
+                {
+                    "specialist": "Summary expert",
+                    "job_title": "Сводная роль",
+                    "professional_status": "SUM",
+                    "service_name": "",
+                    "rate_eur_per_day": "150",
+                    "asset_day_counts": ["3"],
+                    "total_eur_without_vat": "500",
+                }
+            ],
+            ensure_ascii=False,
+        )
+        payload["summary_commercial_totals_payload"] = json.dumps(
+            {
+                "exchange_rate": "95.1000",
+                "discount_percent": "0",
+                "contract_total": "500",
+                "contract_total_auto": "500",
+                "rub_total_service_text": "Курс ЦБ",
+                "discounted_total_service_text": "Скидка",
+                "travel_expenses_mode": "actual",
+            },
+            ensure_ascii=False,
+        )
+        payload.setlist("evaluation_date", ["01.01.2026", "05.02.2026"])
+        payload.setlist("service_term_months", ["1.0", "2.0"])
+        payload.setlist("preliminary_report_date", ["15.01.2026", "15.04.2026"])
+        payload.setlist("final_report_term_weeks", ["2.0", "3.0"])
+        payload.setlist("final_report_date", ["29.01.2026", "06.05.2026"])
+
+        form = ProposalRegistrationForm(data=payload)
+
+        self.assertTrue(form.is_valid(), form.errors)
+        proposal = form.save(commit=False)
+        proposal.save()
+        form._save_ranked_products(proposal)
+        form.save_commercial_offers(proposal)
+
+        replacements, lists, tables = resolve_variables(
+            proposal,
+            [
+                ProposalVariable(key="{{service_goal_genitive}}", is_computed=True),
+                ProposalVariable(key="[[scope_of_work]]", is_computed=True),
+                ProposalVariable(key="[[budget_table]]", is_computed=True),
+            ],
+        )
+
+        self.assertEqual(proposal.type_id, second_product.pk)
+        self.assertEqual(replacements["{{service_goal_genitive}}"], "Подготовки второго этапа")
+        self.assertEqual(lists["[[scope_of_work]]"], [{"html": "<p><strong>Scope 2</strong></p>"}])
+        budget_rows = tables["[[budget_table]]"]["rows"]
+        self.assertEqual(budget_rows[1][0]["text"], "Summary expert")
+        self.assertEqual(budget_rows[1][1]["text"], "Сводная роль, SUM")
+
+    def test_multistage_fallback_aggregates_travel_day_counts_for_calculation_mode(self):
+        group_member = GroupMember.objects.create(
+            short_name="IMC Montan",
+            country_name="Россия",
+            country_code="643",
+            country_alpha2="RU",
+            position=1,
+        )
+        first_product = Product.objects.create(
+            short_name="TRAVEL-1",
+            name_en="Travel One",
+            name_ru="Командировка 1",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=1,
+        )
+        second_product = Product.objects.create(
+            short_name="TRAVEL-2",
+            name_en="Travel Two",
+            name_ru="Командировка 2",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Оптимизация",
+            position=2,
+        )
+        totals_payload = json.dumps(
+            {
+                "exchange_rate": "95.1000",
+                "discount_percent": "0",
+                "contract_total": "1000",
+                "contract_total_auto": "1000",
+                "rub_total_service_text": "Курс ЦБ",
+                "discounted_total_service_text": "Скидка",
+                "travel_expenses_mode": "calculation",
+            },
+            ensure_ascii=False,
+        )
+        payload = QueryDict("", mutable=True)
+        payload.update(
+            {
+                "number": "3333",
+                "group_member": str(group_member.pk),
+                "name": "Командировки по всем этапам",
+                "kind": ProposalRegistration.ProposalKind.REGULAR,
+                "status": ProposalRegistration.ProposalStatus.FINAL,
+                "year": "2026",
+            }
+        )
+        payload.setlist("type", [str(first_product.pk), str(second_product.pk)])
+        payload.setlist(
+            "type_consulting",
+            [first_product.consulting_type_display, second_product.consulting_type_display],
+        )
+        payload.setlist(
+            "type_service_category",
+            [first_product.service_category_display, second_product.service_category_display],
+        )
+        payload.setlist(
+            "type_service_subtype",
+            [first_product.service_subtype_display, second_product.service_subtype_display],
+        )
+        payload.setlist("service_sections_payload", ["[]", "[]"])
+        payload.setlist("service_sections_editor_state", ["[]", "[]"])
+        payload.setlist("service_customer_tz_editor_state", ["", ""])
+        payload.setlist("service_composition_customer_tz", ["", ""])
+        payload.setlist("service_composition_mode", ["sections", "sections"])
+        payload.setlist("service_composition", ["", ""])
+        payload.setlist(
+            "commercial_offer_payload",
+            [
+                json.dumps(
+                    [
+                        {
+                            "specialist": "",
+                            "job_title": "",
+                            "professional_status": "",
+                            "service_name": "Командировочные расходы, евро",
+                            "rate_eur_per_day": "",
+                            "asset_day_counts": ["1.50", "2.00"],
+                            "total_eur_without_vat": "3.50",
+                        }
+                    ],
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    [
+                        {
+                            "specialist": "",
+                            "job_title": "",
+                            "professional_status": "",
+                            "service_name": "Командировочные расходы, евро",
+                            "rate_eur_per_day": "",
+                            "asset_day_counts": ["3.00", "4.00"],
+                            "total_eur_without_vat": "7.00",
+                        }
+                    ],
+                    ensure_ascii=False,
+                ),
+            ],
+        )
+        payload.setlist("commercial_totals_payload", [totals_payload, totals_payload])
+        payload.setlist("evaluation_date", ["01.01.2026", "05.02.2026"])
+        payload.setlist("service_term_months", ["1.0", "2.0"])
+        payload.setlist("preliminary_report_date", ["15.01.2026", "15.04.2026"])
+        payload.setlist("final_report_term_weeks", ["2.0", "3.0"])
+        payload.setlist("final_report_date", ["29.01.2026", "06.05.2026"])
+
+        form = ProposalRegistrationForm(data=payload)
+
+        self.assertTrue(form.is_valid(), form.errors)
+        proposal = form.save()
+        form.save_commercial_offers(proposal)
+        proposal.refresh_from_db()
+
+        travel_offer = proposal.commercial_offers.get(service_name="Командировочные расходы, евро")
+        self.assertEqual(travel_offer.asset_day_counts, ["4.50", "6.00"])
+        self.assertEqual(str(travel_offer.total_eur_without_vat), "10.50")
+        self.assertEqual(proposal.commercial_totals_json["travel_expenses_mode"], "calculation")
+
+
 class ProposalFormContextTests(TestCase):
     def setUp(self):
         self.user = get_user_model().objects.create_user(
@@ -3951,6 +4557,69 @@ class ProposalFormContextTests(TestCase):
         self.assertContains(response, 'name="final_report_date"', html=False)
         self.assertContains(response, 'id="proposal-typical-service-terms-data"', html=False)
         self.assertContains(response, 'js-proposal-report-terms-lock', count=2, html=False)
+        self.assertContains(response, 'id="proposal-number-display"', html=False)
+        self.assertContains(response, 'placeholder="0001"', html=False)
+
+    def test_proposal_form_renders_multistage_containers(self):
+        with patch("proposals_app.forms.get_cbr_eur_rate_for_today", return_value=Decimal("95.1111")):
+            response = self.client.get(reverse("proposal_form_create"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="proposal-products-container"', html=False)
+        self.assertContains(response, 'id="proposal-service-stages-container"', html=False)
+        self.assertContains(response, 'id="proposal-commercial-stages-container"', html=False)
+        self.assertContains(response, 'id="proposal-stage-terms-tbody"', html=False)
+        self.assertContains(response, "Состав услуг / техническое задание", html=False)
+        self.assertContains(response, "Коммерческое предложение", html=False)
+        self.assertNotContains(response, "Состав услуг / техническое задание: Этап 1", html=False)
+        self.assertNotContains(response, "Коммерческое предложение: Этап 1", html=False)
+        self.assertContains(response, 'name="summary_commercial_offer_payload"', html=False)
+
+    def test_proposal_form_edit_renders_stage_titles_with_product_short_names(self):
+        first_product = Product.objects.create(
+            short_name="TDD",
+            name_en="Technical Due Diligence",
+            name_ru="ТДД",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=1,
+        )
+        second_product = Product.objects.create(
+            short_name="JORC",
+            name_en="JORC Report",
+            name_ru="JORC",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Оптимизация",
+            position=2,
+        )
+        proposal = ProposalRegistration.objects.create(
+            number=3333,
+            group_member=self.group_member,
+            type=second_product,
+            name="Мультиэтапное ТКП",
+            year=2026,
+            stage_payloads_json=[
+                {"rank": 1, "product_id": first_product.pk},
+                {"rank": 2, "product_id": second_product.pk},
+            ],
+        )
+        ProposalRegistrationProduct.objects.bulk_create(
+            [
+                ProposalRegistrationProduct(proposal=proposal, product=first_product, rank=1),
+                ProposalRegistrationProduct(proposal=proposal, product=second_product, rank=2),
+            ]
+        )
+
+        response = self.client.get(reverse("proposal_form_edit", args=[proposal.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Состав услуг / техническое задание: Этап 1 TDD", html=False)
+        self.assertContains(response, "Состав услуг / техническое задание: Этап 2 JORC", html=False)
+        self.assertContains(response, "Коммерческое предложение: Этап 1 TDD", html=False)
+        self.assertContains(response, "Коммерческое предложение: Этап 2 JORC", html=False)
+        self.assertContains(response, "Коммерческое предложение: все этапы", html=False)
 
 
 class ProposalNextcloudWorkspaceHookTests(TestCase):
@@ -4182,6 +4851,15 @@ class ProposalDispatchDiskColumnTests(TestCase):
             year=2026,
             proposal_workspace_disk_path="/Corporate Root/ТКП/2026/333300RU DD Тестовое ТКП",
         )
+
+    def test_proposals_partial_renders_zero_padded_number(self):
+        self.proposal.number = 1
+        self.proposal.save(update_fields=["number", "short_uid"])
+
+        response = self.client.get(reverse("proposals_partial"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, ">0001<", html=False)
 
     @patch("nextcloud_app.api.NextcloudApiClient.list_user_shares")
     def test_proposals_partial_renders_disk_icon_with_nextcloud_share_target(self, mocked_list_user_shares):

--- a/proposals_app/views.py
+++ b/proposals_app/views.py
@@ -28,6 +28,7 @@ from nextcloud_app.api import NextcloudApiClient, NextcloudApiError
 from nextcloud_app.models import NextcloudUserLink
 from nextcloud_app.workspace import build_proposal_workspace_path, create_proposal_workspace
 from policy_app.models import (
+    Product,
     ServiceGoalReport,
     SpecialtyTariff,
     Tariff,
@@ -35,6 +36,7 @@ from policy_app.models import (
     TypicalSectionSpecialty,
     TypicalServiceComposition,
     TypicalServiceTerm,
+    build_consulting_catalog_meta,
 )
 from projects_app.models import ProjectRegistration, ProjectRegistrationProduct, _sync_project_registration_primary_product
 from smtp_app.models import ExternalSMTPAccount
@@ -1130,6 +1132,44 @@ def _resolve_workspace_folder_file_id(workspace_path: str) -> str:
         return ""
 
 
+def _proposal_product_catalog():
+    products = list(Product.objects.order_by("position", "id"))
+    catalog_meta = build_consulting_catalog_meta()
+    consulting_types = []
+    service_categories = []
+    seen_consulting_types = set()
+    seen_service_categories = set()
+    for item in catalog_meta["consulting_types"]:
+        label = item["label"]
+        if label and label not in seen_consulting_types:
+            seen_consulting_types.add(label)
+            consulting_types.append(label)
+    for item in catalog_meta["service_categories"]:
+        label = item["label"]
+        if label and label not in seen_service_categories:
+            seen_service_categories.add(label)
+            service_categories.append(label)
+    return {
+        "consulting_types": consulting_types,
+        "service_categories": service_categories,
+        "products": [
+            {
+                "id": product.pk,
+                "label": " ".join(
+                    part
+                    for part in ((product.short_name or "").strip(), (product.display_name or "").strip())
+                    if part
+                ),
+                "short_label": (product.short_name or "").strip(),
+                "consulting_type": (product.consulting_type_display or "").strip(),
+                "service_category": (product.service_category_display or "").strip(),
+                "service_subtype": (product.service_subtype_display or "").strip(),
+            }
+            for product in products
+        ],
+    }
+
+
 def _render_proposal_form(request, *, form, action, proposal=None):
     def _section_specialty_names(section):
         names = []
@@ -1429,6 +1469,7 @@ def _render_proposal_form(request, *, form, action, proposal=None):
             "form": form,
             "action": action,
             "proposal": proposal,
+            "proposal_type_meta_json": json.dumps(_proposal_product_catalog(), ensure_ascii=False),
             "typical_sections_json": sections_map,
             "service_goal_reports_json": service_goal_reports_map,
             "typical_service_compositions_json": typical_service_compositions_map,
@@ -1567,6 +1608,7 @@ def proposal_form_create(request):
     if not getattr(proposal, "position", 0):
         proposal.position = _next_position(ProposalRegistration)
     proposal.save()
+    form._save_ranked_products(proposal)
     form.save_assets(proposal, request.user)
     form.save_legal_entities(proposal, request.user)
     form.save_objects(proposal, request.user)
@@ -1876,25 +1918,35 @@ def proposal_dispatch_transfer_to_contract(request):
                 or ""
             ).strip().upper()
             agreement_number = f"IMCM/{proposal.number}" if group_alpha2 == "RU" else ""
-            project, was_created = ProjectRegistration.objects.get_or_create(
-                number=proposal.number,
-                group_member=proposal.group_member,
-                agreement_type=ProjectRegistration.AgreementType.MAIN,
-                agreement_number=agreement_number,
-                defaults={
-                    "position": next_position,
-                    "group": proposal.group,
-                    "type": proposal.type,
-                    "name": proposal.name,
-                    "year": proposal.year,
-                    "customer": proposal.customer,
-                    "country": proposal.country,
-                    "identifier": proposal.identifier,
-                    "registration_number": proposal.registration_number,
-                    "registration_date": proposal.registration_date,
-                },
+            project = (
+                ProjectRegistration.objects
+                .filter(
+                    number=proposal.number,
+                    group_member=proposal.group_member,
+                    agreement_type=ProjectRegistration.AgreementType.MAIN,
+                    agreement_number=agreement_number,
+                )
+                .order_by("position", "id")
+                .first()
             )
+            was_created = project is None
             if was_created:
+                project = ProjectRegistration.objects.create(
+                    number=proposal.number,
+                    group_member=proposal.group_member,
+                    agreement_type=ProjectRegistration.AgreementType.MAIN,
+                    agreement_number=agreement_number,
+                    position=next_position,
+                    group=proposal.group,
+                    type=proposal.type,
+                    name=proposal.name,
+                    year=proposal.year,
+                    customer=proposal.customer,
+                    country=proposal.country,
+                    identifier=proposal.identifier,
+                    registration_number=proposal.registration_number,
+                    registration_date=proposal.registration_date,
+                )
                 if proposal.type_id:
                     ProjectRegistrationProduct.objects.update_or_create(
                         registration=project,

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,7 +22,7 @@
     <ul class="nav nav-pills flex-column gap-2 px-2 py-3">
       {% if request.user.is_staff %}
         <li class="nav-item">
-          <a class="nav-link active d-flex align-items-center" href="#notifications" data-bs-toggle="tab">
+          <a class="nav-link d-flex align-items-center" href="#notifications" data-bs-toggle="tab">
             <i class="bi bi-bell me-2"></i>
             <span class="link-text">Уведомления</span>
           </a>
@@ -205,7 +205,7 @@
   <main class="flex-grow-1 py-4 px-3" style="min-width:0; overflow-x:clip;">
     <div class="tab-content">
       <!-- Уведомления -->
-      <section id="notifications" class="tab-pane fade show active">
+      <section id="notifications" class="tab-pane fade">
         <div class="templates-bleed">
           <div class="bg-white border-bottom content-bleed-x section-header d-flex flex-column">
             <div class="px-3 d-flex justify-content-between align-items-center flex-grow-1" style="min-height: 30px;">
@@ -870,6 +870,7 @@
       {% endif %}
 
       <!-- Справочники -->
+      {% if not is_expert %}
       <section id="classifiers" class="tab-pane fade">
         <div class="d-flex templates-bleed">
           <!-- Второй уровень сайдбара для раздела "Справочники" -->
@@ -1565,6 +1566,7 @@
           </div>
         </div>
       </section>
+      {% endif %}
 
         <script>
         (function () {
@@ -2403,7 +2405,6 @@
               window.bootstrap.Tab.getOrCreateInstance(link).show();
             }
           }
-          showTabFromHash();
           window.addEventListener('hashchange', showTabFromHash);
         });
         </script>


### PR DESCRIPTION
## Summary
- update multi-stage proposal registry behavior and summary commercial block handling
- add new proposal status option and expose it in the master status filter
- allow duplicate project registrations while preserving unique project IDs

## Test plan
- [x] python3 manage.py test proposals_app.tests.ProposalRegistrationFormTests
- [x] python3 manage.py test projects_app.tests.ProjectRegistrationFormTests.test_form_allows_duplicate_project_identity_values_and_keeps_project_id_unique projects_app.tests.ProjectRegistrationRegistrySyncTests.test_manual_registration_save_allows_duplicate_identity_values proposals_app.tests.ProposalDispatchSendTests.test_dispatch_transfer_to_contract_handles_duplicate_existing_main_contracts
- [x] node --check core/static/core/js/proposals-panels.js