### PR TITLE
Add CSV import/export for business registry

### DIFF
--- a/classifiers_app/templates/classifiers_app/bei_form.html
+++ b/classifiers_app/templates/classifiers_app/bei_form.html
@@ -133,10 +133,12 @@
   var countryCodeEl = document.getElementById('id_registration_country_code_display');
   var regionCodeEl = document.getElementById('id_registration_region_code_display');
   var identifierTypeEl = document.getElementById('id_identifier_type');
+  var numberEl = document.getElementById('id_number');
   var validToEl = document.getElementById('id_valid_to');
   var isActiveEl = document.getElementById('id_is_active');
   if (!validToEl || !isActiveEl) return;
   var searchUrl = '{% url "brl_business_entity_search" %}';
+  var regionAutofillUrl = '{% url "ler_region_autofill" %}';
 
   function fitListWidth(list) {
     if (!list) return;
@@ -296,9 +298,9 @@
     regionEl.appendChild(opt);
   }
 
-  function loadRegions(countryId, preserveCurrent) {
+  function loadRegions(countryId, preserveCurrent, selectedRegion) {
     if (!countryEl || !regionEl) return;
-    var currentRegion = preserveCurrent ? (regionEl.value || '') : '';
+    var currentRegion = preserveCurrent ? (regionEl.value || '') : (selectedRegion || '');
     if (!countryId) {
       regionEl.innerHTML = '<option value="">---------</option>';
       syncRegionCode();
@@ -332,6 +334,53 @@
         regionEl.value = currentRegion;
         syncRegionCode();
       });
+  }
+
+  function bindRegionAutofill() {
+    if (!countryEl || !identifierTypeEl || !numberEl || !regionEl) return;
+    var debounce = null;
+    var requestSeq = 0;
+
+    function applyRegion(regionName) {
+      loadRegions(countryEl.value || '', false, String(regionName || '').trim());
+    }
+
+    function schedule() {
+      if (debounce) clearTimeout(debounce);
+      debounce = setTimeout(function() {
+        var seq = requestSeq + 1;
+        requestSeq = seq;
+        var countryId = String(countryEl.value || '').trim();
+        var identifier = String(identifierTypeEl.value || '').trim();
+        var registrationNumber = String(numberEl.value || '').trim();
+
+        if (!countryId) {
+          applyRegion('');
+          return;
+        }
+
+        var url = regionAutofillUrl
+          + '?country_id=' + encodeURIComponent(countryId)
+          + '&identifier=' + encodeURIComponent(identifier)
+          + '&registration_number=' + encodeURIComponent(registrationNumber);
+
+        fetch(url)
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            if (seq !== requestSeq) return;
+            applyRegion(data && data.region ? data.region : '');
+          })
+          .catch(function() {
+            if (seq !== requestSeq) return;
+            applyRegion('');
+          });
+      }, 150);
+    }
+
+    numberEl.addEventListener('input', schedule);
+    numberEl.addEventListener('change', schedule);
+    countryEl.addEventListener('change', schedule);
+    identifierTypeEl.addEventListener('change', schedule);
   }
 
   function loadIdentifierTypes(countryId, preserveCurrent) {
@@ -401,6 +450,7 @@
   validToEl.addEventListener('input', syncIsActive);
   validToEl.addEventListener('change', syncIsActive);
   bindBusinessEntityAutocomplete();
+  bindRegionAutofill();
   syncIsActive();
   syncRegionCode();
 })();

--- a/classifiers_app/tests.py
+++ b/classifiers_app/tests.py
@@ -1,4 +1,6 @@
 from datetime import date
+import csv
+import io
 import json
 
 from django.contrib.auth import get_user_model
@@ -27,7 +29,7 @@ from classifiers_app.forms import (
     BusinessEntityLegalAddressRecordForm,
     BusinessEntityRecordForm,
 )
-from classifiers_app.views import sync_autocomplete_registry_entry
+from classifiers_app.views import BUSINESS_REGISTRY_CSV_FIELDS, sync_autocomplete_registry_entry
 
 
 class OKSMCountryTests(TestCase):
@@ -1067,6 +1069,357 @@ class BusinessRegistryMasterFilterTests(TestCase):
         self.assertGreaterEqual(response.content.decode().count('hx-target="this"'), 6)
 
 
+class BusinessRegistryCsvTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="business-registry-csv-user",
+            password="secret",
+            is_staff=True,
+        )
+        self.client.force_login(self.user)
+        self.country = OKSMCountry.objects.create(
+            number=643,
+            code="643",
+            short_name="Россия",
+            full_name="Российская Федерация",
+            alpha2="RU",
+            alpha3="RUS",
+            position=1,
+        )
+        self.alpha = BusinessEntityRecord.objects.create(
+            name='ООО "Альфа"',
+            record_date=date(2024, 1, 10),
+            record_author="tester",
+            source="source-alpha",
+            comment="comment-alpha",
+            position=1,
+        )
+        self.beta = BusinessEntityRecord.objects.create(
+            name='ООО "Бета"',
+            record_date=date(2024, 1, 11),
+            record_author="tester",
+            source="source-beta",
+            comment="comment-beta",
+            position=2,
+        )
+        self.alpha_identifier = BusinessEntityIdentifierRecord.objects.create(
+            business_entity=self.alpha,
+            identifier_type="ОГРН",
+            registration_country=self.country,
+            registration_region="Москва",
+            record_date=date(2024, 1, 10),
+            record_author="tester",
+            registration_date=date(2024, 1, 10),
+            number="7700000001",
+            valid_from=date(2024, 1, 10),
+            position=1,
+        )
+        self.beta_identifier = BusinessEntityIdentifierRecord.objects.create(
+            business_entity=self.beta,
+            identifier_type="ИНН",
+            registration_country=self.country,
+            registration_region="Тюмень",
+            record_date=date(2024, 1, 11),
+            record_author="tester",
+            registration_date=date(2024, 1, 11),
+            number="7200000002",
+            valid_from=date(2024, 1, 11),
+            position=2,
+        )
+        LegalEntityRecord.objects.create(
+            attribute=LegalEntityRecord.ATTRIBUTE_NAME,
+            identifier_record=self.alpha_identifier,
+            registration_country=self.country,
+            registration_region="Москва",
+            record_date=date(2024, 1, 10),
+            record_author="tester",
+            registration_date=date(2024, 1, 10),
+            registration_number="7700000001",
+            identifier="ОГРН",
+            short_name='ООО "Альфа"',
+            full_name='Общество с ограниченной ответственностью "Альфа"',
+            name_received_date=date(2024, 1, 10),
+            position=1,
+        )
+        LegalEntityRecord.objects.create(
+            attribute=LegalEntityRecord.ATTRIBUTE_NAME,
+            identifier_record=self.beta_identifier,
+            registration_country=self.country,
+            registration_region="Тюмень",
+            record_date=date(2024, 1, 11),
+            record_author="tester",
+            registration_date=date(2024, 1, 11),
+            registration_number="7200000002",
+            identifier="ИНН",
+            short_name='ООО "Бета"',
+            full_name='Общество с ограниченной ответственностью "Бета"',
+            name_received_date=date(2024, 1, 11),
+            position=2,
+        )
+        LegalEntityRecord.objects.create(
+            attribute=LegalEntityRecord.ATTRIBUTE_LEGAL_ADDRESS,
+            identifier_record=self.alpha_identifier,
+            registration_country=self.country,
+            registration_region="Москва",
+            record_date=date(2024, 1, 10),
+            record_author="tester",
+            postal_code="101000",
+            locality="Москва",
+            street="Тверская",
+            building="1",
+            valid_from=date(2024, 1, 10),
+            position=3,
+        )
+        LegalEntityRecord.objects.create(
+            attribute=LegalEntityRecord.ATTRIBUTE_LEGAL_ADDRESS,
+            identifier_record=self.beta_identifier,
+            registration_country=self.country,
+            registration_region="Тюмень",
+            record_date=date(2024, 1, 11),
+            record_author="tester",
+            postal_code="625000",
+            locality="Тюмень",
+            street="Республики",
+            building="2",
+            valid_from=date(2024, 1, 11),
+            position=4,
+        )
+        self.event = BusinessEntityReorganizationEvent.objects.create(
+            reorganization_event_uid="00001-REO",
+            relation_type="Присоединение",
+            event_date=date(2025, 1, 10),
+            comment="Объединение реестров",
+            position=1,
+        )
+        BusinessEntityRelationRecord.objects.create(
+            event=self.event,
+            from_business_entity=self.alpha,
+            to_business_entity=self.beta,
+            position=1,
+        )
+
+    def _make_csv_upload(self, rows):
+        buffer = io.StringIO()
+        writer = csv.DictWriter(buffer, fieldnames=BUSINESS_REGISTRY_CSV_FIELDS, delimiter=";", lineterminator="\n")
+        writer.writeheader()
+        for row in rows:
+            payload = {field: "" for field in BUSINESS_REGISTRY_CSV_FIELDS}
+            payload.update(row)
+            writer.writerow(payload)
+        return SimpleUploadedFile(
+            "business-registry.csv",
+            ("\ufeff" + buffer.getvalue()).encode("utf-8"),
+            content_type="text/csv",
+        )
+
+    def test_csv_download_exports_all_business_registry_sections(self):
+        response = self.client.get(reverse("business_registry_csv_download"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv; charset=utf-8")
+        self.assertIn('attachment; filename="business-registry.csv"', response["Content-Disposition"])
+
+        rows = list(csv.DictReader(io.StringIO(response.content.decode("utf-8-sig")), delimiter=";"))
+        self.assertEqual(
+            {row["section"] for row in rows},
+            {"business_entity", "identifier", "name", "address", "relation"},
+        )
+
+        relation_row = next(row for row in rows if row["section"] == "relation")
+        self.assertEqual(relation_row["event_ref"], "00001-REO")
+        self.assertEqual(relation_row["from_business_entity_ref"], f"{self.alpha.pk:05d}-BSN")
+        self.assertEqual(relation_row["to_business_entity_ref"], f"{self.beta.pk:05d}-BSN")
+
+    def test_csv_upload_replaces_entire_business_registry(self):
+        upload = self._make_csv_upload(
+            [
+                {
+                    "section": "business_entity",
+                    "business_entity_ref": "00010-BSN",
+                    "position": "1",
+                    "business_entity_name": 'ООО "Новый источник"',
+                    "record_date": "2026-01-10",
+                    "record_author": "csv-import",
+                    "source": "csv-source",
+                    "comment": "csv-comment",
+                },
+                {
+                    "section": "business_entity",
+                    "business_entity_ref": "00011-BSN",
+                    "position": "2",
+                    "business_entity_name": 'ООО "Новый приемник"',
+                    "record_date": "2026-01-11",
+                    "record_author": "csv-import",
+                },
+                {
+                    "section": "identifier",
+                    "business_entity_ref": "00010-BSN",
+                    "identifier_ref": "00010-IDN",
+                    "position": "1",
+                    "record_date": "2026-01-10",
+                    "record_author": "csv-import",
+                    "identifier_type": "ОГРН",
+                    "registration_country_code": "643",
+                    "registration_country_name": "Россия",
+                    "registration_region": "Москва",
+                    "registration_date": "2026-01-10",
+                    "registration_number": "7701234567890",
+                    "valid_from": "2026-01-10",
+                },
+                {
+                    "section": "identifier",
+                    "business_entity_ref": "00011-BSN",
+                    "identifier_ref": "00011-IDN",
+                    "position": "2",
+                    "record_date": "2026-01-11",
+                    "record_author": "csv-import",
+                    "identifier_type": "ИНН",
+                    "registration_country_code": "643",
+                    "registration_country_name": "Россия",
+                    "registration_region": "Санкт-Петербург",
+                    "registration_date": "2026-01-11",
+                    "registration_number": "7801234567",
+                    "valid_from": "2026-01-11",
+                },
+                {
+                    "section": "name",
+                    "business_entity_ref": "00010-BSN",
+                    "identifier_ref": "00010-IDN",
+                    "position": "1",
+                    "record_date": "2026-01-10",
+                    "record_author": "csv-import",
+                    "registration_country_code": "643",
+                    "registration_country_name": "Россия",
+                    "registration_region": "Москва",
+                    "registration_date": "2026-01-10",
+                    "registration_number": "7701234567890",
+                    "identifier_value": "ОГРН",
+                    "short_name": 'ООО "Новый источник"',
+                    "full_name": 'Общество с ограниченной ответственностью "Новый источник"',
+                    "name_received_date": "2026-01-10",
+                },
+                {
+                    "section": "name",
+                    "business_entity_ref": "00011-BSN",
+                    "identifier_ref": "00011-IDN",
+                    "position": "2",
+                    "record_date": "2026-01-11",
+                    "record_author": "csv-import",
+                    "registration_country_code": "643",
+                    "registration_country_name": "Россия",
+                    "registration_region": "Санкт-Петербург",
+                    "registration_date": "2026-01-11",
+                    "registration_number": "7801234567",
+                    "identifier_value": "ИНН",
+                    "short_name": 'ООО "Новый приемник"',
+                    "full_name": 'Общество с ограниченной ответственностью "Новый приемник"',
+                    "name_received_date": "2026-01-11",
+                },
+                {
+                    "section": "address",
+                    "business_entity_ref": "00010-BSN",
+                    "identifier_ref": "00010-IDN",
+                    "position": "3",
+                    "record_date": "2026-01-10",
+                    "record_author": "csv-import",
+                    "registration_country_code": "643",
+                    "registration_country_name": "Россия",
+                    "registration_region": "Москва",
+                    "valid_from": "2026-01-10",
+                    "postal_code": "101000",
+                    "locality": "Москва",
+                    "street": "Новая",
+                    "building": "10",
+                },
+                {
+                    "section": "address",
+                    "business_entity_ref": "00011-BSN",
+                    "identifier_ref": "00011-IDN",
+                    "position": "4",
+                    "record_date": "2026-01-11",
+                    "record_author": "csv-import",
+                    "registration_country_code": "643",
+                    "registration_country_name": "Россия",
+                    "registration_region": "Санкт-Петербург",
+                    "valid_from": "2026-01-11",
+                    "postal_code": "190000",
+                    "locality": "Санкт-Петербург",
+                    "street": "Главная",
+                    "building": "11",
+                },
+                {
+                    "section": "relation",
+                    "event_ref": "90001-REO",
+                    "from_business_entity_ref": "00010-BSN",
+                    "to_business_entity_ref": "00011-BSN",
+                    "position": "1",
+                    "relation_type": "Присоединение",
+                    "event_uid": "90001-REO",
+                    "event_date": "2026-02-01",
+                    "event_position": "1",
+                    "comment": "CSV relation",
+                },
+            ]
+        )
+
+        response = self.client.post(reverse("business_registry_csv_upload"), {"csv_file": upload})
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["created"], 9)
+        self.assertEqual(BusinessEntityRecord.objects.count(), 2)
+        self.assertEqual(BusinessEntityIdentifierRecord.objects.count(), 2)
+        self.assertEqual(
+            LegalEntityRecord.objects.filter(attribute=LegalEntityRecord.ATTRIBUTE_NAME).count(),
+            2,
+        )
+        self.assertEqual(
+            LegalEntityRecord.objects.filter(attribute=LegalEntityRecord.ATTRIBUTE_LEGAL_ADDRESS).count(),
+            2,
+        )
+        self.assertEqual(BusinessEntityRelationRecord.objects.count(), 1)
+        self.assertEqual(BusinessEntityReorganizationEvent.objects.count(), 1)
+        self.assertFalse(BusinessEntityRecord.objects.filter(name='ООО "Альфа"').exists())
+        self.assertTrue(BusinessEntityRecord.objects.filter(name='ООО "Новый источник"').exists())
+        relation = BusinessEntityRelationRecord.objects.select_related("event").get()
+        self.assertEqual(relation.event.reorganization_event_uid, "90001-REO")
+        self.assertEqual(relation.event.comment, "CSV relation")
+
+    def test_csv_upload_rolls_back_when_references_are_invalid(self):
+        upload = self._make_csv_upload(
+            [
+                {
+                    "section": "business_entity",
+                    "business_entity_ref": "00020-BSN",
+                    "position": "1",
+                    "business_entity_name": 'ООО "Промежуточная"',
+                },
+                {
+                    "section": "identifier",
+                    "business_entity_ref": "missing-BSN",
+                    "identifier_ref": "00020-IDN",
+                    "position": "1",
+                    "identifier_type": "ОГРН",
+                    "registration_country_code": "643",
+                    "registration_country_name": "Россия",
+                    "registration_number": "123",
+                },
+            ]
+        )
+
+        response = self.client.post(reverse("business_registry_csv_upload"), {"csv_file": upload})
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertFalse(payload["ok"])
+        self.assertTrue(payload["warnings"])
+        self.assertTrue(BusinessEntityRecord.objects.filter(name='ООО "Альфа"').exists())
+        self.assertEqual(BusinessEntityRecord.objects.count(), 2)
+        self.assertEqual(BusinessEntityIdentifierRecord.objects.count(), 2)
+        self.assertEqual(BusinessEntityRelationRecord.objects.count(), 1)
+
+
 class BusinessEntityIdentifierFormTests(TestCase):
     def setUp(self):
         self.user = get_user_model().objects.create_user(
@@ -1101,6 +1454,14 @@ class BusinessEntityIdentifierFormTests(TestCase):
             name='ООО "Дата"',
             position=1,
         )
+
+    def test_create_form_wires_region_autofill_endpoint_for_identifier_number(self):
+        response = self.client.get(reverse("bei_form_create"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse("ler_region_autofill"))
+        self.assertContains(response, 'id="id_number"', html=False)
+        self.assertContains(response, 'id="id_registration_region"', html=False)
 
     def test_create_accepts_registration_date_in_russian_format(self):
         response = self.client.post(

--- a/classifiers_app/urls.py
+++ b/classifiers_app/urls.py
@@ -109,6 +109,8 @@ urlpatterns = [
     path("lw/<int:pk>/move-up/", views.lw_move_up, name="lw_move_up"),
     path("lw/<int:pk>/move-down/", views.lw_move_down, name="lw_move_down"),
     path("lw/csv-upload/", views.lw_csv_upload, name="lw_csv_upload"),
+    path("business-registry/csv-download/", views.business_registry_csv_download, name="business_registry_csv_download"),
+    path("business-registry/csv-upload/", views.business_registry_csv_upload, name="business_registry_csv_upload"),
     # База юридических лиц (LER)
     path("ler/search/", views.ler_search, name="ler_search"),
     path("ler/identifiers-for-country/", views.ler_identifiers_for_country, name="ler_identifiers_for_country"),

--- a/classifiers_app/views.py
+++ b/classifiers_app/views.py
@@ -91,6 +91,47 @@ BRL_TABLE_URL = "/classifiers/brl/table/"
 BUSINESS_ENTITY_SOURCE_BER = "[База юрлиц / Реестр бизнес-сущностей]"
 BUSINESS_ENTITY_SOURCE_LER = "[База юрлиц / Реестр наименований]"
 BUSINESS_ENTITY_SOURCE_BRL = "[База юрлиц / Реестр связей]"
+BUSINESS_REGISTRY_CSV_FIELDS = [
+    "section",
+    "business_entity_ref",
+    "identifier_ref",
+    "event_ref",
+    "from_business_entity_ref",
+    "to_business_entity_ref",
+    "position",
+    "business_entity_name",
+    "record_date",
+    "record_author",
+    "source",
+    "comment",
+    "identifier_type",
+    "registration_country_code",
+    "registration_country_name",
+    "registration_region",
+    "registration_date",
+    "registration_number",
+    "identifier_value",
+    "valid_from",
+    "valid_to",
+    "short_name",
+    "full_name",
+    "name_received_date",
+    "name_changed_date",
+    "postal_code",
+    "municipality",
+    "settlement",
+    "locality",
+    "district",
+    "street",
+    "building",
+    "premise",
+    "premise_part",
+    "relation_type",
+    "event_uid",
+    "event_date",
+    "event_position",
+]
+BUSINESS_REGISTRY_CSV_UPLOAD_AFFECTED = ["ber-select", "bei-select", "ler-select", "bea-select", "brl-select"]
 PAGINATION_PRESERVED_PARAMS = {
     "business_entity_ids",
     "oksm_date",
@@ -1555,6 +1596,666 @@ def _parse_csv_date(raw: str) -> date_type | None:
         except ValueError:
             continue
     return None
+
+
+def _csv_cell(value):
+    if value is None:
+        return ""
+    if isinstance(value, date_type):
+        return value.isoformat()
+    return str(value)
+
+
+def _business_entity_csv_ref(entity_id: int) -> str:
+    return f"{entity_id:05d}-BSN"
+
+
+def _identifier_csv_ref(identifier_id: int) -> str:
+    return f"{identifier_id:05d}-IDN"
+
+
+def _event_csv_ref(event) -> str:
+    value = (getattr(event, "reorganization_event_uid", "") or "").strip()
+    if value:
+        return value
+    return f"{getattr(event, 'pk', 0):05d}-REO"
+
+
+def _read_uploaded_dict_rows(csv_file):
+    if not csv_file:
+        raise ValueError("Файл не выбран.")
+    if not csv_file.name.lower().endswith(".csv"):
+        raise ValueError("Допустимы только файлы CSV.")
+
+    try:
+        raw = csv_file.read().decode("utf-8-sig")
+    except UnicodeDecodeError:
+        try:
+            csv_file.seek(0)
+            raw = csv_file.read().decode("cp1251")
+        except Exception as exc:
+            raise ValueError(
+                "Не удалось прочитать файл. Проверьте кодировку (UTF-8 или Windows-1251)."
+            ) from exc
+
+    def parse_rows(delimiter):
+        reader = csv.DictReader(io.StringIO(raw), delimiter=delimiter)
+        return reader.fieldnames or [], list(reader)
+
+    fieldnames, rows = parse_rows(";")
+    if len(fieldnames) <= 1:
+        fieldnames, rows = parse_rows(",")
+    if not fieldnames:
+        raise ValueError("Файл пуст или не содержит заголовок CSV.")
+    return fieldnames, rows
+
+
+def _parse_import_csv_date(raw_value, *, row_number, field_label, errors):
+    value = (raw_value or "").strip()
+    if not value:
+        return None
+    parsed = _parse_csv_date(value)
+    if parsed is None:
+        errors.append(f"Строка {row_number}: неверная дата в поле «{field_label}»: «{value}».")
+    return parsed
+
+
+def _parse_import_position(raw_value, *, row_number, field_label, fallback, errors):
+    value = (raw_value or "").strip()
+    if not value:
+        return fallback
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        errors.append(f"Строка {row_number}: поле «{field_label}» должно быть целым числом.")
+        return fallback
+    if parsed < 1:
+        errors.append(f"Строка {row_number}: поле «{field_label}» должно быть не меньше 1.")
+        return fallback
+    return parsed
+
+
+def _resolve_import_country(*, code, name, row_number, field_label, countries_by_code, countries_by_name, errors):
+    code_value = (code or "").strip()
+    name_value = (name or "").strip()
+    if not code_value and not name_value:
+        return None
+
+    country = None
+    if code_value:
+        country = countries_by_code.get(code_value)
+    if country is None and name_value:
+        country = countries_by_name.get(name_value.lower())
+    if country is None:
+        lookup_value = code_value or name_value
+        errors.append(f"Строка {row_number}: страна «{lookup_value}» не найдена для поля «{field_label}».")
+        return None
+    return country
+
+
+def _build_business_registry_csv_rows():
+    rows = []
+
+    for item in BusinessEntityRecord.objects.order_by("position", "id").iterator():
+        rows.append(
+            {
+                "section": "business_entity",
+                "business_entity_ref": _business_entity_csv_ref(item.pk),
+                "position": _csv_cell(item.position),
+                "business_entity_name": _csv_cell(item.name),
+                "record_date": _csv_cell(item.record_date),
+                "record_author": _csv_cell(item.record_author),
+                "source": _csv_cell(item.source),
+                "comment": _csv_cell(item.comment),
+            }
+        )
+
+    identifiers = BusinessEntityIdentifierRecord.objects.select_related("business_entity", "registration_country").order_by(
+        "position", "id"
+    )
+    for item in identifiers.iterator():
+        rows.append(
+            {
+                "section": "identifier",
+                "business_entity_ref": _business_entity_csv_ref(item.business_entity_id),
+                "identifier_ref": _identifier_csv_ref(item.pk),
+                "position": _csv_cell(item.position),
+                "record_date": _csv_cell(item.record_date),
+                "record_author": _csv_cell(item.record_author),
+                "identifier_type": _csv_cell(item.identifier_type),
+                "registration_country_code": _csv_cell(item.registration_country.code if item.registration_country_id else ""),
+                "registration_country_name": _csv_cell(item.registration_country.short_name if item.registration_country_id else ""),
+                "registration_region": _csv_cell(item.registration_region),
+                "registration_date": _csv_cell(item.registration_date),
+                "registration_number": _csv_cell(item.number),
+                "valid_from": _csv_cell(item.valid_from),
+                "valid_to": _csv_cell(item.valid_to),
+            }
+        )
+
+    legal_records = LegalEntityRecord.objects.select_related(
+        "identifier_record__business_entity",
+        "registration_country",
+    ).order_by("position", "id")
+    for item in legal_records.filter(attribute=LegalEntityRecord.ATTRIBUTE_NAME).iterator():
+        identifier_record = item.identifier_record
+        rows.append(
+            {
+                "section": "name",
+                "business_entity_ref": _business_entity_csv_ref(identifier_record.business_entity_id) if identifier_record and identifier_record.business_entity_id else "",
+                "identifier_ref": _identifier_csv_ref(identifier_record.pk) if identifier_record else "",
+                "position": _csv_cell(item.position),
+                "record_date": _csv_cell(item.record_date),
+                "record_author": _csv_cell(item.record_author),
+                "registration_country_code": _csv_cell(item.registration_country.code if item.registration_country_id else ""),
+                "registration_country_name": _csv_cell(item.registration_country.short_name if item.registration_country_id else ""),
+                "registration_region": _csv_cell(item.registration_region),
+                "registration_date": _csv_cell(item.registration_date),
+                "registration_number": _csv_cell(item.registration_number),
+                "identifier_value": _csv_cell(item.identifier),
+                "short_name": _csv_cell(item.short_name),
+                "full_name": _csv_cell(item.full_name),
+                "name_received_date": _csv_cell(item.name_received_date),
+                "name_changed_date": _csv_cell(item.name_changed_date),
+            }
+        )
+
+    for item in legal_records.filter(attribute=LegalEntityRecord.ATTRIBUTE_LEGAL_ADDRESS).iterator():
+        identifier_record = item.identifier_record
+        rows.append(
+            {
+                "section": "address",
+                "business_entity_ref": _business_entity_csv_ref(identifier_record.business_entity_id) if identifier_record and identifier_record.business_entity_id else "",
+                "identifier_ref": _identifier_csv_ref(identifier_record.pk) if identifier_record else "",
+                "position": _csv_cell(item.position),
+                "record_date": _csv_cell(item.record_date),
+                "record_author": _csv_cell(item.record_author),
+                "registration_country_code": _csv_cell(item.registration_country.code if item.registration_country_id else ""),
+                "registration_country_name": _csv_cell(item.registration_country.short_name if item.registration_country_id else ""),
+                "registration_region": _csv_cell(item.registration_region),
+                "valid_from": _csv_cell(item.valid_from),
+                "valid_to": _csv_cell(item.valid_to),
+                "postal_code": _csv_cell(item.postal_code),
+                "municipality": _csv_cell(item.municipality),
+                "settlement": _csv_cell(item.settlement),
+                "locality": _csv_cell(item.locality),
+                "district": _csv_cell(item.district),
+                "street": _csv_cell(item.street),
+                "building": _csv_cell(item.building),
+                "premise": _csv_cell(item.premise),
+                "premise_part": _csv_cell(item.premise_part),
+            }
+        )
+
+    relations = BusinessEntityRelationRecord.objects.select_related(
+        "event",
+        "from_business_entity",
+        "to_business_entity",
+    ).order_by("position", "id")
+    for item in relations.iterator():
+        event = item.event
+        rows.append(
+            {
+                "section": "relation",
+                "event_ref": _event_csv_ref(event),
+                "from_business_entity_ref": _business_entity_csv_ref(item.from_business_entity_id),
+                "to_business_entity_ref": _business_entity_csv_ref(item.to_business_entity_id),
+                "position": _csv_cell(item.position),
+                "relation_type": _csv_cell(event.relation_type if event else ""),
+                "event_uid": _csv_cell(event.reorganization_event_uid if event else ""),
+                "event_date": _csv_cell(event.event_date if event else ""),
+                "event_position": _csv_cell(event.position if event else ""),
+                "comment": _csv_cell(event.comment if event else ""),
+            }
+        )
+
+    return rows
+
+
+def _import_business_registry_csv_rows(rows):
+    errors = []
+    business_entities = []
+    identifiers = []
+    names = []
+    addresses = []
+    relations = []
+    event_definitions = {}
+    event_order = []
+
+    countries_by_code = {item.code.strip(): item for item in OKSMCountry.objects.exclude(code="")}
+    countries_by_name = {item.short_name.strip().lower(): item for item in OKSMCountry.objects.exclude(short_name="")}
+    entity_refs = set()
+    identifier_refs = set()
+    event_ref_to_uid = {}
+
+    section_positions = {
+        "business_entity": 1,
+        "identifier": 1,
+        "name": 1,
+        "address": 1,
+        "relation": 1,
+        "event": 1,
+    }
+
+    for row_number, row in enumerate(rows, start=2):
+        if not any((value or "").strip() for value in row.values()):
+            continue
+
+        section = (row.get("section") or "").strip()
+        if section not in {"business_entity", "identifier", "name", "address", "relation"}:
+            errors.append(f"Строка {row_number}: неизвестное значение в поле «section»: «{section or '—'}».")
+            continue
+
+        if section == "business_entity":
+            ref = (row.get("business_entity_ref") or "").strip()
+            if not ref:
+                errors.append(f"Строка {row_number}: отсутствует business_entity_ref.")
+                continue
+            if ref in entity_refs:
+                errors.append(f"Строка {row_number}: повторяющийся business_entity_ref «{ref}».")
+                continue
+            entity_refs.add(ref)
+            name = (row.get("business_entity_name") or "").strip()
+            if not name:
+                errors.append(f"Строка {row_number}: отсутствует наименование бизнес-сущности.")
+                continue
+            business_entities.append(
+                {
+                    "ref": ref,
+                    "name": name,
+                    "record_date": _parse_import_csv_date(
+                        row.get("record_date"),
+                        row_number=row_number,
+                        field_label="record_date",
+                        errors=errors,
+                    ),
+                    "record_author": (row.get("record_author") or "").strip(),
+                    "source": (row.get("source") or "").strip(),
+                    "comment": (row.get("comment") or "").strip(),
+                    "position": _parse_import_position(
+                        row.get("position"),
+                        row_number=row_number,
+                        field_label="position",
+                        fallback=section_positions["business_entity"],
+                        errors=errors,
+                    ),
+                }
+            )
+            section_positions["business_entity"] += 1
+            continue
+
+        if section == "identifier":
+            ref = (row.get("identifier_ref") or "").strip()
+            business_entity_ref = (row.get("business_entity_ref") or "").strip()
+            if not ref:
+                errors.append(f"Строка {row_number}: отсутствует identifier_ref.")
+                continue
+            if ref in identifier_refs:
+                errors.append(f"Строка {row_number}: повторяющийся identifier_ref «{ref}».")
+                continue
+            if not business_entity_ref:
+                errors.append(f"Строка {row_number}: отсутствует business_entity_ref для идентификатора.")
+                continue
+            identifier_refs.add(ref)
+            identifiers.append(
+                {
+                    "ref": ref,
+                    "business_entity_ref": business_entity_ref,
+                    "record_date": _parse_import_csv_date(
+                        row.get("record_date"),
+                        row_number=row_number,
+                        field_label="record_date",
+                        errors=errors,
+                    ),
+                    "record_author": (row.get("record_author") or "").strip(),
+                    "identifier_type": (row.get("identifier_type") or "").strip(),
+                    "registration_country": _resolve_import_country(
+                        code=row.get("registration_country_code"),
+                        name=row.get("registration_country_name"),
+                        row_number=row_number,
+                        field_label="registration_country_code",
+                        countries_by_code=countries_by_code,
+                        countries_by_name=countries_by_name,
+                        errors=errors,
+                    ),
+                    "registration_region": (row.get("registration_region") or "").strip(),
+                    "registration_date": _parse_import_csv_date(
+                        row.get("registration_date"),
+                        row_number=row_number,
+                        field_label="registration_date",
+                        errors=errors,
+                    ),
+                    "number": (row.get("registration_number") or "").strip(),
+                    "valid_from": _parse_import_csv_date(
+                        row.get("valid_from"),
+                        row_number=row_number,
+                        field_label="valid_from",
+                        errors=errors,
+                    ),
+                    "valid_to": _parse_import_csv_date(
+                        row.get("valid_to"),
+                        row_number=row_number,
+                        field_label="valid_to",
+                        errors=errors,
+                    ),
+                    "position": _parse_import_position(
+                        row.get("position"),
+                        row_number=row_number,
+                        field_label="position",
+                        fallback=section_positions["identifier"],
+                        errors=errors,
+                    ),
+                }
+            )
+            section_positions["identifier"] += 1
+            continue
+
+        if section in {"name", "address"}:
+            identifier_ref = (row.get("identifier_ref") or "").strip()
+            if not identifier_ref:
+                errors.append(f"Строка {row_number}: отсутствует identifier_ref для раздела «{section}».")
+                continue
+            item = {
+                "section": section,
+                "identifier_ref": identifier_ref,
+                "business_entity_ref": (row.get("business_entity_ref") or "").strip(),
+                "record_date": _parse_import_csv_date(
+                    row.get("record_date"),
+                    row_number=row_number,
+                    field_label="record_date",
+                    errors=errors,
+                ),
+                "record_author": (row.get("record_author") or "").strip(),
+                "registration_country": _resolve_import_country(
+                    code=row.get("registration_country_code"),
+                    name=row.get("registration_country_name"),
+                    row_number=row_number,
+                    field_label="registration_country_code",
+                    countries_by_code=countries_by_code,
+                    countries_by_name=countries_by_name,
+                    errors=errors,
+                ),
+                "registration_region": (row.get("registration_region") or "").strip(),
+                "registration_date": _parse_import_csv_date(
+                    row.get("registration_date"),
+                    row_number=row_number,
+                    field_label="registration_date",
+                    errors=errors,
+                ),
+                "registration_number": (row.get("registration_number") or "").strip(),
+                "identifier_value": (row.get("identifier_value") or "").strip(),
+                "short_name": (row.get("short_name") or "").strip(),
+                "full_name": (row.get("full_name") or "").strip(),
+                "name_received_date": _parse_import_csv_date(
+                    row.get("name_received_date"),
+                    row_number=row_number,
+                    field_label="name_received_date",
+                    errors=errors,
+                ),
+                "name_changed_date": _parse_import_csv_date(
+                    row.get("name_changed_date"),
+                    row_number=row_number,
+                    field_label="name_changed_date",
+                    errors=errors,
+                ),
+                "postal_code": (row.get("postal_code") or "").strip(),
+                "municipality": (row.get("municipality") or "").strip(),
+                "settlement": (row.get("settlement") or "").strip(),
+                "locality": (row.get("locality") or "").strip(),
+                "district": (row.get("district") or "").strip(),
+                "street": (row.get("street") or "").strip(),
+                "building": (row.get("building") or "").strip(),
+                "premise": (row.get("premise") or "").strip(),
+                "premise_part": (row.get("premise_part") or "").strip(),
+                "valid_from": _parse_import_csv_date(
+                    row.get("valid_from"),
+                    row_number=row_number,
+                    field_label="valid_from",
+                    errors=errors,
+                ),
+                "valid_to": _parse_import_csv_date(
+                    row.get("valid_to"),
+                    row_number=row_number,
+                    field_label="valid_to",
+                    errors=errors,
+                ),
+                "position": _parse_import_position(
+                    row.get("position"),
+                    row_number=row_number,
+                    field_label="position",
+                    fallback=section_positions[section],
+                    errors=errors,
+                ),
+            }
+            if section == "name" and not item["short_name"]:
+                errors.append(f"Строка {row_number}: отсутствует short_name для раздела «name».")
+            if section == "name":
+                names.append(item)
+            else:
+                addresses.append(item)
+            section_positions[section] += 1
+            continue
+
+        event_ref = (row.get("event_ref") or "").strip()
+        from_ref = (row.get("from_business_entity_ref") or "").strip()
+        to_ref = (row.get("to_business_entity_ref") or "").strip()
+        if not event_ref:
+            errors.append(f"Строка {row_number}: отсутствует event_ref для связи.")
+            continue
+        if not from_ref or not to_ref:
+            errors.append(f"Строка {row_number}: для связи должны быть заполнены from_business_entity_ref и to_business_entity_ref.")
+            continue
+        event_uid = (row.get("event_uid") or "").strip() or event_ref
+        event_definition = {
+            "event_uid": event_uid,
+            "relation_type": (row.get("relation_type") or "").strip(),
+            "event_date": _parse_import_csv_date(
+                row.get("event_date"),
+                row_number=row_number,
+                field_label="event_date",
+                errors=errors,
+            ),
+            "comment": (row.get("comment") or "").strip(),
+            "position": _parse_import_position(
+                row.get("event_position"),
+                row_number=row_number,
+                field_label="event_position",
+                fallback=section_positions["event"],
+                errors=errors,
+            ),
+        }
+        existing_event = event_definitions.get(event_ref)
+        if existing_event and existing_event != event_definition:
+            errors.append(f"Строка {row_number}: данные события «{event_ref}» конфликтуют с предыдущими строками.")
+        elif not existing_event:
+            event_definitions[event_ref] = event_definition
+            event_order.append(event_ref)
+            section_positions["event"] += 1
+        owner_ref = event_ref_to_uid.get(event_uid)
+        if owner_ref and owner_ref != event_ref:
+            errors.append(f"Строка {row_number}: event_uid «{event_uid}» используется для разных событий.")
+        else:
+            event_ref_to_uid[event_uid] = event_ref
+        relations.append(
+            {
+                "event_ref": event_ref,
+                "from_business_entity_ref": from_ref,
+                "to_business_entity_ref": to_ref,
+                "position": _parse_import_position(
+                    row.get("position"),
+                    row_number=row_number,
+                    field_label="position",
+                    fallback=section_positions["relation"],
+                    errors=errors,
+                ),
+            }
+        )
+        section_positions["relation"] += 1
+
+    entity_ref_map = {item["ref"]: item for item in business_entities}
+    identifier_ref_map = {item["ref"]: item for item in identifiers}
+
+    for item in identifiers:
+        if item["business_entity_ref"] not in entity_ref_map:
+            errors.append(
+                f"Идентификатор «{item['ref']}» ссылается на отсутствующую бизнес-сущность «{item['business_entity_ref']}»."
+            )
+
+    for item in names + addresses:
+        owner = identifier_ref_map.get(item["identifier_ref"])
+        if owner is None:
+            errors.append(f"Запись раздела «{item['section']}» ссылается на отсутствующий identifier_ref «{item['identifier_ref']}».")
+            continue
+        if item["business_entity_ref"] and item["business_entity_ref"] != owner["business_entity_ref"]:
+            errors.append(
+                f"Запись раздела «{item['section']}» с identifier_ref «{item['identifier_ref']}» указывает неверный business_entity_ref «{item['business_entity_ref']}»."
+            )
+
+    for item in relations:
+        if item["from_business_entity_ref"] not in entity_ref_map:
+            errors.append(
+                f"Связь с event_ref «{item['event_ref']}» ссылается на отсутствующий from_business_entity_ref «{item['from_business_entity_ref']}»."
+            )
+        if item["to_business_entity_ref"] not in entity_ref_map:
+            errors.append(
+                f"Связь с event_ref «{item['event_ref']}» ссылается на отсутствующий to_business_entity_ref «{item['to_business_entity_ref']}»."
+            )
+
+    if errors:
+        raise ValueError(errors)
+
+    created_counts = {
+        "business_entities": 0,
+        "identifiers": 0,
+        "names": 0,
+        "addresses": 0,
+        "relations": 0,
+        "events": 0,
+    }
+
+    with transaction.atomic():
+        BusinessEntityRelationRecord.objects.all().delete()
+        BusinessEntityReorganizationEvent.objects.all().delete()
+        LegalEntityRecord.objects.filter(
+            attribute__in=[
+                LegalEntityRecord.ATTRIBUTE_NAME,
+                LegalEntityRecord.ATTRIBUTE_LEGAL_ADDRESS,
+            ]
+        ).delete()
+        BusinessEntityIdentifierRecord.objects.all().delete()
+        BusinessEntityRecord.objects.all().delete()
+
+        created_entities = {}
+        for item in business_entities:
+            created_entities[item["ref"]] = BusinessEntityRecord.objects.create(
+                name=item["name"],
+                record_date=item["record_date"],
+                record_author=item["record_author"],
+                source=item["source"],
+                comment=item["comment"],
+                position=item["position"],
+            )
+            created_counts["business_entities"] += 1
+
+        created_identifiers = {}
+        for item in identifiers:
+            created_identifiers[item["ref"]] = BusinessEntityIdentifierRecord.objects.create(
+                business_entity=created_entities[item["business_entity_ref"]],
+                identifier_type=item["identifier_type"],
+                registration_country=item["registration_country"],
+                registration_region=item["registration_region"],
+                record_date=item["record_date"],
+                record_author=item["record_author"],
+                registration_date=item["registration_date"],
+                number=item["number"],
+                valid_from=item["valid_from"],
+                valid_to=item["valid_to"],
+                position=item["position"],
+            )
+            created_counts["identifiers"] += 1
+
+        for item in names:
+            LegalEntityRecord.objects.create(
+                attribute=LegalEntityRecord.ATTRIBUTE_NAME,
+                identifier_record=created_identifiers[item["identifier_ref"]],
+                registration_country=item["registration_country"],
+                registration_region=item["registration_region"],
+                record_date=item["record_date"],
+                record_author=item["record_author"],
+                registration_date=item["registration_date"],
+                registration_number=item["registration_number"],
+                identifier=item["identifier_value"],
+                short_name=item["short_name"],
+                full_name=item["full_name"],
+                name_received_date=item["name_received_date"],
+                name_changed_date=item["name_changed_date"],
+                position=item["position"],
+            )
+            created_counts["names"] += 1
+
+        for item in addresses:
+            LegalEntityRecord.objects.create(
+                attribute=LegalEntityRecord.ATTRIBUTE_LEGAL_ADDRESS,
+                identifier_record=created_identifiers[item["identifier_ref"]],
+                registration_country=item["registration_country"],
+                registration_region=item["registration_region"],
+                record_date=item["record_date"],
+                record_author=item["record_author"],
+                postal_code=item["postal_code"],
+                municipality=item["municipality"],
+                settlement=item["settlement"],
+                locality=item["locality"],
+                district=item["district"],
+                street=item["street"],
+                building=item["building"],
+                premise=item["premise"],
+                premise_part=item["premise_part"],
+                valid_from=item["valid_from"],
+                valid_to=item["valid_to"],
+                position=item["position"],
+            )
+            created_counts["addresses"] += 1
+
+        created_events = {}
+        for event_ref in event_order:
+            definition = event_definitions[event_ref]
+            created_events[event_ref] = BusinessEntityReorganizationEvent.objects.create(
+                reorganization_event_uid=definition["event_uid"],
+                relation_type=definition["relation_type"],
+                event_date=definition["event_date"],
+                comment=definition["comment"],
+                position=definition["position"],
+            )
+            created_counts["events"] += 1
+
+        for item in relations:
+            BusinessEntityRelationRecord.objects.create(
+                event=created_events[item["event_ref"]],
+                from_business_entity=created_entities[item["from_business_entity_ref"]],
+                to_business_entity=created_entities[item["to_business_entity_ref"]],
+                position=item["position"],
+            )
+            created_counts["relations"] += 1
+
+    total_created = (
+        created_counts["business_entities"]
+        + created_counts["identifiers"]
+        + created_counts["names"]
+        + created_counts["addresses"]
+        + created_counts["relations"]
+    )
+    return {
+        "ok": True,
+        "created": total_created,
+        "summary": [
+            f"Бизнес-сущности: {created_counts['business_entities']}",
+            f"Идентификаторы: {created_counts['identifiers']}",
+            f"Наименования: {created_counts['names']}",
+            f"Юридические адреса: {created_counts['addresses']}",
+            f"Связи: {created_counts['relations']}",
+            f"События реорганизации: {created_counts['events']}",
+        ],
+    }
 
 
 @login_required
@@ -3898,3 +4599,63 @@ def ler_csv_upload(request):
     if errors:
         result["warnings"] = errors[:50]
     return JsonResponse(result)
+
+
+@login_required
+@user_passes_test(staff_required)
+@require_http_methods(["GET"])
+def business_registry_csv_download(request):
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=BUSINESS_REGISTRY_CSV_FIELDS, delimiter=";", lineterminator="\n")
+    writer.writeheader()
+    for row in _build_business_registry_csv_rows():
+        writer.writerow({field: row.get(field, "") for field in BUSINESS_REGISTRY_CSV_FIELDS})
+
+    response = HttpResponse("\ufeff" + output.getvalue(), content_type="text/csv; charset=utf-8")
+    response["Content-Disposition"] = 'attachment; filename="business-registry.csv"'
+    return response
+
+
+@login_required
+@user_passes_test(staff_required)
+@require_POST
+def business_registry_csv_upload(request):
+    try:
+        fieldnames, rows = _read_uploaded_dict_rows(request.FILES.get("csv_file"))
+    except ValueError as exc:
+        return JsonResponse({"ok": False, "error": str(exc)}, status=400)
+
+    missing_headers = [field for field in BUSINESS_REGISTRY_CSV_FIELDS if field not in fieldnames]
+    if missing_headers:
+        return JsonResponse(
+            {
+                "ok": False,
+                "error": "CSV не соответствует ожидаемому формату.",
+                "warnings": [f"Отсутствуют колонки: {', '.join(missing_headers)}"],
+            },
+            status=400,
+        )
+
+    try:
+        payload = _import_business_registry_csv_rows(rows)
+    except ValueError as exc:
+        warnings = list(exc.args[0]) if exc.args and isinstance(exc.args[0], list) else [str(exc)]
+        return JsonResponse(
+            {
+                "ok": False,
+                "error": "CSV содержит ошибки в данных.",
+                "warnings": warnings[:50],
+            },
+            status=400,
+        )
+    except Exception as exc:
+        logger.exception("Business registry CSV import failed")
+        return JsonResponse(
+            {
+                "ok": False,
+                "error": f"Не удалось импортировать CSV: {exc}",
+            },
+            status=400,
+        )
+
+    return JsonResponse(payload)

--- a/core/static/core/js/classifiers-panels.js
+++ b/core/static/core/js/classifiers-panels.js
@@ -1083,6 +1083,13 @@
       }
       if (data.ok) {
         var html = '<div class="mb-2"><strong>Создано строк: ' + data.created + '</strong></div>';
+        if (data.summary && data.summary.length) {
+          html += '<div class="text-muted mb-2">';
+          for (var summaryIdx = 0; summaryIdx < data.summary.length; summaryIdx++) {
+            html += '<div class="mb-1">' + esc(data.summary[summaryIdx]) + '</div>';
+          }
+          html += '</div>';
+        }
         if (data.updated) {
           html += '<div class="mb-2"><strong>Обновлено строк: ' + data.updated + '</strong></div>';
         }
@@ -1114,7 +1121,10 @@
           html += '</div>';
         }
         showCsvResult(html);
-        if (refreshName && TABLE_CONFIG[refreshName]) {
+        if (uploadOptions.refreshAllBusinessRegistries) {
+          await initBusinessEntityMasterFilter(true);
+          await refreshBusinessRegistryTablesLatest();
+        } else if (refreshName && TABLE_CONFIG[refreshName]) {
           await refreshTable(refreshName);
         } else {
           await htmx.ajax('GET', '/classifiers/partial/' + filterQueryString(), {
@@ -1122,7 +1132,16 @@
           });
         }
       } else {
-        showCsvResult('<div class="text-danger"><strong>Ошибка:</strong> ' + esc(data.error || 'Неизвестная ошибка') + '</div>');
+        var errorHtml = '<div class="text-danger"><strong>Ошибка:</strong> ' + esc(data.error || 'Неизвестная ошибка') + '</div>';
+        if (data.warnings && data.warnings.length) {
+          errorHtml += '<div class="text-danger mt-2"><strong>Детали (' + data.warnings.length + '):</strong></div>';
+          errorHtml += '<div class="text-danger" style="max-height:200px;overflow-y:auto;">';
+          for (var warningIdx = 0; warningIdx < data.warnings.length; warningIdx++) {
+            errorHtml += '<div class="mb-1">' + esc(data.warnings[warningIdx]) + '</div>';
+          }
+          errorHtml += '</div>';
+        }
+        showCsvResult(errorHtml);
       }
     } catch (err) {
       showCsvResult('<div class="text-danger"><strong>Ошибка загрузки:</strong> ' + esc(err.message) + '</div>');
@@ -1131,7 +1150,13 @@
 
   // CSV upload buttons (OKSM + OKV)
   document.addEventListener('click', function (e) {
+    var downloadBtn = e.target.closest('#ber-csv-download-btn');
+    if (downloadBtn) {
+      window.location.href = '/classifiers/business-registry/csv-download/';
+      return;
+    }
     var mapping = {
+      'ber-csv-upload-btn': 'ber-csv-file-input',
       'oksm-csv-upload-btn': 'oksm-csv-file-input',
       'okv-csv-upload-btn': 'okv-csv-file-input',
       'numcap-csv-upload-btn': 'numcap-csv-file-input',
@@ -1152,6 +1177,7 @@
 
   document.addEventListener('change', async function (e) {
     var mapping = {
+      'ber-csv-file-input': { url: '/classifiers/business-registry/csv-upload/', refresh: null, refreshAllBusinessRegistries: true },
       'oksm-csv-file-input': { url: '/classifiers/oksm/csv-upload/', refresh: null },
       'okv-csv-file-input':  { url: '/classifiers/okv/csv-upload/',  refresh: null },
       'numcap-csv-file-input': { url: '/classifiers/numcap/csv-upload/', refresh: 'numcap-select', sequential: true, replaceFirstOnly: true },

--- a/core/static/core/js/ui-prefs-restore.js
+++ b/core/static/core/js/ui-prefs-restore.js
@@ -97,7 +97,7 @@
   function restoreMainTab() {
     if (!window.bootstrap) return;
     var savedTab = P.get('main:tab', null);
-    var targetTab = savedTab || window.location.hash;
+    var targetTab = window.location.hash || savedTab;
     var link = targetTab
       ? document.querySelector('#sidebar a[href="' + targetTab + '"][data-bs-toggle="tab"]')
       : null;

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -1066,6 +1066,50 @@ class ProposalDispatchSendTests(TestCase):
         )
         self.assertTrue(self.successful_proposal.transfer_to_contract_date)
 
+    def test_dispatch_transfer_to_contract_copies_all_ranked_proposal_products_when_creating_project(self):
+        second_product = Product.objects.create(
+            short_name="QAQC_MULTI",
+            name_en="QAQC Multi",
+            name_ru="QAQC Multi",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Контроль качества",
+            position=2,
+        )
+        ProposalRegistrationProduct.objects.create(
+            proposal=self.successful_proposal,
+            product=second_product,
+            rank=1,
+        )
+        ProposalRegistrationProduct.objects.create(
+            proposal=self.successful_proposal,
+            product=self.product,
+            rank=2,
+        )
+
+        response = self.client.post(
+            reverse("proposal_dispatch_transfer_to_contract"),
+            {"proposal_ids[]": [self.successful_proposal.pk]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        project = ProjectRegistration.objects.get(
+            number=self.successful_proposal.number,
+            group_member=self.successful_proposal.group_member,
+            agreement_type=ProjectRegistration.AgreementType.MAIN,
+            agreement_number=f"IMCM/{self.successful_proposal.number}",
+        )
+        self.assertEqual(
+            list(
+                ProjectRegistrationProduct.objects
+                .filter(registration=project)
+                .order_by("rank", "id")
+                .values_list("product_id", flat=True)
+            ),
+            [second_product.pk, self.product.pk],
+        )
+        self.assertEqual(project.type_id, second_product.pk)
+
     def test_dispatch_transfer_to_contract_reuses_existing_main_contract_for_ru_group(self):
         existing_project = ProjectRegistration.objects.create(
             number=self.successful_proposal.number,
@@ -1099,6 +1143,55 @@ class ProposalDispatchSendTests(TestCase):
             ProjectRegistration.objects.get(pk=existing_project.pk).agreement_number,
             f"IMCM/{self.successful_proposal.number}",
         )
+
+    def test_dispatch_transfer_to_contract_copies_all_ranked_proposal_products_to_existing_project_without_links(self):
+        second_product = Product.objects.create(
+            short_name="CTRL_EXISTING",
+            name_en="Control Existing",
+            name_ru="Control Existing",
+            consulting_type="Горный",
+            service_category="Контроль",
+            service_subtype="Контроль качества",
+            position=2,
+        )
+        ProposalRegistrationProduct.objects.create(
+            proposal=self.successful_proposal,
+            product=second_product,
+            rank=1,
+        )
+        ProposalRegistrationProduct.objects.create(
+            proposal=self.successful_proposal,
+            product=self.product,
+            rank=2,
+        )
+        existing_project = ProjectRegistration.objects.create(
+            number=self.successful_proposal.number,
+            group_member=self.successful_proposal.group_member,
+            agreement_type=ProjectRegistration.AgreementType.MAIN,
+            agreement_number=f"IMCM/{self.successful_proposal.number}",
+            type=self.product,
+            name="Уже существует",
+            year=2026,
+            position=1,
+        )
+
+        response = self.client.post(
+            reverse("proposal_dispatch_transfer_to_contract"),
+            {"proposal_ids[]": [self.successful_proposal.pk]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            list(
+                ProjectRegistrationProduct.objects
+                .filter(registration=existing_project)
+                .order_by("rank", "id")
+                .values_list("product_id", flat=True)
+            ),
+            [second_product.pk, self.product.pk],
+        )
+        existing_project.refresh_from_db()
+        self.assertEqual(existing_project.type_id, second_product.pk)
 
     def test_dispatch_transfer_to_contract_handles_duplicate_existing_main_contracts(self):
         first_project = ProjectRegistration.objects.create(

--- a/proposals_app/views.py
+++ b/proposals_app/views.py
@@ -1900,6 +1900,7 @@ def proposal_dispatch_transfer_to_contract(request):
         ProposalRegistration.objects
         .filter(pk__in=proposal_ids)
         .select_related("group_member", "type", "country")
+        .prefetch_related("product_links__product")
         .order_by("position", "id")
     )
     if len(proposals) != len(proposal_ids):
@@ -1908,6 +1909,28 @@ def proposal_dispatch_transfer_to_contract(request):
     created = 0
     existing = 0
     transferred_at_display = timezone.localtime().strftime("%d.%m.%Y %H:%M")
+
+    def iter_ranked_proposal_products(proposal):
+        links = list(getattr(proposal, "product_links", []).all()) if hasattr(getattr(proposal, "product_links", None), "all") else []
+        if links:
+            for index, link in enumerate(sorted(links, key=lambda item: ((item.rank or 0), item.pk or 0)), start=1):
+                if getattr(link, "product_id", None):
+                    yield link.product, index
+            return
+        if proposal.type_id:
+            yield proposal.type, 1
+
+    def sync_project_products_from_proposal(project, proposal):
+        has_products = False
+        for product, rank in iter_ranked_proposal_products(proposal):
+            has_products = True
+            ProjectRegistrationProduct.objects.update_or_create(
+                registration=project,
+                product=product,
+                defaults={"rank": rank},
+            )
+        if has_products:
+            _sync_project_registration_primary_product(project.pk)
 
     with transaction.atomic():
         next_position = (ProjectRegistration.objects.aggregate(mx=Max("position")).get("mx") or 0) + 1
@@ -1947,23 +1970,12 @@ def proposal_dispatch_transfer_to_contract(request):
                     registration_number=proposal.registration_number,
                     registration_date=proposal.registration_date,
                 )
-                if proposal.type_id:
-                    ProjectRegistrationProduct.objects.update_or_create(
-                        registration=project,
-                        product=proposal.type,
-                        defaults={"rank": 1},
-                    )
-                    _sync_project_registration_primary_product(project.pk)
+                sync_project_products_from_proposal(project, proposal)
                 created += 1
                 next_position += 1
             else:
-                if proposal.type_id and not project.product_links.exists():
-                    ProjectRegistrationProduct.objects.update_or_create(
-                        registration=project,
-                        product=proposal.type,
-                        defaults={"rank": 1},
-                    )
-                    _sync_project_registration_primary_product(project.pk)
+                if not project.product_links.exists():
+                    sync_project_products_from_proposal(project, proposal)
                 existing += 1
 
         ProposalRegistration.objects.filter(pk__in=proposal_ids).update(

--- a/templates/index.html
+++ b/templates/index.html
@@ -996,6 +996,19 @@
                                 hx-swap="innerHTML">
                           <i class="bi bi-plus-circle me-2"></i>Добавить строку
                         </button>
+                        <button type="button"
+                                id="ber-csv-download-btn"
+                                class="btn btn-primary btn-sm d-flex align-items-center"
+                                title="Скачать CSV">
+                          <i class="bi bi-cloud-arrow-down me-2"></i>Скачать CSV
+                        </button>
+                        <button type="button"
+                                id="ber-csv-upload-btn"
+                                class="btn btn-primary btn-sm d-flex align-items-center"
+                                title="Загрузить CSV">
+                          <i class="bi bi-cloud-arrow-up me-2"></i>Загрузить CSV
+                        </button>
+                        <input type="file" id="ber-csv-file-input" accept=".csv" style="display:none;">
                         <div id="ber-actions" class="d-none d-flex">
                           <div class="btn-group">
                             <button type="button" id="ber-actions-up" data-panel-action="up" class="btn btn-outline-primary btn-sm h-100 py-0" title="Переместить вверх" aria-label="Переместить вверх">


### PR DESCRIPTION
## Summary
- add CSV download/upload for the full business registry
- import/export business entities, identifiers, names, addresses, and relations in one file
- add tests for export, replace-all import, and invalid CSV rollback
## Test plan
- [ ] python3 manage.py test classifiers_app.tests.BusinessRegistryCsvTests --verbosity 2