### PR TITLE
Fix worktime CSV week-scoped assignments

### DIFF
--- a/classifiers_app/templates/classifiers_app/bei_form.html
+++ b/classifiers_app/templates/classifiers_app/bei_form.html
@@ -341,8 +341,8 @@
     var debounce = null;
     var requestSeq = 0;
 
-    function applyRegion(regionName) {
-      loadRegions(countryEl.value || '', false, String(regionName || '').trim());
+    function applyRegion(regionName, preserveCurrent) {
+      loadRegions(countryEl.value || '', !!preserveCurrent, String(regionName || '').trim());
     }
 
     function schedule() {
@@ -355,7 +355,7 @@
         var registrationNumber = String(numberEl.value || '').trim();
 
         if (!countryId) {
-          applyRegion('');
+          applyRegion('', false);
           return;
         }
 
@@ -368,11 +368,16 @@
           .then(function(r) { return r.json(); })
           .then(function(data) {
             if (seq !== requestSeq) return;
-            applyRegion(data && data.region ? data.region : '');
+            var suggestedRegion = data && data.region ? String(data.region).trim() : '';
+            if (suggestedRegion) {
+              applyRegion(suggestedRegion, false);
+              return;
+            }
+            applyRegion('', true);
           })
           .catch(function() {
             if (seq !== requestSeq) return;
-            applyRegion('');
+            applyRegion('', true);
           });
       }, 150);
     }

--- a/classifiers_app/tests.py
+++ b/classifiers_app/tests.py
@@ -1419,6 +1419,126 @@ class BusinessRegistryCsvTests(TestCase):
         self.assertEqual(BusinessEntityIdentifierRecord.objects.count(), 2)
         self.assertEqual(BusinessEntityRelationRecord.objects.count(), 1)
 
+    def test_csv_upload_accepts_multiple_relations_for_same_event_without_event_position(self):
+        upload = self._make_csv_upload(
+            [
+                {
+                    "section": "business_entity",
+                    "business_entity_ref": "00030-BSN",
+                    "position": "1",
+                    "business_entity_name": 'ООО "Источник 1"',
+                },
+                {
+                    "section": "business_entity",
+                    "business_entity_ref": "00031-BSN",
+                    "position": "2",
+                    "business_entity_name": 'ООО "Источник 2"',
+                },
+                {
+                    "section": "business_entity",
+                    "business_entity_ref": "00032-BSN",
+                    "position": "3",
+                    "business_entity_name": 'ООО "Приемник"',
+                },
+                {
+                    "section": "identifier",
+                    "business_entity_ref": "00030-BSN",
+                    "identifier_ref": "00030-IDN",
+                    "position": "1",
+                    "registration_country_code": "643",
+                    "registration_country_name": "Россия",
+                },
+                {
+                    "section": "identifier",
+                    "business_entity_ref": "00031-BSN",
+                    "identifier_ref": "00031-IDN",
+                    "position": "2",
+                    "registration_country_code": "643",
+                    "registration_country_name": "Россия",
+                },
+                {
+                    "section": "identifier",
+                    "business_entity_ref": "00032-BSN",
+                    "identifier_ref": "00032-IDN",
+                    "position": "3",
+                    "registration_country_code": "643",
+                    "registration_country_name": "Россия",
+                },
+                {
+                    "section": "name",
+                    "business_entity_ref": "00030-BSN",
+                    "identifier_ref": "00030-IDN",
+                    "position": "1",
+                    "short_name": 'ООО "Источник 1"',
+                },
+                {
+                    "section": "name",
+                    "business_entity_ref": "00031-BSN",
+                    "identifier_ref": "00031-IDN",
+                    "position": "2",
+                    "short_name": 'ООО "Источник 2"',
+                },
+                {
+                    "section": "name",
+                    "business_entity_ref": "00032-BSN",
+                    "identifier_ref": "00032-IDN",
+                    "position": "3",
+                    "short_name": 'ООО "Приемник"',
+                },
+                {
+                    "section": "address",
+                    "business_entity_ref": "00030-BSN",
+                    "identifier_ref": "00030-IDN",
+                    "position": "4",
+                },
+                {
+                    "section": "address",
+                    "business_entity_ref": "00031-BSN",
+                    "identifier_ref": "00031-IDN",
+                    "position": "5",
+                },
+                {
+                    "section": "address",
+                    "business_entity_ref": "00032-BSN",
+                    "identifier_ref": "00032-IDN",
+                    "position": "6",
+                },
+                {
+                    "section": "relation",
+                    "event_ref": "90010-REO",
+                    "from_business_entity_ref": "00030-BSN",
+                    "to_business_entity_ref": "00032-BSN",
+                    "position": "1",
+                    "relation_type": "Слияние",
+                    "event_uid": "90010-REO",
+                    "event_date": "2026-03-01",
+                    "comment": "two sources",
+                },
+                {
+                    "section": "relation",
+                    "event_ref": "90010-REO",
+                    "from_business_entity_ref": "00031-BSN",
+                    "to_business_entity_ref": "00032-BSN",
+                    "position": "2",
+                    "relation_type": "Слияние",
+                    "event_uid": "90010-REO",
+                    "event_date": "2026-03-01",
+                    "comment": "two sources",
+                },
+            ]
+        )
+
+        response = self.client.post(reverse("business_registry_csv_upload"), {"csv_file": upload})
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["ok"])
+        self.assertEqual(BusinessEntityReorganizationEvent.objects.count(), 1)
+        self.assertEqual(BusinessEntityRelationRecord.objects.count(), 2)
+        event = BusinessEntityReorganizationEvent.objects.get()
+        self.assertEqual(event.reorganization_event_uid, "90010-REO")
+        self.assertEqual(event.position, 1)
+
 
 class BusinessEntityIdentifierFormTests(TestCase):
     def setUp(self):

--- a/classifiers_app/views.py
+++ b/classifiers_app/views.py
@@ -2046,6 +2046,8 @@ def _import_business_registry_csv_rows(rows):
             errors.append(f"Строка {row_number}: для связи должны быть заполнены from_business_entity_ref и to_business_entity_ref.")
             continue
         event_uid = (row.get("event_uid") or "").strip() or event_ref
+        existing_event = event_definitions.get(event_ref)
+        event_position_fallback = existing_event["position"] if existing_event else section_positions["event"]
         event_definition = {
             "event_uid": event_uid,
             "relation_type": (row.get("relation_type") or "").strip(),
@@ -2060,11 +2062,10 @@ def _import_business_registry_csv_rows(rows):
                 row.get("event_position"),
                 row_number=row_number,
                 field_label="event_position",
-                fallback=section_positions["event"],
+                fallback=event_position_fallback,
                 errors=errors,
             ),
         }
-        existing_event = event_definitions.get(event_ref)
         if existing_event and existing_event != event_definition:
             errors.append(f"Строка {row_number}: данные события «{event_ref}» конфликтуют с предыдущими строками.")
         elif not existing_event:

--- a/proposals_app/models.py
+++ b/proposals_app/models.py
@@ -347,7 +347,7 @@ class ProposalRegistration(models.Model):
         )
 
     def _build_short_uid(self):
-        return f"{self.number}{self.group_order_number}{self.group_alpha2}"
+        return f"{self.formatted_number}{self.group_order_number}{self.group_alpha2}"
 
     def save(self, *args, **kwargs):
         member = self._resolved_group_member()
@@ -390,6 +390,24 @@ class ProposalRegistration(models.Model):
     def last_product(self):
         products = self.ordered_products()
         return products[-1] if products else None
+
+    @property
+    def type_short_names(self):
+        labels = []
+        seen = set()
+        for product in self.ordered_products():
+            label = (
+                getattr(product, "short_name", "")
+                or str(product or "")
+            ).strip()
+            if label and label not in seen:
+                seen.add(label)
+                labels.append(label)
+        return labels
+
+    @property
+    def type_short_display(self):
+        return "-".join(self.type_short_names)
 
 
 class ProposalRegistrationProduct(models.Model):

--- a/proposals_app/templates/proposals_app/proposals_partial.html
+++ b/proposals_app/templates/proposals_app/proposals_partial.html
@@ -126,7 +126,7 @@
               {% endif %}
             </td>
             <td data-col="tkp-id" class="proposal-id-cell"><span class="clf-id-droid-mono">{{ proposal.short_uid }}</span></td>
-            <td data-col="type">{{ proposal.type.short_name|default:proposal.type }}</td>
+            <td data-col="type">{{ proposal.type_short_display }}</td>
             <td data-col="name">{{ proposal.name }}</td>
             <td data-col="kind">{{ proposal.get_kind_display }}</td>
             <td data-col="status" class="proposal-status-cell">{{ proposal.get_status_display }}</td>
@@ -288,7 +288,7 @@
               {% endif %}
             </td>
             <td class="proposal-id-cell"><span class="clf-id-droid-mono">{{ proposal.short_uid }}</span></td>
-            <td>{{ proposal.type.short_name|default:proposal.type }}</td>
+            <td>{{ proposal.type_short_display }}</td>
             <td>{{ proposal.name }}</td>
             <td class="text-nowrap">
               {% with folder_url=proposal.proposal_workspace_folder_url %}

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -4936,6 +4936,15 @@ class ProposalDispatchDiskColumnTests(TestCase):
             service_subtype="Аудит соответствия стандартам",
             position=1,
         )
+        self.second_product = Product.objects.create(
+            short_name="QAQC",
+            name_en="QAQC",
+            name_ru="QAQC",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Контроль качества",
+            position=2,
+        )
         self.proposal = ProposalRegistration.objects.create(
             number=3333,
             group_member=self.group_member,
@@ -4953,6 +4962,22 @@ class ProposalDispatchDiskColumnTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, ">0001<", html=False)
+        self.proposal.refresh_from_db()
+        self.assertEqual(self.proposal.short_uid, "00010RU")
+        self.assertContains(response, ">00010RU<", html=False)
+
+    def test_proposals_partial_renders_multiple_products_with_hyphen_in_type_column(self):
+        ProposalRegistrationProduct.objects.bulk_create(
+            [
+                ProposalRegistrationProduct(proposal_id=self.proposal.pk, product=self.product, rank=1),
+                ProposalRegistrationProduct(proposal_id=self.proposal.pk, product=self.second_product, rank=2),
+            ]
+        )
+
+        response = self.client.get(reverse("proposals_partial"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, ">DD-QAQC<", html=False)
 
     @patch("nextcloud_app.api.NextcloudApiClient.list_user_shares")
     def test_proposals_partial_renders_disk_icon_with_nextcloud_share_target(self, mocked_list_user_shares):

--- a/proposals_app/views.py
+++ b/proposals_app/views.py
@@ -1007,7 +1007,7 @@ def _proposals_context(request=None, user=None, *, debug_nextcloud_links=False):
         "asset_owner_country",
         "type",
         "currency",
-    ).all()
+    ).prefetch_related("product_links__product").all()
     _attach_proposal_folder_urls(proposals, user=user, request=request, debug_nextcloud_links=debug_nextcloud_links)
     proposal_templates = list(ProposalTemplate.objects.select_related("group_member", "product").all())
     proposal_variables = ProposalVariable.objects.all()

--- a/templates/index.html
+++ b/templates/index.html
@@ -3020,6 +3020,22 @@
   });
 </script>
 
+<div class="modal fade" id="worktime-csv-result-modal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-scrollable modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Результат загрузки CSV</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body" id="worktime-csv-result-body" style="font-size: 0.82rem; white-space: pre-wrap; max-height: 70vh;">
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary btn-sm" data-bs-dismiss="modal">Закрыть</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <div class="modal fade" id="worktime-modal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-scrollable">
     <div class="modal-content">

--- a/worktime_app/templates/worktime_app/worktime_partial.html
+++ b/worktime_app/templates/worktime_app/worktime_partial.html
@@ -384,6 +384,33 @@
         <i class="bi bi-plus-circle me-2"></i>Добавить строку
       </button>
     </div>
+  {% else %}
+    {% if worktime_csv_controls_visible %}
+    <div class="d-flex align-items-stretch gap-2 mt-3 flex-wrap" data-worktime-csv-actions>
+      <button type="button"
+              class="btn btn-primary btn-sm d-flex align-items-center"
+              data-worktime-csv-download-btn
+              data-worktime-csv-download-url="{{ worktime_csv_download_url }}"
+              {% if not worktime_csv_controls_enabled %}disabled title="{{ worktime_csv_disabled_hint }}"{% endif %}>
+        <i class="bi bi-cloud-arrow-down me-2"></i>Скачать CSV
+      </button>
+      <button type="button"
+              class="btn btn-primary btn-sm d-flex align-items-center"
+              data-worktime-csv-upload-btn
+              data-worktime-csv-upload-url="{{ worktime_csv_upload_url }}"
+              {% if not worktime_csv_controls_enabled %}disabled title="{{ worktime_csv_disabled_hint }}"{% endif %}>
+        <i class="bi bi-cloud-arrow-up me-2"></i>Загрузить CSV
+      </button>
+      <input type="file"
+             accept=".csv"
+             class="d-none"
+             data-worktime-csv-file-input
+             {% if not worktime_csv_controls_enabled %}disabled{% endif %}>
+      {% if not worktime_csv_controls_enabled %}
+        <span class="text-muted small align-self-center">{{ worktime_csv_disabled_hint }}</span>
+      {% endif %}
+    </div>
+    {% endif %}
   {% endif %}
 </form>
 
@@ -2004,6 +2031,202 @@
       return reloadWorktimePanel(document.querySelector('#worktime-content-timesheet [data-worktime-panel]'));
     }
 
+    function escapeWorktimeHtml(value) {
+      return String(value == null ? '' : value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    function cleanupWorktimeCsvModalArtifacts() {
+      if (document.querySelector('.modal.show')) return;
+      document.querySelectorAll('.modal-backdrop').forEach(function (backdrop) {
+        backdrop.remove();
+      });
+      document.body.classList.remove('modal-open');
+      document.body.style.removeProperty('padding-right');
+    }
+
+    function ensureWorktimeCsvModalBinding(modalEl) {
+      if (!modalEl || modalEl.dataset.worktimeCsvBound === '1') return;
+      modalEl.dataset.worktimeCsvBound = '1';
+      modalEl.addEventListener('hidden.bs.modal', function () {
+        var onHidden = modalEl._worktimeCsvOnHidden;
+        modalEl._worktimeCsvOnHidden = null;
+        cleanupWorktimeCsvModalArtifacts();
+        if (typeof onHidden === 'function') {
+          onHidden();
+        }
+      });
+    }
+
+    function showWorktimeCsvResult(html, options) {
+      var modalEl = document.getElementById('worktime-csv-result-modal');
+      var body = document.getElementById('worktime-csv-result-body');
+      if (!modalEl || !body || !window.bootstrap) {
+        window.alert(String(html || '').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim() || 'Результат загрузки CSV недоступен.');
+        return;
+      }
+      var modalOptions = options || {};
+      ensureWorktimeCsvModalBinding(modalEl);
+      modalEl._worktimeCsvOnHidden = typeof modalOptions.onHidden === 'function' ? modalOptions.onHidden : null;
+      body.innerHTML = html;
+      window.bootstrap.Modal.getOrCreateInstance(modalEl).show();
+    }
+
+    function readWorktimeJsonResponse(response) {
+      var contentType = response.headers.get('content-type') || '';
+      if (contentType.indexOf('application/json') !== -1) {
+        return response.json().catch(function () {
+          return { ok: response.ok, error: 'Получен некорректный ответ сервера.' };
+        });
+      }
+      return response.text().then(function (text) {
+        return { ok: response.ok, error: text || 'Получен некорректный ответ сервера.' };
+      }).catch(function () {
+        return { ok: response.ok, error: 'Получен некорректный ответ сервера.' };
+      });
+    }
+
+    function buildWorktimeCsvParams(panel) {
+      var params = new URLSearchParams();
+      var form = panel && panel.querySelector ? panel.querySelector('[data-worktime-period-form]') : null;
+      if (!form) return params;
+      var formData = new FormData(form);
+      ['scale', 'period', 'breakdown', 'hist_sort'].forEach(function (name) {
+        var value = String(formData.get(name) || '').trim();
+        if (value) {
+          params.set(name, value);
+        }
+      });
+      return params;
+    }
+
+    function worktimeCsvControlsEnabled(panel) {
+      var params = buildWorktimeCsvParams(panel);
+      var scale = String(params.get('scale') || 'month').toLowerCase();
+      var breakdown = String(params.get('breakdown') || 'employees').toLowerCase();
+      return scale === 'month' && breakdown === 'employees';
+    }
+
+    function buildWorktimeCsvSuccessHtml(data) {
+      var created = Number(data && data.created ? data.created : 0);
+      var updated = Number(data && data.updated ? data.updated : 0);
+      var deleted = Number(data && data.deleted ? data.deleted : 0);
+      var createdAssignments = Number(data && data.created_assignments ? data.created_assignments : 0);
+      var warnings = data && Array.isArray(data.warnings) ? data.warnings : [];
+      var totalChanges = created + updated + deleted;
+      var html = totalChanges
+        ? '<div class="mb-2"><strong>Импорт завершен.</strong></div>'
+        : '<div class="mb-2 text-muted"><strong>Изменений нет.</strong></div>';
+      if (createdAssignments) {
+        html += '<div class="mb-1"><strong>Создано строк табеля: ' + escapeWorktimeHtml(createdAssignments) + '</strong></div>';
+      }
+      html += '<div class="mb-1"><strong>Добавлено значений: ' + escapeWorktimeHtml(created) + '</strong></div>';
+      html += '<div class="mb-1"><strong>Обновлено значений: ' + escapeWorktimeHtml(updated) + '</strong></div>';
+      html += '<div class="mb-1"><strong>Удалено значений: ' + escapeWorktimeHtml(deleted) + '</strong></div>';
+      if (warnings.length) {
+        html += '<div class="text-danger mt-3 mb-1"><strong>Предупреждения (' + escapeWorktimeHtml(warnings.length) + '):</strong></div>';
+        html += '<div class="text-danger" style="max-height:200px;overflow-y:auto;">';
+        warnings.forEach(function (warning) {
+          html += '<div class="mb-1">' + escapeWorktimeHtml(warning) + '</div>';
+        });
+        html += '</div>';
+      }
+      return html;
+    }
+
+    function buildWorktimeCsvErrorHtml(data) {
+      var errorMessage = data && data.error ? data.error : 'Неизвестная ошибка.';
+      var warnings = data && Array.isArray(data.warnings) ? data.warnings : [];
+      var html = '<div class="text-danger"><strong>Ошибка:</strong> ' + escapeWorktimeHtml(errorMessage) + '</div>';
+      if (warnings.length) {
+        html += '<div class="text-danger mt-2"><strong>Детали (' + escapeWorktimeHtml(warnings.length) + '):</strong></div>';
+        html += '<div class="text-danger" style="max-height:200px;overflow-y:auto;">';
+        warnings.forEach(function (warning) {
+          html += '<div class="mb-1">' + escapeWorktimeHtml(warning) + '</div>';
+        });
+        html += '</div>';
+      }
+      return html;
+    }
+
+    function getWorktimeCsvFileInput(button) {
+      var actions = button && button.closest ? button.closest('[data-worktime-csv-actions]') : null;
+      return actions && actions.querySelector ? actions.querySelector('[data-worktime-csv-file-input]') : null;
+    }
+
+    function handleWorktimeCsvUpload(button, fileInput, file) {
+      var panel = button && button.closest ? button.closest('[data-worktime-panel]') : null;
+      var uploadUrl = button ? (button.dataset.worktimeCsvUploadUrl || '') : '';
+      if (!panel || !uploadUrl || !file) return Promise.resolve();
+      if (!worktimeCsvControlsEnabled(panel)) {
+        showWorktimeCsvResult(buildWorktimeCsvErrorHtml({
+          error: 'Загрузка и скачивание CSV доступны только для месячного табеля с разбивкой по сотрудникам.'
+        }));
+        return Promise.resolve();
+      }
+
+      var formData = new FormData();
+      formData.append('csv_file', file);
+      buildWorktimeCsvParams(panel).forEach(function (value, key) {
+        formData.append(key, value);
+      });
+      var csrfField = panel.querySelector('[data-worktime-save-form] input[name="csrfmiddlewaretoken"]');
+      if (csrfField && csrfField.value) {
+        formData.append('csrfmiddlewaretoken', csrfField.value);
+      }
+
+      button.disabled = true;
+      return window.fetch(uploadUrl, {
+        method: 'POST',
+        body: formData,
+        credentials: 'same-origin',
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest'
+        }
+      }).then(readWorktimeJsonResponse)
+        .then(function (data) {
+          if (data && data.ok) {
+            showWorktimeCsvResult(buildWorktimeCsvSuccessHtml(data), {
+              onHidden: function () {
+                reloadWorktimePanel(panel);
+              }
+            });
+            return;
+          }
+          showWorktimeCsvResult(buildWorktimeCsvErrorHtml(data || { error: 'Неизвестная ошибка.' }));
+        })
+        .catch(function (error) {
+          showWorktimeCsvResult(buildWorktimeCsvErrorHtml({
+            error: error && error.message ? error.message : 'Не удалось загрузить CSV.'
+          }));
+        })
+        .finally(function () {
+          if (fileInput) {
+            fileInput.value = '';
+          }
+          button.disabled = false;
+        });
+    }
+
+    function handleWorktimeCsvDownload(button) {
+      var panel = button && button.closest ? button.closest('[data-worktime-panel]') : null;
+      var downloadUrl = button ? (button.dataset.worktimeCsvDownloadUrl || '') : '';
+      if (!panel || !downloadUrl) return;
+      if (!worktimeCsvControlsEnabled(panel)) {
+        showWorktimeCsvResult(buildWorktimeCsvErrorHtml({
+          error: 'Загрузка и скачивание CSV доступны только для месячного табеля с разбивкой по сотрудникам.'
+        }));
+        return;
+      }
+      var params = buildWorktimeCsvParams(panel);
+      var requestUrl = params.toString() ? (downloadUrl + '?' + params.toString()) : downloadUrl;
+      window.location.href = requestUrl;
+    }
+
     function getWorktimeAutosaveState(form) {
       if (!form) return null;
       var state = worktimeAutosaveStates.get(form);
@@ -2442,6 +2665,33 @@
           swap: 'innerHTML'
         });
       });
+    });
+
+    document.addEventListener('click', function (event) {
+      var uploadButton = event.target && event.target.closest ? event.target.closest('[data-worktime-csv-upload-btn]') : null;
+      if (uploadButton) {
+        event.preventDefault();
+        var fileInput = getWorktimeCsvFileInput(uploadButton);
+        if (!fileInput) return;
+        fileInput.value = '';
+        fileInput.click();
+        return;
+      }
+      var downloadButton = event.target && event.target.closest ? event.target.closest('[data-worktime-csv-download-btn]') : null;
+      if (!downloadButton) return;
+      event.preventDefault();
+      handleWorktimeCsvDownload(downloadButton);
+    });
+
+    document.addEventListener('change', function (event) {
+      var fileInput = event.target && event.target.closest ? event.target.closest('[data-worktime-csv-file-input]') : null;
+      if (!fileInput) return;
+      var file = fileInput.files && fileInput.files[0];
+      if (!file) return;
+      var actions = fileInput.closest('[data-worktime-csv-actions]');
+      var uploadButton = actions && actions.querySelector ? actions.querySelector('[data-worktime-csv-upload-btn]') : null;
+      if (!uploadButton) return;
+      handleWorktimeCsvUpload(uploadButton, fileInput, file);
     });
 
     document.addEventListener('submit', function (event) {

--- a/worktime_app/tests.py
+++ b/worktime_app/tests.py
@@ -1,7 +1,11 @@
+import csv
+import io
+from calendar import monthrange
 from datetime import date, timedelta
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.template.loader import render_to_string
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
@@ -9,7 +13,7 @@ from django.utils import timezone
 
 from notifications_app.models import Notification, NotificationPerformerLink
 from notifications_app.services import process_participation_notification
-from policy_app.models import DEPARTMENT_HEAD_GROUP, Product
+from policy_app.models import ADMIN_GROUP, DEPARTMENT_HEAD_GROUP, Product
 from projects_app.models import Performer, ProjectRegistration
 from proposals_app.models import ProposalRegistration
 from users_app.models import Employee
@@ -30,7 +34,7 @@ class WorktimeAppTests(TestCase):
             last_name="Иванов",
         )
         self.client.force_login(self.user)
-        self.employee = Employee.objects.create(user=self.user, patronymic="Иванович")
+        self.employee = Employee.objects.create(user=self.user, patronymic="Иванович", role=ADMIN_GROUP)
 
         self.other_user = get_user_model().objects.create_user(
             username="other-worktime-user",
@@ -123,6 +127,25 @@ class WorktimeAppTests(TestCase):
 
     def _full_name(self, employee):
         return Performer.employee_full_name(employee)
+
+    def _worktime_csv_header(self, month_value):
+        year, month = [int(part) for part in str(month_value).split("-", 1)]
+        total_days = monthrange(year, month)[1]
+        return ["Сотрудник", "Проект", "Тип", "Название", *[str(day) for day in range(1, total_days + 1)]]
+
+    def _make_worktime_csv_upload(self, header, rows, *, name="worktime.csv"):
+        buffer = io.StringIO()
+        writer = csv.writer(buffer, delimiter=";")
+        writer.writerow(header)
+        writer.writerows(rows)
+        return SimpleUploadedFile(
+            name,
+            buffer.getvalue().encode("utf-8-sig"),
+            content_type="text/csv",
+        )
+
+    def _parse_worktime_csv_response(self, response):
+        return list(csv.reader(io.StringIO(response.content.decode("utf-8-sig")), delimiter=";"))
 
     def test_attach_group_histograms_scales_detail_rows_to_group_bar(self):
         groups = [
@@ -1000,6 +1023,57 @@ class WorktimeAppTests(TestCase):
         self.assertContains(response, 'value="month"', html=False)
         self.assertContains(response, "Апрель, 2026 г.")
 
+    def test_general_partial_renders_csv_controls_for_employee_month_breakdown(self):
+        response = self.client.get(
+            reverse("worktime_partial"),
+            {"scale": "month", "period": "2026-04", "breakdown": "employees"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Скачать CSV")
+        self.assertContains(response, "Загрузить CSV")
+        self.assertContains(response, 'data-worktime-csv-download-url="/worktime/csv-download/"', html=False)
+        self.assertContains(response, 'data-worktime-csv-upload-url="/worktime/csv-upload/"', html=False)
+        self.assertContains(response, 'class="btn btn-primary btn-sm d-flex align-items-center"', html=False, count=2)
+        self.assertContains(response, 'class="bi bi-cloud-arrow-down me-2"', html=False)
+        self.assertNotContains(
+            response,
+            'disabled title="Загрузка и скачивание CSV доступны только для месячного табеля с разбивкой по сотрудникам."',
+            html=False,
+        )
+
+    def test_general_partial_disables_csv_controls_for_activity_breakdown(self):
+        response = self.client.get(
+            reverse("worktime_partial"),
+            {"scale": "month", "period": "2026-04", "breakdown": "activities"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Скачать CSV")
+        self.assertContains(response, "Загрузить CSV")
+        self.assertContains(
+            response,
+            'disabled title="Загрузка и скачивание CSV доступны только для месячного табеля с разбивкой по сотрудникам."',
+            html=False,
+            count=2,
+        )
+        self.assertContains(response, "Загрузка и скачивание CSV доступны только для месячного табеля с разбивкой по сотрудникам.")
+
+    def test_general_partial_hides_csv_controls_for_non_admin_user(self):
+        self.employee.role = ""
+        self.employee.save(update_fields=["role"])
+
+        response = self.client.get(
+            reverse("worktime_partial"),
+            {"scale": "month", "period": "2026-04", "breakdown": "employees"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Скачать CSV")
+        self.assertNotContains(response, "Загрузить CSV")
+        self.assertNotContains(response, 'data-worktime-csv-download-url="/worktime/csv-download/"', html=False)
+        self.assertNotContains(response, 'data-worktime-csv-upload-url="/worktime/csv-upload/"', html=False)
+
     def test_general_partial_year_scale_aggregates_hours_by_month(self):
         assignment = WorktimeAssignment.objects.create(
             registration=self.registration,
@@ -1033,6 +1107,360 @@ class WorktimeAppTests(TestCase):
         self.assertContains(response, ">13<", html=False)
         self.assertContains(response, ">3<", html=False)
         self.assertNotContains(response, f'hours_{assignment.pk}_20260407', html=False)
+
+    def test_worktime_csv_download_returns_selected_month_data(self):
+        assignment = WorktimeAssignment.objects.create(
+            registration=self.registration,
+            employee=self.employee,
+            executor_name=self._full_name(self.employee),
+            source_type=WorktimeAssignment.SourceType.PERFORMER_CONFIRMATION,
+        )
+        WorktimeEntry.objects.create(
+            assignment=assignment,
+            work_date=date(2026, 4, 1),
+            hours=7,
+        )
+        WorktimeEntry.objects.create(
+            assignment=assignment,
+            work_date=date(2026, 4, 3),
+            hours=5,
+        )
+
+        response = self.client.get(
+            reverse("worktime_csv_download"),
+            {"scale": "month", "period": "2026-04", "breakdown": "employees"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text/csv", response["Content-Type"])
+        self.assertEqual(response["Content-Disposition"], 'attachment; filename="worktime-2026-04.csv"')
+        rows = self._parse_worktime_csv_response(response)
+        self.assertEqual(rows[0], self._worktime_csv_header("2026-04"))
+        self.assertEqual(rows[1][0], self._full_name(self.employee))
+        self.assertEqual(rows[1][1], assignment.display_project_code)
+        self.assertEqual(rows[1][2], assignment.display_type_label)
+        self.assertEqual(rows[1][3], assignment.display_project_name)
+        self.assertEqual(rows[1][4], "7")
+        self.assertEqual(rows[1][5], "")
+        self.assertEqual(rows[1][6], "5")
+
+    def test_worktime_csv_upload_replaces_only_selected_month_for_touched_rows(self):
+        assignment = WorktimeAssignment.objects.create(
+            registration=self.registration,
+            employee=self.employee,
+            executor_name=self._full_name(self.employee),
+            source_type=WorktimeAssignment.SourceType.PERFORMER_CONFIRMATION,
+        )
+        untouched_assignment = WorktimeAssignment.objects.create(
+            registration=self.second_registration,
+            employee=self.employee,
+            executor_name=self._full_name(self.employee),
+            source_type=WorktimeAssignment.SourceType.PROJECT_MANAGER,
+        )
+        WorktimeEntry.objects.create(assignment=assignment, work_date=date(2026, 4, 1), hours=3)
+        WorktimeEntry.objects.create(assignment=assignment, work_date=date(2026, 4, 2), hours=4)
+        WorktimeEntry.objects.create(assignment=assignment, work_date=date(2026, 5, 1), hours=7)
+        WorktimeEntry.objects.create(assignment=untouched_assignment, work_date=date(2026, 4, 1), hours=5)
+
+        april_days = [""] * 30
+        april_days[0] = "8"
+        april_days[2] = "6"
+        upload = self._make_worktime_csv_upload(
+            self._worktime_csv_header("2026-04"),
+            [[
+                self._full_name(self.employee),
+                assignment.display_project_code,
+                assignment.display_type_label,
+                assignment.display_project_name,
+                *april_days,
+            ]],
+        )
+
+        response = self.client.post(
+            reverse("worktime_csv_upload"),
+            {
+                "csv_file": upload,
+                "scale": "month",
+                "period": "2026-04",
+                "breakdown": "employees",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"ok": True, "created": 1, "updated": 1, "deleted": 1},
+        )
+        self.assertEqual(
+            list(
+                WorktimeEntry.objects.filter(assignment=assignment)
+                .order_by("work_date")
+                .values_list("work_date", "hours")
+            ),
+            [
+                (date(2026, 4, 1), 8),
+                (date(2026, 4, 3), 6),
+                (date(2026, 5, 1), 7),
+            ],
+        )
+        self.assertEqual(
+            list(
+                WorktimeEntry.objects.filter(assignment=untouched_assignment)
+                .order_by("work_date")
+                .values_list("work_date", "hours")
+            ),
+            [(date(2026, 4, 1), 5)],
+        )
+
+    def test_worktime_csv_upload_creates_missing_assignment_for_existing_project_and_employee(self):
+        april_days = [""] * 30
+        april_days[0] = "8"
+        upload = self._make_worktime_csv_upload(
+            self._worktime_csv_header("2026-04"),
+            [[
+                self._full_name(self.employee),
+                self.second_registration.short_uid,
+                self.second_registration.type_short_display or "—",
+                self.second_registration.name,
+                *april_days,
+            ]],
+        )
+
+        response = self.client.post(
+            reverse("worktime_csv_upload"),
+            {
+                "csv_file": upload,
+                "scale": "month",
+                "period": "2026-04",
+                "breakdown": "employees",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "ok": True,
+                "created": 1,
+                "updated": 0,
+                "deleted": 0,
+                "created_assignments": 1,
+            },
+        )
+        assignment = WorktimeAssignment.objects.get(
+            registration=self.second_registration,
+            executor_name=self._full_name(self.employee),
+        )
+        self.assertEqual(assignment.employee, self.employee)
+        self.assertEqual(assignment.record_type, WorktimeAssignment.RecordType.PROJECT)
+        self.assertEqual(assignment.source_type, WorktimeAssignment.SourceType.MANUAL_PERSONAL_WEEK)
+        self.assertTrue(
+            PersonalWorktimeWeekAssignment.objects.filter(
+                assignment=assignment,
+                week_start=date(2026, 3, 30),
+            ).exists()
+        )
+        self.assertEqual(
+            list(
+                WorktimeEntry.objects.filter(assignment=assignment)
+                .order_by("work_date")
+                .values_list("work_date", "hours")
+            ),
+            [(date(2026, 4, 1), 8)],
+        )
+        visible_response = self.client.get(reverse("personal_worktime_partial"), {"week": "2026-04-01"})
+        hidden_response = self.client.get(reverse("personal_worktime_partial"), {"week": "2026-04-14"})
+        self.assertContains(visible_response, self.second_registration.name)
+        self.assertNotContains(hidden_response, self.second_registration.name)
+
+    def test_worktime_csv_upload_rejects_missing_file(self):
+        response = self.client.post(
+            reverse("worktime_csv_upload"),
+            {"scale": "month", "period": "2026-04", "breakdown": "employees"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"ok": False, "error": "Файл не выбран."})
+
+    def test_worktime_csv_upload_rejects_non_csv_file(self):
+        response = self.client.post(
+            reverse("worktime_csv_upload"),
+            {
+                "csv_file": SimpleUploadedFile("worktime.txt", b"test", content_type="text/plain"),
+                "scale": "month",
+                "period": "2026-04",
+                "breakdown": "employees",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"ok": False, "error": "Допустимы только файлы CSV."})
+
+    def test_worktime_csv_upload_rejects_invalid_header(self):
+        upload = self._make_worktime_csv_upload(
+            ["Сотрудник", "Проект", "Тип", "Название", "1", "2"],
+            [["Иван Иванов", "4444", "WT", "Проект Альфа", "8", "4"]],
+        )
+
+        response = self.client.post(
+            reverse("worktime_csv_upload"),
+            {
+                "csv_file": upload,
+                "scale": "month",
+                "period": "2026-04",
+                "breakdown": "employees",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(response.json()["ok"])
+        self.assertIn("CSV должен содержать колонки:", response.json()["error"])
+
+    def test_worktime_csv_upload_reports_unknown_row(self):
+        assignment = WorktimeAssignment.objects.create(
+            registration=self.registration,
+            employee=self.employee,
+            executor_name=self._full_name(self.employee),
+            source_type=WorktimeAssignment.SourceType.PERFORMER_CONFIRMATION,
+        )
+        april_days = [""] * 30
+        april_days[0] = "8"
+        upload = self._make_worktime_csv_upload(
+            self._worktime_csv_header("2026-04"),
+            [[
+                "Несуществующий Сотрудник",
+                assignment.display_project_code,
+                assignment.display_type_label,
+                assignment.display_project_name,
+                *april_days,
+            ]],
+        )
+
+        response = self.client.post(
+            reverse("worktime_csv_upload"),
+            {
+                "csv_file": upload,
+                "scale": "month",
+                "period": "2026-04",
+                "breakdown": "employees",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["error"], "Не удалось обработать ни одной строки табеля.")
+        self.assertIn("не найден среди штатных сотрудников", payload["warnings"][0])
+
+    def test_worktime_csv_upload_rejects_hours_out_of_range(self):
+        assignment = WorktimeAssignment.objects.create(
+            registration=self.registration,
+            employee=self.employee,
+            executor_name=self._full_name(self.employee),
+            source_type=WorktimeAssignment.SourceType.PERFORMER_CONFIRMATION,
+        )
+        april_days = [""] * 30
+        april_days[0] = "25"
+        upload = self._make_worktime_csv_upload(
+            self._worktime_csv_header("2026-04"),
+            [[
+                self._full_name(self.employee),
+                assignment.display_project_code,
+                assignment.display_type_label,
+                assignment.display_project_name,
+                *april_days,
+            ]],
+        )
+
+        response = self.client.post(
+            reverse("worktime_csv_upload"),
+            {
+                "csv_file": upload,
+                "scale": "month",
+                "period": "2026-04",
+                "breakdown": "employees",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["error"], "Не удалось обработать ни одной строки табеля.")
+        self.assertIn("должно быть в диапазоне от 0 до 24", payload["warnings"][0])
+
+    def test_worktime_csv_upload_rejects_activity_breakdown(self):
+        upload = self._make_worktime_csv_upload(
+            self._worktime_csv_header("2026-04"),
+            [],
+        )
+
+        response = self.client.post(
+            reverse("worktime_csv_upload"),
+            {
+                "csv_file": upload,
+                "scale": "month",
+                "period": "2026-04",
+                "breakdown": "activities",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                "ok": False,
+                "error": "Загрузка и скачивание CSV доступны только для месячного табеля с разбивкой по сотрудникам.",
+            },
+        )
+
+    def test_worktime_csv_download_rejects_year_scale(self):
+        response = self.client.get(
+            reverse("worktime_csv_download"),
+            {"scale": "year", "period": "2026", "breakdown": "employees"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.content.decode("utf-8"),
+            "Загрузка и скачивание CSV доступны только для месячного табеля с разбивкой по сотрудникам.",
+        )
+
+    def test_worktime_csv_upload_forbidden_for_non_admin_role(self):
+        self.employee.role = ""
+        self.employee.save(update_fields=["role"])
+        upload = self._make_worktime_csv_upload(self._worktime_csv_header("2026-04"), [])
+
+        response = self.client.post(
+            reverse("worktime_csv_upload"),
+            {
+                "csv_file": upload,
+                "scale": "month",
+                "period": "2026-04",
+                "breakdown": "employees",
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json(),
+            {
+                "ok": False,
+                "error": "Загрузка и скачивание CSV доступны только пользователям с ролью Администратор.",
+            },
+        )
+
+    def test_worktime_csv_download_forbidden_for_non_admin_role(self):
+        self.employee.role = ""
+        self.employee.save(update_fields=["role"])
+
+        response = self.client.get(
+            reverse("worktime_csv_download"),
+            {"scale": "month", "period": "2026-04", "breakdown": "employees"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.content.decode("utf-8"),
+            "Загрузка и скачивание CSV доступны только пользователям с ролью Администратор.",
+        )
 
     def test_panel_defers_initial_timesheet_load_until_explicit_event(self):
         request = self.factory.get("/")

--- a/worktime_app/urls.py
+++ b/worktime_app/urls.py
@@ -6,6 +6,8 @@ from . import views
 urlpatterns = [
     path("partial/", views.worktime_partial, name="worktime_partial"),
     path("partial/personal/", views.personal_worktime_partial, name="personal_worktime_partial"),
+    path("csv-upload/", views.worktime_csv_upload, name="worktime_csv_upload"),
+    path("csv-download/", views.worktime_csv_download, name="worktime_csv_download"),
     path("personal/add-row/", views.personal_worktime_row_form, name="personal_worktime_row_form"),
     path("save/", views.worktime_save, name="worktime_save"),
 ]

--- a/worktime_app/views.py
+++ b/worktime_app/views.py
@@ -1,3 +1,5 @@
+import csv
+import io
 import json
 from calendar import monthrange
 from datetime import date, datetime, timedelta
@@ -6,18 +8,23 @@ from django import forms
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.db.models import Q
-from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_http_methods
 
+from policy_app.models import ADMIN_GROUP
 from projects_app.models import Performer, ProjectRegistration
 from proposals_app.models import ProposalRegistration
 
 from .forms import PersonalWorktimeWeekAssignmentForm
-from .models import WorktimeAssignment, WorktimeEntry
-from .services import ensure_personal_week_assignment, is_worktime_eligible_employee
+from .models import PersonalWorktimeWeekAssignment, WorktimeAssignment, WorktimeEntry
+from .services import (
+    ensure_personal_week_assignment,
+    is_worktime_eligible_employee,
+    resolve_employee_and_name,
+)
 
 WORKTIME_PARTIAL_TEMPLATE = "worktime_app/worktime_partial.html"
 MONTH_LABELS = {
@@ -53,6 +60,9 @@ MAX_HOURS_PER_DAY = 24
 PERSONAL_WEEK_LIMIT_WEEKS = 2
 PERSONAL_WEEK_LIMIT_ERROR = "Нельзя выбрать слишком далекую будущую неделю. Доступны текущая неделя и только две следующие."
 WORKTIME_ACCESS_ERROR = 'Табель доступен только штатным сотрудникам с правами staff. Пользователи с трудоустройством "Внештатный сотрудник" не допускаются.'
+WORKTIME_CSV_MODE_ERROR = "Загрузка и скачивание CSV доступны только для месячного табеля с разбивкой по сотрудникам."
+WORKTIME_CSV_ADMIN_ERROR = "Загрузка и скачивание CSV доступны только пользователям с ролью Администратор."
+WORKTIME_CSV_BASE_HEADERS = ("Сотрудник", "Проект", "Тип", "Название")
 
 
 def _resolve_month(raw_value):
@@ -158,6 +168,294 @@ def _visible_period_bounds(period_start, scale):
     return period_start, date(period_start.year, period_start.month, monthrange(period_start.year, period_start.month)[1])
 
 
+def _resolve_general_worktime_request_state(request):
+    scale = _resolve_scale(request.POST.get("scale") or request.GET.get("scale"))
+    breakdown = _resolve_breakdown(request.POST.get("breakdown") or request.GET.get("breakdown"))
+    period_start = _resolve_general_period(
+        request.POST.get("period")
+        or request.POST.get("month")
+        or request.GET.get("period")
+        or request.GET.get("month"),
+        scale,
+    )
+    return scale, breakdown, period_start
+
+
+def _worktime_csv_controls_enabled(scale, breakdown):
+    return _resolve_scale(scale) == "month" and _resolve_breakdown(breakdown) == "employees"
+
+
+def _general_worktime_period_data(user, month_start, *, scale="month", breakdown="employees"):
+    if scale == "year":
+        visible_days = _year_months(month_start)
+    else:
+        visible_days = _month_days(month_start)
+    range_start, range_end = _visible_period_bounds(month_start, scale)
+    assignments = _visible_assignments_for_period(
+        user,
+        personal_only=False,
+        visible_days=visible_days,
+        range_start=range_start,
+        range_end=range_end,
+        breakdown=breakdown,
+    )
+    return visible_days, range_start, range_end, assignments
+
+
+def _normalize_worktime_csv_text(value):
+    return " ".join(str(value or "").replace("\u00a0", " ").split()).strip()
+
+
+def _worktime_csv_headers(month_days):
+    return [*WORKTIME_CSV_BASE_HEADERS, *[str(day.day) for day in month_days]]
+
+
+def _worktime_csv_row_descriptor(assignment):
+    employee_name = assignment.display_executor_name or assignment.executor_name or ""
+    if assignment.has_linked_registry_row:
+        return {
+            "employee_name": employee_name,
+            "project_code": assignment.display_project_code or "",
+            "type_label": assignment.display_type_label or "",
+            "name_label": assignment.display_project_name or "",
+        }
+    return {
+        "employee_name": employee_name,
+        "project_code": "",
+        "type_label": "",
+        "name_label": assignment.display_manual_label or "",
+    }
+
+
+def _worktime_csv_row_key(employee_name, project_code, type_label, name_label):
+    return tuple(
+        _normalize_worktime_csv_text(value).casefold()
+        for value in (employee_name, project_code, type_label, name_label)
+    )
+
+
+def _worktime_csv_assignment_key(assignment):
+    descriptor = _worktime_csv_row_descriptor(assignment)
+    return _worktime_csv_row_key(
+        descriptor["employee_name"],
+        descriptor["project_code"],
+        descriptor["type_label"],
+        descriptor["name_label"],
+    )
+
+
+def _build_worktime_csv_assignment_index(assignments):
+    index = {}
+    duplicate_keys = set()
+    for assignment in assignments:
+        row_key = _worktime_csv_assignment_key(assignment)
+        if row_key in index:
+            duplicate_keys.add(row_key)
+            continue
+        index[row_key] = assignment
+    for row_key in duplicate_keys:
+        index.pop(row_key, None)
+    return index, duplicate_keys
+
+
+def _worktime_csv_project_key(project_code, type_label, name_label):
+    return tuple(
+        _normalize_worktime_csv_text(value).casefold()
+        for value in (project_code, type_label, name_label)
+    )
+
+
+def _project_registration_csv_descriptor(registration):
+    return {
+        "project_code": getattr(registration, "short_uid", "") or "—",
+        "type_label": getattr(registration, "type_short_display", "") or "—",
+        "name_label": getattr(registration, "name", "") or "—",
+    }
+
+
+def _build_worktime_csv_project_index():
+    projects_by_code = {}
+    projects_by_key = {}
+    duplicate_project_keys = set()
+    registrations = (
+        ProjectRegistration.objects
+        .select_related("type")
+        .order_by("id")
+    )
+    for registration in registrations:
+        descriptor = _project_registration_csv_descriptor(registration)
+        code_key = _normalize_worktime_csv_text(descriptor["project_code"]).casefold()
+        if code_key:
+            projects_by_code[code_key] = registration
+        project_key = _worktime_csv_project_key(
+            descriptor["project_code"],
+            descriptor["type_label"],
+            descriptor["name_label"],
+        )
+        if project_key in projects_by_key:
+            duplicate_project_keys.add(project_key)
+            continue
+        projects_by_key[project_key] = registration
+    for project_key in duplicate_project_keys:
+        projects_by_key.pop(project_key, None)
+    return projects_by_code, projects_by_key, duplicate_project_keys
+
+
+def _resolve_worktime_csv_project_registration(project_code, type_label, name_label, *, projects_by_code, projects_by_key, duplicate_project_keys):
+    code_key = _normalize_worktime_csv_text(project_code).casefold()
+    if code_key:
+        registration = projects_by_code.get(code_key)
+        if registration is not None:
+            return registration
+    project_key = _worktime_csv_project_key(project_code, type_label, name_label)
+    if project_key in duplicate_project_keys:
+        raise forms.ValidationError("проект определен неоднозначно.")
+    return projects_by_key.get(project_key)
+
+
+def _find_or_create_worktime_csv_assignment(
+    *,
+    employee_name,
+    project_code,
+    type_label,
+    name_label,
+    week_starts,
+    row_key,
+    assignments_by_key,
+    projects_by_code,
+    projects_by_key,
+    duplicate_project_keys,
+):
+    assignment = assignments_by_key.get(row_key)
+    if assignment is not None:
+        return assignment, False
+
+    if not week_starts:
+        return None, False
+
+    normalized_name, employee = resolve_employee_and_name(executor_name=employee_name)
+    if employee is None or not normalized_name or not is_worktime_eligible_employee(employee):
+        raise forms.ValidationError(f'сотрудник "{employee_name}" не найден среди штатных сотрудников.')
+
+    registration = _resolve_worktime_csv_project_registration(
+        project_code,
+        type_label,
+        name_label,
+        projects_by_code=projects_by_code,
+        projects_by_key=projects_by_key,
+        duplicate_project_keys=duplicate_project_keys,
+    )
+    if registration is None:
+        raise forms.ValidationError(
+            f'проект "{project_code or name_label or "без названия"}" не найден среди существующих проектов.'
+        )
+
+    assignment, _ = ensure_personal_week_assignment(
+        registration=registration,
+        employee=employee,
+        week_start=week_starts[0],
+        record_type=WorktimeAssignment.RecordType.PROJECT,
+    )
+    if assignment is None:
+        raise forms.ValidationError("не удалось создать строку табеля для проекта и сотрудника.")
+
+    for week_start in week_starts[1:]:
+        PersonalWorktimeWeekAssignment.objects.get_or_create(
+            assignment=assignment,
+            week_start=week_start,
+        )
+
+    assignments_by_key[row_key] = assignment
+    assignments_by_key[_worktime_csv_assignment_key(assignment)] = assignment
+    return assignment, True
+
+
+def _read_uploaded_csv_rows(csv_file):
+    if not csv_file:
+        raise forms.ValidationError("Файл не выбран.")
+    if not csv_file.name.lower().endswith(".csv"):
+        raise forms.ValidationError("Допустимы только файлы CSV.")
+    raw_bytes = csv_file.read()
+    raw_text = None
+    for encoding in ("utf-8-sig", "utf-8", "cp1251"):
+        try:
+            raw_text = raw_bytes.decode(encoding)
+            break
+        except (UnicodeDecodeError, ValueError):
+            continue
+    if raw_text is None:
+        raise forms.ValidationError("Не удалось прочитать файл. Проверьте кодировку (UTF-8 или Windows-1251).")
+    reader = csv.reader(io.StringIO(raw_text), delimiter=";")
+    rows = list(reader)
+    if rows and len(rows[0]) <= 1:
+        reader = csv.reader(io.StringIO(raw_text), delimiter=",")
+        rows = list(reader)
+    if not rows:
+        raise forms.ValidationError("Файл пуст.")
+    if len(rows) < 2:
+        raise forms.ValidationError("Файл должен содержать заголовок и хотя бы одну строку данных.")
+    return rows
+
+
+def _validate_worktime_csv_header(header, month_days):
+    expected_header = _worktime_csv_headers(month_days)
+    normalized_header = list(header or [])
+    while normalized_header and not _normalize_worktime_csv_text(normalized_header[-1]):
+        normalized_header.pop()
+    normalized_header = [_normalize_worktime_csv_text(cell) for cell in normalized_header]
+    if normalized_header != expected_header:
+        raise forms.ValidationError(
+            "CSV должен содержать колонки: "
+            + ", ".join(expected_header)
+            + "."
+        )
+
+
+def _normalize_worktime_csv_row(row, expected_length):
+    normalized_row = list(row or [])
+    if len(normalized_row) < expected_length:
+        normalized_row.extend([""] * (expected_length - len(normalized_row)))
+        return normalized_row
+    if len(normalized_row) > expected_length:
+        extra_cells = normalized_row[expected_length:]
+        if any(_normalize_worktime_csv_text(cell) for cell in extra_cells):
+            raise forms.ValidationError("Строка содержит лишние столбцы.")
+        return normalized_row[:expected_length]
+    return normalized_row
+
+
+def _parse_worktime_csv_hours(raw_value, work_day, *, row_number):
+    raw_text = str(raw_value or "").strip()
+    if not raw_text:
+        return None
+    try:
+        hours = int(raw_text)
+    except (TypeError, ValueError):
+        raise forms.ValidationError(
+            f"Строка {row_number}: значение за {work_day.strftime('%d.%m.%Y')} должно быть целым числом."
+        )
+    if hours < 0 or hours > MAX_HOURS_PER_DAY:
+        raise forms.ValidationError(
+            f"Строка {row_number}: количество часов за {work_day.strftime('%d.%m.%Y')} должно быть в диапазоне от 0 до {MAX_HOURS_PER_DAY}."
+        )
+    return hours
+
+
+def _parse_worktime_csv_row_values(month_days, raw_values, *, row_number):
+    return {
+        work_day: _parse_worktime_csv_hours(cell_value, work_day, row_number=row_number)
+        for work_day, cell_value in zip(month_days, raw_values)
+    }
+
+
+def _worktime_csv_week_starts(day_values):
+    return sorted({
+        _start_of_week(work_day)
+        for work_day, hours in (day_values or {}).items()
+        if hours is not None
+    })
+
+
 def _base_worktime_assignment_queryset():
     return WorktimeAssignment.objects.select_related(
         "registration",
@@ -179,6 +477,11 @@ def _current_employee_and_name(user):
 
 def _has_worktime_access(user):
     return is_worktime_eligible_employee(getattr(user, "employee_profile", None))
+
+
+def _has_worktime_csv_access(user):
+    employee = getattr(user, "employee_profile", None)
+    return _has_worktime_access(user) and getattr(employee, "role", "") == ADMIN_GROUP
 
 
 def _assignment_is_worktime_visible(assignment):
@@ -653,6 +956,12 @@ def _worktime_context(
         if general_scale == "year"
         else f"{MONTH_LABELS[month_start.month]}, {month_start.year} г."
     )
+    csv_controls_enabled = (
+        (not personal_only)
+        and _has_worktime_csv_access(user)
+        and _worktime_csv_controls_enabled(general_scale, breakdown_value)
+    )
+    csv_controls_visible = (not personal_only) and _has_worktime_csv_access(user)
 
     return {
         "groups": groups,
@@ -689,6 +998,11 @@ def _worktime_context(
         "period_label": period_label,
         "column_totals": column_totals,
         "grand_total": grand_total,
+        "worktime_csv_controls_visible": csv_controls_visible,
+        "worktime_csv_controls_enabled": csv_controls_enabled,
+        "worktime_csv_upload_url": reverse("worktime_csv_upload") if not personal_only else "",
+        "worktime_csv_download_url": reverse("worktime_csv_download") if not personal_only else "",
+        "worktime_csv_disabled_hint": WORKTIME_CSV_MODE_ERROR,
         "partial_path": reverse("personal_worktime_partial" if personal_only else "worktime_partial"),
         "personal_add_row_url": reverse("personal_worktime_row_form") if personal_only else "",
         "current_employee_name": current_employee_name or "—",
@@ -716,6 +1030,46 @@ def _parse_hours_payload(request_post, assignment_ids, month_days):
                 )
             parsed[(assignment_id, work_day)] = hours
     return parsed
+
+
+def _sync_worktime_entries(parsed_values, *, assignment_ids, range_start, range_end):
+    existing_entries = {
+        (entry.assignment_id, entry.work_date): entry
+        for entry in WorktimeEntry.objects.filter(
+            assignment_id__in=assignment_ids,
+            work_date__range=(range_start, range_end),
+        )
+    }
+    to_create = []
+    to_update = []
+    to_delete_ids = []
+
+    for key, hours in parsed_values.items():
+        existing = existing_entries.get(key)
+        if hours is None:
+            if existing is not None:
+                to_delete_ids.append(existing.pk)
+            continue
+        if existing is None:
+            to_create.append(WorktimeEntry(assignment_id=key[0], work_date=key[1], hours=hours))
+            continue
+        if existing.hours != hours:
+            existing.hours = hours
+            to_update.append(existing)
+
+    with transaction.atomic():
+        if to_delete_ids:
+            WorktimeEntry.objects.filter(pk__in=to_delete_ids).delete()
+        if to_create:
+            WorktimeEntry.objects.bulk_create(to_create)
+        if to_update:
+            WorktimeEntry.objects.bulk_update(to_update, ["hours", "updated_at"])
+
+    return {
+        "created": len(to_create),
+        "updated": len(to_update),
+        "deleted": len(to_delete_ids),
+    }
 
 
 def _render_worktime_panel(request, *, personal_only=False, month_start=None, error_message="", success_message=""):
@@ -751,6 +1105,179 @@ def worktime_partial(request):
             breakdown=request.GET.get("breakdown"),
         ),
     )
+
+
+@login_required
+@require_http_methods(["POST"])
+def worktime_csv_upload(request):
+    if not _has_worktime_access(request.user):
+        return JsonResponse({"ok": False, "error": WORKTIME_ACCESS_ERROR}, status=403)
+    if not _has_worktime_csv_access(request.user):
+        return JsonResponse({"ok": False, "error": WORKTIME_CSV_ADMIN_ERROR}, status=403)
+
+    scale, breakdown, period_start = _resolve_general_worktime_request_state(request)
+    if not _worktime_csv_controls_enabled(scale, breakdown):
+        return JsonResponse({"ok": False, "error": WORKTIME_CSV_MODE_ERROR}, status=400)
+
+    try:
+        rows = _read_uploaded_csv_rows(request.FILES.get("csv_file"))
+    except forms.ValidationError as exc:
+        return JsonResponse({"ok": False, "error": exc.message}, status=400)
+
+    month_days, range_start, range_end, assignments = _general_worktime_period_data(
+        request.user,
+        period_start,
+        scale=scale,
+        breakdown=breakdown,
+    )
+    try:
+        _validate_worktime_csv_header(rows[0], month_days)
+    except forms.ValidationError as exc:
+        return JsonResponse({"ok": False, "error": exc.message}, status=400)
+
+    assignments_by_key, duplicate_keys = _build_worktime_csv_assignment_index(assignments)
+    projects_by_code, projects_by_key, duplicate_project_keys = _build_worktime_csv_project_index()
+    expected_row_length = len(_worktime_csv_headers(month_days))
+    warnings = []
+    parsed_values = {}
+    touched_assignment_ids = []
+    touched_keys = set()
+    created_assignments_count = 0
+
+    for row_number, raw_row in enumerate(rows[1:], start=2):
+        if not any(_normalize_worktime_csv_text(cell) for cell in raw_row):
+            continue
+        try:
+            row = _normalize_worktime_csv_row(raw_row, expected_row_length)
+        except forms.ValidationError as exc:
+            warnings.append(f"Строка {row_number}: {exc.message}")
+            continue
+
+        employee_name, project_code, type_label, name_label = row[:4]
+        row_key = _worktime_csv_row_key(employee_name, project_code, type_label, name_label)
+        row_label = _normalize_worktime_csv_text(name_label) or _normalize_worktime_csv_text(project_code) or "без названия"
+
+        if row_key in touched_keys:
+            warnings.append(f'Строка {row_number}: дублирует запись табеля сотрудника "{employee_name}" ({row_label}).')
+            continue
+        if row_key in duplicate_keys:
+            warnings.append(f'Строка {row_number}: строка табеля для сотрудника "{employee_name}" определена неоднозначно.')
+            continue
+
+        try:
+            row_day_values = _parse_worktime_csv_row_values(
+                month_days,
+                row[4:],
+                row_number=row_number,
+            )
+        except forms.ValidationError as exc:
+            warnings.append(exc.message)
+            continue
+
+        week_starts = _worktime_csv_week_starts(row_day_values)
+        try:
+            assignment, assignment_created = _find_or_create_worktime_csv_assignment(
+                employee_name=employee_name,
+                project_code=project_code,
+                type_label=type_label,
+                name_label=name_label,
+                week_starts=week_starts,
+                row_key=row_key,
+                assignments_by_key=assignments_by_key,
+                projects_by_code=projects_by_code,
+                projects_by_key=projects_by_key,
+                duplicate_project_keys=duplicate_project_keys,
+            )
+        except forms.ValidationError as exc:
+            warnings.append(f"Строка {row_number}: {exc.message}")
+            continue
+        if assignment is None:
+            continue
+        if assignment_created:
+            created_assignments_count += 1
+
+        row_payload = {
+            (assignment.pk, work_day): hours
+            for work_day, hours in row_day_values.items()
+        }
+
+        touched_keys.add(row_key)
+        touched_assignment_ids.append(assignment.pk)
+        parsed_values.update(row_payload)
+
+    if not touched_assignment_ids:
+        payload = {"ok": False, "error": "Не удалось обработать ни одной строки табеля."}
+        if warnings:
+            payload["warnings"] = warnings[:50]
+        return JsonResponse(payload, status=400)
+
+    sync_result = _sync_worktime_entries(
+        parsed_values,
+        assignment_ids=touched_assignment_ids,
+        range_start=range_start,
+        range_end=range_end,
+    )
+    result = {
+        "ok": True,
+        "created": sync_result["created"],
+        "updated": sync_result["updated"],
+        "deleted": sync_result["deleted"],
+    }
+    if created_assignments_count:
+        result["created_assignments"] = created_assignments_count
+    if warnings:
+        result["warnings"] = warnings[:50]
+    return JsonResponse(result)
+
+
+@login_required
+@require_http_methods(["GET"])
+def worktime_csv_download(request):
+    if not _has_worktime_access(request.user):
+        return HttpResponseForbidden(WORKTIME_ACCESS_ERROR)
+    if not _has_worktime_csv_access(request.user):
+        return HttpResponseForbidden(WORKTIME_CSV_ADMIN_ERROR)
+
+    scale, breakdown, period_start = _resolve_general_worktime_request_state(request)
+    if not _worktime_csv_controls_enabled(scale, breakdown):
+        return HttpResponseBadRequest(WORKTIME_CSV_MODE_ERROR)
+
+    month_days, range_start, range_end, assignments = _general_worktime_period_data(
+        request.user,
+        period_start,
+        scale=scale,
+        breakdown=breakdown,
+    )
+    entries = (
+        WorktimeEntry.objects
+        .filter(assignment_id__in=[assignment.pk for assignment in assignments], work_date__range=(range_start, range_end))
+        .only("assignment_id", "work_date", "hours")
+    )
+    entry_map = _build_entry_map(entries, scale=scale)
+
+    response = HttpResponse(content_type="text/csv; charset=utf-8")
+    response["Content-Disposition"] = f'attachment; filename="worktime-{period_start:%Y-%m}.csv"'
+    response.write("\ufeff")
+    writer = csv.writer(response, delimiter=";")
+    writer.writerow(_worktime_csv_headers(month_days))
+
+    for assignment in assignments:
+        descriptor = _worktime_csv_row_descriptor(assignment)
+        day_values = entry_map.get(assignment.pk, {})
+        writer.writerow(
+            [
+                descriptor["employee_name"],
+                descriptor["project_code"],
+                descriptor["type_label"],
+                descriptor["name_label"],
+                *[
+                    "" if day_values.get(work_day) is None else day_values.get(work_day)
+                    for work_day in month_days
+                ],
+            ]
+        )
+
+    return response
 
 
 @login_required
@@ -916,38 +1443,12 @@ def worktime_save(request):
             month_start=month_start,
             error_message=exc.message,
         )
-
-    existing_entries = {
-        (entry.assignment_id, entry.work_date): entry
-        for entry in WorktimeEntry.objects.filter(
-            assignment_id__in=assignment_ids,
-            work_date__range=(range_start, range_end),
-        )
-    }
-    to_create = []
-    to_update = []
-    to_delete_ids = []
-
-    for key, hours in parsed_values.items():
-        existing = existing_entries.get(key)
-        if hours is None:
-            if existing is not None:
-                to_delete_ids.append(existing.pk)
-            continue
-        if existing is None:
-            to_create.append(WorktimeEntry(assignment_id=key[0], work_date=key[1], hours=hours))
-            continue
-        if existing.hours != hours:
-            existing.hours = hours
-            to_update.append(existing)
-
-    with transaction.atomic():
-        if to_delete_ids:
-            WorktimeEntry.objects.filter(pk__in=to_delete_ids).delete()
-        if to_create:
-            WorktimeEntry.objects.bulk_create(to_create)
-        if to_update:
-            WorktimeEntry.objects.bulk_update(to_update, ["hours", "updated_at"])
+    _sync_worktime_entries(
+        parsed_values,
+        assignment_ids=assignment_ids,
+        range_start=range_start,
+        range_end=range_end,
+    )
 
     if autosave:
         return JsonResponse({"ok": True})


### PR DESCRIPTION
## Summary
- make CSV-created worktime assignments week-scoped instead of permanent
- align imported assignments with manual personal worktime behavior
- update targeted tests
## Test plan
- run focused worktime CSV tests
- verify CI/CD pipeline