### PR TITLE
Support decimal worktime hours in worktime CSV import

### DIFF
--- a/worktime_app/migrations/0006_alter_worktimeentry_hours_decimal.py
+++ b/worktime_app/migrations/0006_alter_worktimeentry_hours_decimal.py
@@ -1,0 +1,22 @@
+from django.core import validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("worktime_app", "0005_worktimeassignment_proposal_registration"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="worktimeentry",
+            name="hours",
+            field=models.DecimalField(
+                decimal_places=2,
+                max_digits=5,
+                validators=[validators.MinValueValidator(0), validators.MaxValueValidator(24)],
+                verbose_name="Количество часов",
+            ),
+        ),
+    ]

--- a/worktime_app/models.py
+++ b/worktime_app/models.py
@@ -155,8 +155,10 @@ class WorktimeEntry(models.Model):
         verbose_name="Строка табеля",
     )
     work_date = models.DateField("Дата")
-    hours = models.PositiveIntegerField(
+    hours = models.DecimalField(
         "Количество часов",
+        max_digits=5,
+        decimal_places=2,
         validators=[MinValueValidator(0), MaxValueValidator(24)],
     )
     created_at = models.DateTimeField(auto_now_add=True)

--- a/worktime_app/templates/worktime_app/worktime_partial.html
+++ b/worktime_app/templates/worktime_app/worktime_partial.html
@@ -265,10 +265,10 @@
                   <td class="p-1 worktime-flex-cell">
                     <input type="number"
                            name="{{ cell.input_name }}"
-                           value="{{ cell.value|default_if_none:'' }}"
+                           value="{{ cell.value|default_if_none:''|unlocalize }}"
                            min="0"
                            max="24"
-                           step="1"
+                           step="0.01"
                            class="form-control form-control-sm worktime-cell-input"
                            data-worktime-grid-input
                            aria-label="Часы за {{ cell.date|date:'d.m.Y' }}">

--- a/worktime_app/tests.py
+++ b/worktime_app/tests.py
@@ -2,23 +2,26 @@ import csv
 import io
 from calendar import monthrange
 from datetime import date, timedelta
+from decimal import Decimal
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import connection
 from django.template.loader import render_to_string
 from django.test import RequestFactory, TestCase
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 
 from notifications_app.models import Notification, NotificationPerformerLink
 from notifications_app.services import process_participation_notification
 from policy_app.models import ADMIN_GROUP, DEPARTMENT_HEAD_GROUP, Product
-from projects_app.models import Performer, ProjectRegistration
+from projects_app.models import Performer, ProjectRegistration, ProjectRegistrationProduct
 from proposals_app.models import ProposalRegistration
 from users_app.models import Employee
 from worktime_app.models import PersonalWorktimeWeekAssignment, WorktimeAssignment, WorktimeEntry
-from worktime_app.views import _attach_group_histograms, _worktime_context
+from worktime_app.views import _attach_group_histograms, _build_worktime_csv_project_index, _worktime_context
 
 
 class WorktimeAppTests(TestCase):
@@ -602,6 +605,39 @@ class WorktimeAppTests(TestCase):
             [
                 (date(2026, 4, 1), 8),
                 (date(2026, 4, 2), 6),
+            ],
+        )
+
+    def test_save_accepts_decimal_hours_for_month(self):
+        assignment = WorktimeAssignment.objects.create(
+            registration=self.registration,
+            employee=self.employee,
+            executor_name=self._full_name(self.employee),
+            source_type=WorktimeAssignment.SourceType.PERFORMER_CONFIRMATION,
+        )
+
+        response = self.client.post(
+            reverse("worktime_save"),
+            {
+                "scope": "all",
+                "month": "2026-04",
+                "assignment_ids": [str(assignment.pk)],
+                f"hours_{assignment.pk}_20260401": "7.5",
+                f"hours_{assignment.pk}_20260402": "0,25",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Табель сохранен.")
+        self.assertEqual(
+            list(
+                WorktimeEntry.objects.filter(assignment=assignment)
+                .order_by("work_date")
+                .values_list("work_date", "hours")
+            ),
+            [
+                (date(2026, 4, 1), Decimal("7.50")),
+                (date(2026, 4, 2), Decimal("0.25")),
             ],
         )
 
@@ -1272,6 +1308,147 @@ class WorktimeAppTests(TestCase):
         hidden_response = self.client.get(reverse("personal_worktime_partial"), {"week": "2026-04-14"})
         self.assertContains(visible_response, self.second_registration.name)
         self.assertNotContains(hidden_response, self.second_registration.name)
+
+    def test_worktime_csv_upload_accepts_decimal_hours(self):
+        assignment = WorktimeAssignment.objects.create(
+            registration=self.registration,
+            employee=self.employee,
+            executor_name=self._full_name(self.employee),
+            source_type=WorktimeAssignment.SourceType.PERFORMER_CONFIRMATION,
+        )
+        april_days = [""] * 30
+        april_days[0] = "7,5"
+        april_days[1] = "0.25"
+        upload = self._make_worktime_csv_upload(
+            self._worktime_csv_header("2026-04"),
+            [[
+                self._full_name(self.employee),
+                assignment.display_project_code,
+                assignment.display_type_label,
+                assignment.display_project_name,
+                *april_days,
+            ]],
+        )
+
+        response = self.client.post(
+            reverse("worktime_csv_upload"),
+            {
+                "csv_file": upload,
+                "scale": "month",
+                "period": "2026-04",
+                "breakdown": "employees",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"ok": True, "created": 2, "updated": 0, "deleted": 0},
+        )
+        self.assertEqual(
+            list(
+                WorktimeEntry.objects.filter(assignment=assignment)
+                .order_by("work_date")
+                .values_list("work_date", "hours")
+            ),
+            [
+                (date(2026, 4, 1), Decimal("7.50")),
+                (date(2026, 4, 2), Decimal("0.25")),
+            ],
+        )
+
+    def test_worktime_csv_upload_reuses_existing_manual_assignment_and_adds_missing_week_links(self):
+        assignment = WorktimeAssignment.objects.create(
+            registration=self.second_registration,
+            employee=self.employee,
+            executor_name=self._full_name(self.employee),
+            source_type=WorktimeAssignment.SourceType.MANUAL_PERSONAL_WEEK,
+        )
+        PersonalWorktimeWeekAssignment.objects.create(
+            assignment=assignment,
+            week_start=date(2026, 3, 30),
+        )
+        WorktimeEntry.objects.create(assignment=assignment, work_date=date(2026, 4, 1), hours=8)
+
+        april_days = [""] * 30
+        april_days[0] = "8"
+        april_days[13] = "6"
+        upload = self._make_worktime_csv_upload(
+            self._worktime_csv_header("2026-04"),
+            [[
+                self._full_name(self.employee),
+                self.second_registration.short_uid,
+                self.second_registration.type_short_display or "—",
+                self.second_registration.name,
+                *april_days,
+            ]],
+        )
+
+        response = self.client.post(
+            reverse("worktime_csv_upload"),
+            {
+                "csv_file": upload,
+                "scale": "month",
+                "period": "2026-04",
+                "breakdown": "employees",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"ok": True, "created": 1, "updated": 0, "deleted": 0},
+        )
+        self.assertTrue(
+            PersonalWorktimeWeekAssignment.objects.filter(
+                assignment=assignment,
+                week_start=date(2026, 4, 13),
+            ).exists()
+        )
+        self.assertEqual(
+            list(
+                WorktimeEntry.objects.filter(assignment=assignment)
+                .order_by("work_date")
+                .values_list("work_date", "hours")
+            ),
+            [(date(2026, 4, 1), 8), (date(2026, 4, 14), 6)],
+        )
+        visible_response = self.client.get(reverse("personal_worktime_partial"), {"week": "2026-04-14"})
+        self.assertContains(visible_response, self.second_registration.name)
+
+    def test_build_worktime_csv_project_index_prefetches_product_links(self):
+        third_registration = ProjectRegistration.objects.create(
+            number=4446,
+            type=self.product,
+            name="Проект Гамма",
+            deadline=date(2026, 4, 30),
+        )
+        for registration, rank in (
+            (self.registration, 1),
+            (self.second_registration, 2),
+            (third_registration, 3),
+        ):
+            ProjectRegistrationProduct.objects.create(
+                registration=registration,
+                product=self.product,
+                rank=rank,
+            )
+
+        with CaptureQueriesContext(connection) as queries:
+            projects_by_code, projects_by_key, duplicate_keys = _build_worktime_csv_project_index()
+
+        self.assertLessEqual(len(queries), 3)
+        self.assertIn(self.registration.short_uid.casefold(), projects_by_code)
+        self.assertIn(third_registration.short_uid.casefold(), projects_by_code)
+        self.assertFalse(duplicate_keys)
+        self.assertIn(
+            (
+                self.registration.short_uid.casefold(),
+                (self.registration.type_short_display or "—").casefold(),
+                self.registration.name.casefold(),
+            ),
+            projects_by_key,
+        )
 
     def test_worktime_csv_upload_rejects_missing_file(self):
         response = self.client.post(

--- a/worktime_app/views.py
+++ b/worktime_app/views.py
@@ -3,6 +3,7 @@ import io
 import json
 from calendar import monthrange
 from datetime import date, datetime, timedelta
+from decimal import Decimal, InvalidOperation
 
 from django import forms
 from django.contrib.auth.decorators import login_required
@@ -56,7 +57,8 @@ MONTH_SHORT_LABELS = {
     12: "Дек",
 }
 WEEKDAY_LABELS = ("Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс")
-MAX_HOURS_PER_DAY = 24
+MAX_HOURS_PER_DAY = Decimal("24")
+WORKTIME_HOURS_QUANT = Decimal("0.01")
 PERSONAL_WEEK_LIMIT_WEEKS = 2
 PERSONAL_WEEK_LIMIT_ERROR = "Нельзя выбрать слишком далекую будущую неделю. Доступны текущая неделя и только две следующие."
 WORKTIME_ACCESS_ERROR = 'Табель доступен только штатным сотрудникам с правами staff. Пользователи с трудоустройством "Внештатный сотрудник" не допускаются.'
@@ -280,6 +282,7 @@ def _build_worktime_csv_project_index():
     registrations = (
         ProjectRegistration.objects
         .select_related("type")
+        .prefetch_related("product_links__product")
         .order_by("id")
     )
     for registration in registrations:
@@ -328,6 +331,7 @@ def _find_or_create_worktime_csv_assignment(
 ):
     assignment = assignments_by_key.get(row_key)
     if assignment is not None:
+        _ensure_worktime_csv_week_links(assignment, week_starts)
         return assignment, False
 
     if not week_starts:
@@ -359,11 +363,7 @@ def _find_or_create_worktime_csv_assignment(
     if assignment is None:
         raise forms.ValidationError("не удалось создать строку табеля для проекта и сотрудника.")
 
-    for week_start in week_starts[1:]:
-        PersonalWorktimeWeekAssignment.objects.get_or_create(
-            assignment=assignment,
-            week_start=week_start,
-        )
+    _ensure_worktime_csv_week_links(assignment, week_starts)
 
     assignments_by_key[row_key] = assignment
     assignments_by_key[_worktime_csv_assignment_key(assignment)] = assignment
@@ -425,20 +425,19 @@ def _normalize_worktime_csv_row(row, expected_length):
 
 
 def _parse_worktime_csv_hours(raw_value, work_day, *, row_number):
-    raw_text = str(raw_value or "").strip()
-    if not raw_text:
-        return None
-    try:
-        hours = int(raw_text)
-    except (TypeError, ValueError):
-        raise forms.ValidationError(
-            f"Строка {row_number}: значение за {work_day.strftime('%d.%m.%Y')} должно быть целым числом."
-        )
-    if hours < 0 or hours > MAX_HOURS_PER_DAY:
-        raise forms.ValidationError(
-            f"Строка {row_number}: количество часов за {work_day.strftime('%d.%m.%Y')} должно быть в диапазоне от 0 до {MAX_HOURS_PER_DAY}."
-        )
-    return hours
+    return _parse_worktime_hours_value(
+        raw_value,
+        work_day,
+        invalid_message=f"Строка {row_number}: значение за {work_day.strftime('%d.%m.%Y')} должно быть числом.",
+        precision_message=(
+            f"Строка {row_number}: значение за {work_day.strftime('%d.%m.%Y')} "
+            "должно быть числом с не более чем двумя знаками после запятой."
+        ),
+        range_message=(
+            f"Строка {row_number}: количество часов за {work_day.strftime('%d.%m.%Y')} "
+            f"должно быть в диапазоне от 0 до {MAX_HOURS_PER_DAY}."
+        ),
+    )
 
 
 def _parse_worktime_csv_row_values(month_days, raw_values, *, row_number):
@@ -454,6 +453,34 @@ def _worktime_csv_week_starts(day_values):
         for work_day, hours in (day_values or {}).items()
         if hours is not None
     })
+
+
+def _ensure_worktime_csv_week_links(assignment, week_starts):
+    if assignment is None or assignment.source_type != WorktimeAssignment.SourceType.MANUAL_PERSONAL_WEEK:
+        return
+    for week_start in week_starts or []:
+        PersonalWorktimeWeekAssignment.objects.get_or_create(
+            assignment=assignment,
+            week_start=week_start,
+        )
+
+
+def _parse_worktime_hours_value(raw_value, work_day, *, invalid_message, precision_message, range_message):
+    raw_text = str(raw_value or "").strip().replace(",", ".")
+    if not raw_text:
+        return None
+    try:
+        hours = Decimal(raw_text)
+    except (InvalidOperation, TypeError, ValueError):
+        raise forms.ValidationError(invalid_message)
+    if not hours.is_finite():
+        raise forms.ValidationError(invalid_message)
+    normalized_hours = hours.quantize(WORKTIME_HOURS_QUANT)
+    if normalized_hours != hours:
+        raise forms.ValidationError(precision_message)
+    if normalized_hours < 0 or normalized_hours > MAX_HOURS_PER_DAY:
+        raise forms.ValidationError(range_message)
+    return normalized_hours
 
 
 def _base_worktime_assignment_queryset():
@@ -1018,17 +1045,19 @@ def _parse_hours_payload(request_post, assignment_ids, month_days):
             if not raw_value:
                 parsed[(assignment_id, work_day)] = None
                 continue
-            try:
-                hours = int(raw_value)
-            except (TypeError, ValueError):
-                raise forms.ValidationError(
-                    f"Значение за {work_day.strftime('%d.%m.%Y')} должно быть целым числом."
-                )
-            if hours < 0 or hours > MAX_HOURS_PER_DAY:
-                raise forms.ValidationError(
-                    f"Количество часов за {work_day.strftime('%d.%m.%Y')} должно быть в диапазоне от 0 до {MAX_HOURS_PER_DAY}."
-                )
-            parsed[(assignment_id, work_day)] = hours
+            parsed[(assignment_id, work_day)] = _parse_worktime_hours_value(
+                raw_value,
+                work_day,
+                invalid_message=f"Значение за {work_day.strftime('%d.%m.%Y')} должно быть числом.",
+                precision_message=(
+                    f"Значение за {work_day.strftime('%d.%m.%Y')} "
+                    "должно быть числом с не более чем двумя знаками после запятой."
+                ),
+                range_message=(
+                    f"Количество часов за {work_day.strftime('%d.%m.%Y')} "
+                    f"должно быть в диапазоне от 0 до {MAX_HOURS_PER_DAY}."
+                ),
+            )
     return parsed
 
 


### PR DESCRIPTION
## Summary
- support decimal hours in worktime CSV import
- support decimal hours in worktime table editing
- add migration and targeted tests
## Test plan
- python manage.py migrate
- python manage.py test worktime_app.tests.WorktimeAppTests.test_save_accepts_decimal_hours_for_month worktime_app.tests.WorktimeAppTests.test_worktime_csv_upload_accepts_decimal_hours worktime_app.tests.WorktimeAppTests.test_worktime_csv_upload_rejects_hours_out_of_range worktime_app.tests.WorktimeAppTests.test_worktime_csv_upload_creates_missing_assignment_for_existing_project_and_employee
- python manage.py makemigrations --check