### PR TITLE
Update worktime week calendar behavior

### DIFF
--- a/worktime_app/templates/worktime_app/worktime_partial.html
+++ b/worktime_app/templates/worktime_app/worktime_partial.html
@@ -334,8 +334,9 @@
                              data-worktime-calculated-downtime-input
                              data-worktime-scheduled-hours="{{ cell.scheduled_hours|default:0|unlocalize }}"
                              disabled
-                           {% elif cell.is_vacation_non_working_day %}
-                             data-worktime-vacation-non-working-input
+                          {% elif cell.is_blocked_non_working_day %}
+                            data-worktime-blocked-non-working-input
+                            {% if cell.is_vacation_non_working_day %}data-worktime-vacation-non-working-input{% endif %}
                              disabled
                            {% endif %}
                            aria-label="Часы за {{ cell.date|date:'d.m.Y' }}">
@@ -858,11 +859,15 @@
   .worktime-calendar-wrap {
     width: 100%;
     min-width: 0;
-    overflow-x: auto;
+    overflow-x: hidden;
     overflow-y: hidden;
     max-width: 100%;
     padding-bottom: .55rem;
     -webkit-overflow-scrolling: touch;
+  }
+
+  .worktime-calendar-wrap.worktime-calendar-wrap-scrollable {
+    overflow-x: auto;
   }
 
   .worktime-calendar-table {
@@ -2554,34 +2559,6 @@
     border-bottom-right-radius: .35rem;
   }
 
-  .flatpickr-calendar .flatpickr-day.worktime-week-hover.worktime-production-holiday-day:not(.prevMonthDay):not(.nextMonthDay),
-  .flatpickr-calendar .flatpickr-day.worktime-week-hover.worktime-production-holiday-day:not(.prevMonthDay):not(.nextMonthDay):hover {
-    --worktime-week-fill: #f1f3f5;
-    --worktime-week-border: #adb5bd;
-  }
-
-  .flatpickr-calendar .flatpickr-day.worktime-week-hover.worktime-production-holiday-day:not(.prevMonthDay):not(.nextMonthDay)::before {
-    left: -1px;
-    right: -1px;
-    border-left: 0;
-    border-right: 0;
-    border-radius: 0;
-  }
-
-  .flatpickr-calendar .dayContainer .flatpickr-day.worktime-week-hover.worktime-production-holiday-day:nth-child(7n+1)::before {
-    left: 0;
-    border-left: 1px solid var(--worktime-week-border);
-    border-top-left-radius: .35rem;
-    border-bottom-left-radius: .35rem;
-  }
-
-  .flatpickr-calendar .dayContainer .flatpickr-day.worktime-week-hover.worktime-production-holiday-day:nth-child(7n)::before {
-    right: 0;
-    border-right: 1px solid var(--worktime-week-border);
-    border-top-right-radius: .35rem;
-    border-bottom-right-radius: .35rem;
-  }
-
   .flatpickr-calendar .flatpickr-day.worktime-week-selected.worktime-production-holiday-day:not(.prevMonthDay):not(.nextMonthDay),
   .flatpickr-calendar .flatpickr-day.worktime-week-selected.worktime-production-holiday-day:not(.prevMonthDay):not(.nextMonthDay):hover {
     --worktime-week-fill: rgba(13, 110, 253, .10);
@@ -2604,6 +2581,34 @@
   }
 
   .flatpickr-calendar .dayContainer .flatpickr-day.worktime-week-selected.worktime-production-holiday-day:nth-child(7n)::before {
+    right: 0;
+    border-right: 1px solid var(--worktime-week-border);
+    border-top-right-radius: .35rem;
+    border-bottom-right-radius: .35rem;
+  }
+
+  .flatpickr-calendar .flatpickr-day.worktime-week-hover.worktime-production-holiday-day:not(.prevMonthDay):not(.nextMonthDay),
+  .flatpickr-calendar .flatpickr-day.worktime-week-hover.worktime-production-holiday-day:not(.prevMonthDay):not(.nextMonthDay):hover {
+    --worktime-week-fill: #f1f3f5;
+    --worktime-week-border: #adb5bd;
+  }
+
+  .flatpickr-calendar .flatpickr-day.worktime-week-hover.worktime-production-holiday-day:not(.prevMonthDay):not(.nextMonthDay)::before {
+    left: -1px;
+    right: -1px;
+    border-left: 0;
+    border-right: 0;
+    border-radius: 0;
+  }
+
+  .flatpickr-calendar .dayContainer .flatpickr-day.worktime-week-hover.worktime-production-holiday-day:nth-child(7n+1)::before {
+    left: 0;
+    border-left: 1px solid var(--worktime-week-border);
+    border-top-left-radius: .35rem;
+    border-bottom-left-radius: .35rem;
+  }
+
+  .flatpickr-calendar .dayContainer .flatpickr-day.worktime-week-hover.worktime-production-holiday-day:nth-child(7n)::before {
     right: 0;
     border-right: 1px solid var(--worktime-week-border);
     border-top-right-radius: .35rem;
@@ -2718,8 +2723,10 @@
     var worktimeTableResizeObserver = window.__worktimeTableResizeObserver || null;
     var worktimeAutosaveStates = window.__worktimeAutosaveStates || new WeakMap();
     var cleanupWorktimeFloatingScroll = window.__cleanupWorktimeFloatingScroll || null;
+    var cleanupWorktimeStickyHeader = window.__cleanupWorktimeStickyHeader || null;
     window.__worktimeAutosaveStates = worktimeAutosaveStates;
     window.__cleanupWorktimeFloatingScroll = cleanupWorktimeFloatingScroll;
+    window.__cleanupWorktimeStickyHeader = cleanupWorktimeStickyHeader;
 
     function getStoredWorktimeGeneralCollapseState() {
       try {
@@ -3240,7 +3247,7 @@
     function syncWorktimeWrapOverflowState(wrap, table) {
       if (!wrap || !table) return;
       var overflowWidth = Math.ceil((table.scrollWidth || 0) - (wrap.clientWidth || 0));
-      wrap.classList.toggle('worktime-calendar-wrap-scrollable', overflowWidth > 1);
+      wrap.classList.toggle('worktime-calendar-wrap-scrollable', overflowWidth > 8);
     }
 
     function syncWorktimeTableLayout(root) {
@@ -3311,6 +3318,7 @@
       window.requestAnimationFrame(function () {
         syncWorktimeTableLayout(root);
         setupWorktimeFloatingScroll(root);
+        setupWorktimeStickyHeader(root);
       });
       window.setTimeout(function () {
         syncWorktimeTableLayout(root);
@@ -3321,6 +3329,7 @@
       window.setTimeout(function () {
         syncWorktimeTableLayout(root);
         setupWorktimeFloatingScroll(root);
+        setupWorktimeStickyHeader(root);
       }, 300);
       bindWorktimeTableObservers(root);
     }
@@ -3387,7 +3396,7 @@
           return;
         }
 
-        var hasOverflow = tableWrap.scrollWidth > tableWrap.clientWidth;
+        var hasOverflow = (tableWrap.scrollWidth - tableWrap.clientWidth) > 8;
         if (!hasOverflow) {
           proxy.style.display = 'none';
           return;
@@ -3437,6 +3446,551 @@
         }
       };
       window.__cleanupWorktimeFloatingScroll = cleanupWorktimeFloatingScroll;
+      update();
+    }
+
+    function clearWorktimeStickyHeader() {
+      if (typeof cleanupWorktimeStickyHeader === 'function') {
+        cleanupWorktimeStickyHeader();
+      }
+      cleanupWorktimeStickyHeader = null;
+      window.__cleanupWorktimeStickyHeader = null;
+    }
+
+    function setupWorktimeStickyHeader(root) {
+      clearWorktimeStickyHeader();
+
+      var scope = root && root.querySelectorAll ? root : document;
+      var section = null;
+      if (scope.matches && scope.matches('#worktime-content-timesheet')) {
+        section = scope;
+      } else if (scope.querySelector) {
+        section = scope.querySelector('#worktime-content-timesheet');
+      }
+      if (!section) {
+        section = document.querySelector('#worktime-content-timesheet');
+      }
+      if (!section || section.classList.contains('d-none') || section.offsetParent === null) return;
+
+      var panel = section.querySelector('[data-worktime-panel]');
+      var filterHeader = panel ? panel.querySelector('.table-section-header') : null;
+      var table = panel ? panel.querySelector('.worktime-calendar-table-general') : null;
+      var tableWrap = table ? table.closest('.worktime-calendar-wrap') : null;
+      var thead = table ? table.querySelector('thead') : null;
+      var cardBody = panel ? panel.closest('.card-body') : null;
+      var tableCard = panel ? panel.closest('.card') : null;
+      var sectionHeader = document.querySelector('#worktime .section-header');
+      if (!panel || !filterHeader || !table || !tableWrap || !thead || !cardBody || !tableCard || !sectionHeader) return;
+
+      var originalFilterGap = parseFloat(getComputedStyle(filterHeader).marginBottom) || 0;
+      var measuredCardGap = tableCard.getBoundingClientRect().top - sectionHeader.getBoundingClientRect().bottom;
+      var fallbackCardGap = (parseFloat(getComputedStyle(sectionHeader).marginBottom) || 0) + (parseFloat(getComputedStyle(tableCard).marginTop) || 0);
+      var stickyCardGap = measuredCardGap >= 0 && measuredCardGap < 160 ? measuredCardGap : fallbackCardGap;
+      var initialCardTop = tableCard.getBoundingClientRect().top + (window.pageYOffset || 0);
+      var pageBg = (function () {
+        var bodyBg = getComputedStyle(document.body).backgroundColor;
+        if (bodyBg && bodyBg !== 'transparent' && bodyBg !== 'rgba(0, 0, 0, 0)') return bodyBg;
+        var htmlBg = getComputedStyle(document.documentElement).backgroundColor;
+        if (htmlBg && htmlBg !== 'transparent' && htmlBg !== 'rgba(0, 0, 0, 0)') return htmlBg;
+        return '#f8f9fa';
+      })();
+      var cardStyles = getComputedStyle(tableCard);
+      var cardRadius = cardStyles.borderTopLeftRadius || '.375rem';
+      var cardBorderColor = cardStyles.borderTopColor || 'var(--bs-border-color,#dee2e6)';
+      var cardBorderWidth = cardStyles.borderTopWidth || '1px';
+      var cardBorderWidthPx = parseFloat(cardBorderWidth) || 1;
+      var headerBorderColor = (function () {
+        var firstHeaderCell = thead.querySelector('th');
+        if (!firstHeaderCell) return cardBorderColor;
+        var headerStyles = getComputedStyle(firstHeaderCell);
+        return headerStyles.borderBottomColor || cardBorderColor;
+      })();
+      var cornerSize = Math.max(8, (parseFloat(cardRadius) || 6) * 2);
+
+      var filterSpacer = document.createElement('div');
+      filterSpacer.style.display = 'none';
+      filterHeader.parentNode.insertBefore(filterSpacer, filterHeader.nextSibling);
+
+      var gapFill = document.createElement('div');
+      gapFill.style.cssText = (
+        'display:none;position:fixed;z-index:1028;pointer-events:none;' +
+        'background:' + pageBg + ';'
+      );
+      document.body.appendChild(gapFill);
+
+      var sideFrame = document.createElement('div');
+      sideFrame.style.cssText = (
+        'display:none;position:fixed;z-index:1029;pointer-events:none;box-sizing:border-box;' +
+        'background:#fff;' +
+        'border-left:' + cardBorderWidth + ' solid ' + cardBorderColor + ';' +
+        'border-right:' + cardBorderWidth + ' solid ' + cardBorderColor + ';' +
+        'border-top:' + cardBorderWidth + ' solid ' + cardBorderColor + ';' +
+        'border-radius:' + cardRadius + ' ' + cardRadius + ' 0 0;'
+      );
+      document.body.appendChild(sideFrame);
+
+      var cornerMaskL = document.createElement('div');
+      var cornerMaskR = document.createElement('div');
+      var cornerMaskCss = (
+        'display:none;position:fixed;z-index:1028;pointer-events:none;' +
+        'width:' + (cornerSize + 8) + 'px;height:' + (cornerSize + 8) + 'px;' +
+        'background:' + pageBg + ';'
+      );
+      cornerMaskL.style.cssText = cornerMaskCss;
+      cornerMaskR.style.cssText = cornerMaskCss;
+      document.body.appendChild(cornerMaskL);
+      document.body.appendChild(cornerMaskR);
+
+      var cloneOuter = document.createElement('div');
+      cloneOuter.className = 'worktime-thead-clone';
+      cloneOuter.style.cssText = (
+        'display:none;position:fixed;z-index:1030;overflow:hidden;background:#fff;box-sizing:border-box;' +
+        'box-shadow:inset 0 -1px 0 ' + headerBorderColor + ';'
+      );
+      var cloneInner = document.createElement('div');
+      cloneInner.style.overflow = 'hidden';
+      cloneInner.style.boxSizing = 'border-box';
+      cloneOuter.appendChild(cloneInner);
+      var stickyDivider = document.createElement('div');
+      stickyDivider.style.cssText = 'display:none;position:absolute;top:0;bottom:0;width:1px;background:#c8d0d9;z-index:4;pointer-events:none;';
+      cloneOuter.appendChild(stickyDivider);
+      var frozenHeaderOverlay = document.createElement('div');
+      frozenHeaderOverlay.style.cssText = 'display:none;position:absolute;top:0;bottom:0;overflow:hidden;background:#fff;z-index:3;';
+      cloneOuter.appendChild(frozenHeaderOverlay);
+      var cloneScroll = document.createElement('div');
+      cloneInner.appendChild(cloneScroll);
+      document.body.appendChild(cloneOuter);
+
+      cloneOuter.addEventListener('click', function (event) {
+        var target = event.target;
+        if (!target || !target.closest) return;
+
+        var collapseButton = target.closest('[data-worktime-general-collapse-toggle]');
+        if (collapseButton) {
+          var realCollapseButton = table.querySelector('[data-worktime-general-collapse-toggle]');
+          if (realCollapseButton) realCollapseButton.click();
+          return;
+        }
+
+        var sortButton = target.closest('[data-worktime-hist-sort-btn]');
+        if (sortButton) {
+          var sortValue = sortButton.dataset.worktimeHistSortBtn || '';
+          var realSortButton = table.querySelector('[data-worktime-hist-sort-btn="' + sortValue + '"]');
+          if (realSortButton) realSortButton.click();
+        }
+      });
+
+      var isFilterStuck = false;
+      var isTheadStuck = false;
+      var resizeObs = null;
+      var frozenHeaderWidth = 0;
+
+      function buildHeaderTable() {
+        var clonedTable = document.createElement('table');
+        clonedTable.className = table.className;
+        if (table.getAttribute('style')) {
+          clonedTable.setAttribute('style', table.getAttribute('style'));
+        }
+
+        var realHeaders = thead.querySelectorAll('th');
+        var measuredWidths = Array.prototype.map.call(realHeaders, function (header) {
+          var rect = header.getBoundingClientRect();
+          return rect && rect.width ? rect.width : (header.offsetWidth || 0);
+        });
+        var totalWidth = measuredWidths.reduce(function (sum, width) { return sum + width; }, 0);
+        var tableRect = table.getBoundingClientRect();
+        var fallbackTableWidth = tableRect && tableRect.width ? tableRect.width : (table.offsetWidth || 0);
+        var lockedWidth = totalWidth > 0 ? totalWidth : fallbackTableWidth;
+
+        clonedTable.style.width = lockedWidth + 'px';
+        clonedTable.style.minWidth = lockedWidth + 'px';
+        clonedTable.style.maxWidth = lockedWidth + 'px';
+        clonedTable.style.tableLayout = 'fixed';
+        clonedTable.style.margin = '0';
+
+        var newColgroup = document.createElement('colgroup');
+        measuredWidths.forEach(function (width) {
+          var col = document.createElement('col');
+          col.style.width = width + 'px';
+          newColgroup.appendChild(col);
+        });
+        clonedTable.appendChild(newColgroup);
+
+        var theadClone = thead.cloneNode(true);
+        theadClone.style.visibility = 'visible';
+        clonedTable.appendChild(theadClone);
+
+        var clonedHeaders = clonedTable.querySelectorAll('thead th');
+        realHeaders.forEach(function (header, index) {
+          if (!clonedHeaders[index]) return;
+          var width = measuredWidths[index] + 'px';
+          clonedHeaders[index].style.width = width;
+          clonedHeaders[index].style.minWidth = width;
+          clonedHeaders[index].style.maxWidth = width;
+          clonedHeaders[index].style.boxSizing = 'border-box';
+        });
+
+        var realSelectHeader = thead.querySelector('.worktime-col-select');
+        var realProjectHeader = thead.querySelector('.worktime-col-project');
+        var realTypeHeader = thead.querySelector('.worktime-col-type');
+        var realNameHeader = thead.querySelector('.worktime-col-name');
+        var selectWidth = realSelectHeader ? (realSelectHeader.getBoundingClientRect().width || 0) : 0;
+        var projectWidth = realProjectHeader ? (realProjectHeader.getBoundingClientRect().width || 0) : 0;
+        var typeWidth = realTypeHeader ? (realTypeHeader.getBoundingClientRect().width || 0) : 0;
+        var nameWidth = realNameHeader ? (realNameHeader.getBoundingClientRect().width || 0) : 0;
+
+        if (projectWidth > 0) clonedTable.style.setProperty('--worktime-project-width', projectWidth + 'px');
+        if (typeWidth > 0) clonedTable.style.setProperty('--worktime-type-width', typeWidth + 'px');
+        if (nameWidth > 0) clonedTable.style.setProperty('--worktime-name-width', nameWidth + 'px');
+        clonedTable.style.setProperty('--worktime-project-sticky-left', selectWidth + 'px');
+        clonedTable.style.setProperty('--worktime-type-sticky-left', (selectWidth + projectWidth) + 'px');
+        clonedTable.style.setProperty('--worktime-name-sticky-left', (selectWidth + projectWidth + typeWidth) + 'px');
+
+        return clonedTable;
+      }
+
+      function buildClone() {
+        cloneScroll.innerHTML = '';
+        frozenHeaderOverlay.innerHTML = '';
+        frozenHeaderWidth = 0;
+
+        var clonedTable = buildHeaderTable();
+        if (tableWrap.classList.contains('worktime-calendar-wrap-scrollable')) {
+          clonedTable.querySelectorAll('thead .worktime-sticky-select, thead .worktime-sticky-col, thead .worktime-sticky-col-2, thead .worktime-sticky-col-3').forEach(function (header) {
+            header.style.visibility = 'hidden';
+          });
+          frozenHeaderWidth = getFrozenHeaderWidth();
+          frozenHeaderOverlay.appendChild(buildFrozenHeaderTable());
+        }
+        cloneScroll.appendChild(clonedTable);
+      }
+
+      function syncCloneScroll() {
+        var scrollLeft = tableWrap.scrollLeft || 0;
+        cloneInner.scrollLeft = 0;
+        if (tableWrap.classList.contains('worktime-calendar-wrap-scrollable')) {
+          cloneScroll.style.marginLeft = (-(scrollLeft + frozenHeaderWidth)) + 'px';
+        } else {
+          cloneScroll.style.marginLeft = '';
+          cloneInner.scrollLeft = scrollLeft;
+        }
+      }
+
+      function getFrozenHeaderWidth() {
+        return [
+          thead.querySelector('.worktime-col-select'),
+          thead.querySelector('.worktime-col-project'),
+          thead.querySelector('.worktime-col-type'),
+          thead.querySelector('.worktime-col-name')
+        ].filter(Boolean).reduce(function (sum, header) {
+          return sum + (header.getBoundingClientRect().width || 0);
+        }, 0);
+      }
+
+      function buildFrozenHeaderTable() {
+        var sourceHeaders = [
+          thead.querySelector('.worktime-col-select'),
+          thead.querySelector('.worktime-col-project'),
+          thead.querySelector('.worktime-col-type'),
+          thead.querySelector('.worktime-col-name')
+        ].filter(Boolean);
+        var widths = sourceHeaders.map(function (header) {
+          return header.getBoundingClientRect().width || 0;
+        });
+        var frozenWidth = widths.reduce(function (sum, width) {
+          return sum + width;
+        }, 0);
+        var frozenTable = document.createElement('table');
+        frozenTable.className = table.className;
+        frozenTable.style.width = frozenWidth + 'px';
+        frozenTable.style.minWidth = frozenWidth + 'px';
+        frozenTable.style.margin = '0';
+        frozenTable.style.tableLayout = 'fixed';
+        frozenTable.style.height = '100%';
+        frozenTable.style.borderCollapse = 'collapse';
+
+        var colgroup = document.createElement('colgroup');
+        widths.forEach(function (width) {
+          var col = document.createElement('col');
+          col.style.width = width + 'px';
+          colgroup.appendChild(col);
+        });
+        frozenTable.appendChild(colgroup);
+
+        var frozenThead = document.createElement('thead');
+        frozenThead.style.height = '100%';
+        var row = document.createElement('tr');
+        row.style.height = '100%';
+        sourceHeaders.forEach(function (header, index) {
+          var clonedHeader = header.cloneNode(true);
+          var width = widths[index] + 'px';
+          clonedHeader.style.position = 'static';
+          clonedHeader.style.left = 'auto';
+          clonedHeader.style.width = width;
+          clonedHeader.style.minWidth = width;
+          clonedHeader.style.maxWidth = width;
+          clonedHeader.style.height = '100%';
+          clonedHeader.style.boxSizing = 'border-box';
+          clonedHeader.style.visibility = 'visible';
+          row.appendChild(clonedHeader);
+        });
+        frozenThead.appendChild(row);
+        frozenTable.appendChild(frozenThead);
+
+        return frozenTable;
+      }
+
+      function fixedTop() {
+        var rect = sectionHeader.getBoundingClientRect();
+        return Math.max(0, rect.bottom);
+      }
+
+      function fixedCardTop() {
+        return fixedTop() + stickyCardGap;
+      }
+
+      function filterGap() {
+        return originalFilterGap;
+      }
+
+      function positionElements() {
+        var cardRect = tableCard.getBoundingClientRect();
+        var tableWrapRect = tableWrap.getBoundingClientRect();
+        var mainEl = section.closest('main') || document.body;
+        var mainRect = mainEl.getBoundingClientRect ? mainEl.getBoundingClientRect() : cardRect;
+        var bodyStyle = getComputedStyle(cardBody);
+        var contentLeft = tableWrapRect.left - cardRect.left;
+        var contentRight = cardRect.right - tableWrapRect.right;
+        var padTop = parseFloat(bodyStyle.paddingTop) || 0;
+        var cardTop = fixedCardTop();
+        var top = cardTop + cardBorderWidthPx + padTop;
+        var headerHeight = filterHeader.offsetHeight;
+        var cloneTop = top + headerHeight + filterGap();
+
+        gapFill.style.top = fixedTop() + 'px';
+        gapFill.style.left = mainRect.left + 'px';
+        gapFill.style.width = mainRect.width + 'px';
+        gapFill.style.height = stickyCardGap + 'px';
+
+        filterHeader.style.top = top + 'px';
+        filterHeader.style.left = tableWrapRect.left + 'px';
+        filterHeader.style.width = tableWrapRect.width + 'px';
+
+        sideFrame.style.top = cardTop + 'px';
+        sideFrame.style.left = cardRect.left + 'px';
+        sideFrame.style.width = cardRect.width + 'px';
+        cornerMaskL.style.top = (cardTop - 4) + 'px';
+        cornerMaskL.style.left = (cardRect.left - 4) + 'px';
+        cornerMaskR.style.top = (cardTop - 4) + 'px';
+        cornerMaskR.style.left = (cardRect.right - cornerSize - 4) + 'px';
+
+        if (isTheadStuck) {
+          var theadRect = thead.getBoundingClientRect();
+          var theadHeight = theadRect && theadRect.height ? theadRect.height : thead.offsetHeight;
+          if (!theadHeight) {
+            theadHeight = headerHeight;
+          }
+          cloneOuter.style.top = cloneTop + 'px';
+          cloneOuter.style.left = tableWrapRect.left + 'px';
+          cloneOuter.style.width = tableWrapRect.width + 'px';
+          cloneOuter.style.height = theadHeight + 'px';
+          cloneInner.style.height = '100%';
+
+          if (tableWrap.classList.contains('worktime-calendar-wrap-scrollable')) {
+            cloneInner.style.position = 'absolute';
+            cloneInner.style.top = '0';
+            cloneInner.style.bottom = '0';
+            cloneInner.style.left = frozenHeaderWidth + 'px';
+            cloneInner.style.width = Math.max(0, tableWrapRect.width - frozenHeaderWidth) + 'px';
+            cloneInner.style.paddingLeft = '0';
+            cloneInner.style.paddingRight = '0';
+            frozenHeaderOverlay.style.left = '0';
+            frozenHeaderOverlay.style.width = frozenHeaderWidth + 'px';
+            frozenHeaderOverlay.style.display = 'block';
+            stickyDivider.style.left = (frozenHeaderWidth - 1) + 'px';
+            stickyDivider.style.display = 'block';
+          } else {
+            cloneInner.style.position = '';
+            cloneInner.style.top = '';
+            cloneInner.style.bottom = '';
+            cloneInner.style.left = '';
+            cloneInner.style.width = '';
+            cloneInner.style.paddingLeft = '0';
+            cloneInner.style.paddingRight = '0';
+            frozenHeaderOverlay.style.display = 'none';
+            stickyDivider.style.display = 'none';
+          }
+
+          sideFrame.style.height = (cardBorderWidthPx + padTop + headerHeight + filterGap() + cloneOuter.offsetHeight) + 'px';
+          sideFrame.style.boxShadow = '';
+        } else {
+          sideFrame.style.height = (cardBorderWidthPx + padTop + headerHeight + filterGap()) + 'px';
+          sideFrame.style.boxShadow = '';
+          cloneOuter.style.height = '';
+          cloneInner.style.height = '';
+          cloneInner.style.position = '';
+          cloneInner.style.top = '';
+          cloneInner.style.bottom = '';
+          cloneInner.style.left = '';
+          cloneInner.style.width = '';
+          frozenHeaderOverlay.style.display = 'none';
+          stickyDivider.style.display = 'none';
+        }
+      }
+
+      function activateFilter() {
+        if (isFilterStuck) return;
+        isFilterStuck = true;
+
+        var style = getComputedStyle(filterHeader);
+        filterSpacer.style.height = filterHeader.offsetHeight + 'px';
+        filterSpacer.style.marginBottom = style.marginBottom;
+        filterSpacer.style.display = 'block';
+
+        filterHeader.style.position = 'fixed';
+        filterHeader.style.zIndex = '1031';
+        filterHeader.style.margin = '0';
+        filterHeader.style.boxSizing = 'border-box';
+        filterHeader.style.background = '#fff';
+
+        sideFrame.style.display = 'block';
+        gapFill.style.display = 'block';
+        cornerMaskL.style.display = 'block';
+        cornerMaskR.style.display = 'block';
+        positionElements();
+      }
+
+      function activateThead() {
+        if (isTheadStuck) return;
+        isTheadStuck = true;
+
+        buildClone();
+        cloneOuter.style.display = 'block';
+        thead.style.visibility = 'hidden';
+
+        positionElements();
+        syncCloneScroll();
+      }
+
+      function deactivateThead() {
+        if (!isTheadStuck) return;
+        isTheadStuck = false;
+
+        cloneOuter.style.display = 'none';
+        thead.style.visibility = '';
+        positionElements();
+      }
+
+      function deactivateFilter() {
+        if (!isFilterStuck) return;
+        if (isTheadStuck) deactivateThead();
+        isFilterStuck = false;
+
+        filterHeader.style.position = '';
+        filterHeader.style.top = '';
+        filterHeader.style.left = '';
+        filterHeader.style.width = '';
+        filterHeader.style.zIndex = '';
+        filterHeader.style.margin = '';
+        filterHeader.style.boxSizing = '';
+        filterHeader.style.background = '';
+        filterSpacer.style.display = 'none';
+        filterSpacer.style.height = '';
+        filterSpacer.style.marginBottom = '';
+        sideFrame.style.display = 'none';
+        gapFill.style.display = 'none';
+        cornerMaskL.style.display = 'none';
+        cornerMaskR.style.display = 'none';
+        frozenHeaderOverlay.style.display = 'none';
+        stickyDivider.style.display = 'none';
+        cloneOuter.style.display = 'none';
+        thead.style.visibility = '';
+      }
+
+      function update() {
+        if (!panel.isConnected || section.classList.contains('d-none') || section.offsetParent === null) {
+          deactivateFilter();
+          return;
+        }
+
+        var shouldStickFilter = tableCard.getBoundingClientRect().top < initialCardTop;
+        if (shouldStickFilter && !isFilterStuck) {
+          activateFilter();
+        } else if (!shouldStickFilter && isFilterStuck) {
+          deactivateFilter();
+        }
+
+        if (!isFilterStuck) return;
+
+        var bodyStyle = getComputedStyle(cardBody);
+        var padTop = parseFloat(bodyStyle.paddingTop) || 0;
+        var cloneTop = fixedCardTop() + cardBorderWidthPx + padTop + filterHeader.offsetHeight + filterGap();
+        var shouldStickThead = tableWrap.getBoundingClientRect().top <= cloneTop;
+        if (shouldStickThead && !isTheadStuck) {
+          activateThead();
+        } else if (!shouldStickThead && isTheadStuck) {
+          deactivateThead();
+        }
+
+        positionElements();
+        if (isTheadStuck) {
+          syncCloneScroll();
+        }
+      }
+
+      function onFrame() {
+        window.requestAnimationFrame(update);
+      }
+
+      tableWrap.addEventListener('scroll', syncCloneScroll, { passive: true });
+      window.addEventListener('scroll', onFrame, { passive: true });
+      window.addEventListener('resize', onFrame, { passive: true });
+
+      if (window.ResizeObserver) {
+        resizeObs = new ResizeObserver(function () {
+          if (isTheadStuck) {
+            buildClone();
+          }
+          update();
+        });
+        resizeObs.observe(cardBody);
+        resizeObs.observe(tableWrap);
+        resizeObs.observe(sectionHeader);
+      }
+
+      cleanupWorktimeStickyHeader = function () {
+        deactivateFilter();
+        tableCard.style.borderTopLeftRadius = '';
+        tableCard.style.borderTopRightRadius = '';
+        tableCard.style.borderTopWidth = '';
+        thead.style.visibility = '';
+        tableWrap.removeEventListener('scroll', syncCloneScroll);
+        window.removeEventListener('scroll', onFrame);
+        window.removeEventListener('resize', onFrame);
+        if (resizeObs) {
+          resizeObs.disconnect();
+          resizeObs = null;
+        }
+        if (filterSpacer.isConnected) {
+          filterSpacer.remove();
+        }
+        if (sideFrame.isConnected) {
+          sideFrame.remove();
+        }
+        if (gapFill.isConnected) {
+          gapFill.remove();
+        }
+        if (cornerMaskL.isConnected) {
+          cornerMaskL.remove();
+        }
+        if (cornerMaskR.isConnected) {
+          cornerMaskR.remove();
+        }
+        if (cloneOuter.isConnected) {
+          cloneOuter.remove();
+        }
+      };
+      window.__cleanupWorktimeStickyHeader = cleanupWorktimeStickyHeader;
       update();
     }
 

--- a/worktime_app/tests.py
+++ b/worktime_app/tests.py
@@ -26,6 +26,7 @@ from users_app.models import Employee
 from worktime_app.models import PersonalWorktimeWeekAssignment, WorktimeAssignment, WorktimeEntry
 from worktime_app.views import (
     REGULAR_WORKDAY_HOURS,
+    SHORTENED_WORKDAY_HOURS,
     ZERO_DECIMAL,
     _attach_group_histograms,
     _attach_row_histograms,
@@ -1015,6 +1016,7 @@ class WorktimeAppTests(TestCase):
         )
         ProductionCalendarDay.objects.create(country=country, date=date(2026, 4, 8), is_working_day=False, is_holiday=True, working_hours=Decimal("0.0"))
         ProductionCalendarDay.objects.create(country=country, date=date(2026, 4, 9), is_working_day=False, is_weekend=True, working_hours=Decimal("0.0"))
+        ProductionCalendarDay.objects.create(country=country, date=date(2026, 4, 10), is_working_day=True, is_shortened_day=True)
         project_assignment = WorktimeAssignment.objects.create(
             registration=self.registration,
             employee=self.employee,
@@ -1034,7 +1036,7 @@ class WorktimeAppTests(TestCase):
         self.assertEqual(downtime_row["assignment"].record_type, WorktimeAssignment.RecordType.DOWNTIME)
         self.assertTrue(downtime_row["is_calculated_downtime"])
         self.assertTrue(downtime_row["is_locked"])
-        self.assertEqual(downtime_values[:5], [Decimal("6.0"), Decimal("4.0"), ZERO_DECIMAL, ZERO_DECIMAL, REGULAR_WORKDAY_HOURS])
+        self.assertEqual(downtime_values[:5], [Decimal("6.0"), Decimal("4.0"), ZERO_DECIMAL, ZERO_DECIMAL, SHORTENED_WORKDAY_HOURS])
         self.assertFalse(context["days"][0]["is_non_working_day"])
         self.assertTrue(context["days"][2]["is_non_working_day"])
         self.assertTrue(context["days"][3]["is_non_working_day"])
@@ -1091,6 +1093,42 @@ class WorktimeAppTests(TestCase):
         self.assertTrue(vacation_row["cells"][2]["is_vacation_non_working_day"])
         self.assertContains(response, "data-worktime-vacation-non-working-input", html=False)
 
+    def test_personal_partial_disables_absence_hours_on_non_working_days(self):
+        country = OKSMCountry.objects.create(
+            number=643,
+            code="643",
+            short_name="Россия",
+            alpha2="RU",
+            alpha3="RUS",
+        )
+        company = GroupMember.objects.create(
+            short_name="IMC Russia",
+            country_name="Россия",
+            country_code="643",
+        )
+        self.employee.employment = company.short_name
+        self.employee.save(update_fields=["employment"])
+        ProductionCalendarDay.objects.create(country=country, date=date(2026, 4, 8), is_working_day=False, is_holiday=True, working_hours=Decimal("0.0"))
+        time_off_assignment = WorktimeAssignment.objects.create(
+            record_type=WorktimeAssignment.RecordType.TIME_OFF,
+            employee=self.employee,
+            executor_name=self._full_name(self.employee),
+            source_type=WorktimeAssignment.SourceType.MANUAL_PERSONAL_WEEK,
+        )
+        PersonalWorktimeWeekAssignment.objects.create(assignment=time_off_assignment, week_start=date(2026, 4, 6))
+        WorktimeEntry.objects.create(assignment=time_off_assignment, work_date=date(2026, 4, 8), hours=Decimal("8"))
+
+        response = self.client.get(reverse("personal_worktime_partial"), {"week": "2026-04-10"})
+
+        self.assertEqual(response.status_code, 200)
+        time_off_row = next(
+            row for row in response.context["rows"]
+            if row["assignment"].pk == time_off_assignment.pk
+        )
+        self.assertIsNone(time_off_row["cells"][2]["value"])
+        self.assertTrue(time_off_row["cells"][2]["is_blocked_non_working_day"])
+        self.assertContains(response, "data-worktime-blocked-non-working-input", html=False)
+
     def test_personal_save_removes_vacation_hours_on_non_working_days(self):
         country = OKSMCountry.objects.create(
             number=643,
@@ -1130,6 +1168,49 @@ class WorktimeAppTests(TestCase):
         self.assertFalse(
             WorktimeEntry.objects.filter(
                 assignment=vacation_assignment,
+                work_date=date(2026, 4, 8),
+            ).exists()
+        )
+
+    def test_personal_save_removes_absence_hours_on_non_working_days(self):
+        country = OKSMCountry.objects.create(
+            number=643,
+            code="643",
+            short_name="Россия",
+            alpha2="RU",
+            alpha3="RUS",
+        )
+        company = GroupMember.objects.create(
+            short_name="IMC Russia",
+            country_name="Россия",
+            country_code="643",
+        )
+        self.employee.employment = company.short_name
+        self.employee.save(update_fields=["employment"])
+        ProductionCalendarDay.objects.create(country=country, date=date(2026, 4, 8), is_working_day=False, is_holiday=True, working_hours=Decimal("0.0"))
+        sick_leave_assignment = WorktimeAssignment.objects.create(
+            record_type=WorktimeAssignment.RecordType.SICK_LEAVE,
+            employee=self.employee,
+            executor_name=self._full_name(self.employee),
+            source_type=WorktimeAssignment.SourceType.MANUAL_PERSONAL_WEEK,
+        )
+        PersonalWorktimeWeekAssignment.objects.create(assignment=sick_leave_assignment, week_start=date(2026, 4, 6))
+        WorktimeEntry.objects.create(assignment=sick_leave_assignment, work_date=date(2026, 4, 8), hours=Decimal("8"))
+
+        response = self.client.post(
+            reverse("worktime_save"),
+            {
+                "scope": "personal",
+                "week": "2026-04-10",
+                "assignment_ids": [str(sick_leave_assignment.pk)],
+                f"hours_{sick_leave_assignment.pk}_20260408": "6",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(
+            WorktimeEntry.objects.filter(
+                assignment=sick_leave_assignment,
                 work_date=date(2026, 4, 8),
             ).exists()
         )
@@ -2582,6 +2663,235 @@ class WorktimeAppTests(TestCase):
                 .values_list("work_date", "hours")
             ),
             [(date(2026, 4, 2), 8)],
+        )
+
+    def test_worktime_csv_upload_removes_vacation_hours_on_non_working_days(self):
+        country = OKSMCountry.objects.create(
+            number=643,
+            code="643",
+            short_name="Россия",
+            alpha2="RU",
+            alpha3="RUS",
+        )
+        company = GroupMember.objects.create(
+            short_name="IMC Russia",
+            country_name="Россия",
+            country_code="643",
+        )
+        self.employee.employment = company.short_name
+        self.employee.save(update_fields=["employment"])
+        ProductionCalendarDay.objects.create(
+            country=country,
+            date=date(2026, 4, 2),
+            is_working_day=False,
+            is_holiday=True,
+            working_hours=Decimal("0.0"),
+        )
+
+        april_days = [""] * 30
+        april_days[1] = "8"
+        april_days[2] = "8"
+        upload = self._make_worktime_csv_upload(
+            self._worktime_csv_header("2026-04"),
+            [[
+                self._full_name(self.employee),
+                WorktimeAssignment.RecordType.VACATION.label,
+                "",
+                "",
+                *april_days,
+            ]],
+        )
+
+        response = self.client.post(
+            reverse("worktime_csv_upload"),
+            {
+                "csv_file": upload,
+                "scale": "month",
+                "period": "2026-04",
+                "breakdown": "employees",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "ok": True,
+                "created": 1,
+                "updated": 0,
+                "deleted": 0,
+                "created_assignments": 1,
+            },
+        )
+        vacation_assignment = WorktimeAssignment.objects.get(
+            registration__isnull=True,
+            proposal_registration__isnull=True,
+            executor_name=self._full_name(self.employee),
+            record_type=WorktimeAssignment.RecordType.VACATION,
+        )
+        self.assertEqual(
+            list(
+                WorktimeEntry.objects.filter(assignment=vacation_assignment)
+                .order_by("work_date")
+                .values_list("work_date", "hours")
+            ),
+            [(date(2026, 4, 3), Decimal("8.00"))],
+        )
+
+    def test_worktime_csv_upload_removes_absence_hours_on_non_working_days(self):
+        country = OKSMCountry.objects.create(
+            number=643,
+            code="643",
+            short_name="Россия",
+            alpha2="RU",
+            alpha3="RUS",
+        )
+        company = GroupMember.objects.create(
+            short_name="IMC Russia",
+            country_name="Россия",
+            country_code="643",
+        )
+        self.employee.employment = company.short_name
+        self.employee.save(update_fields=["employment"])
+        ProductionCalendarDay.objects.create(
+            country=country,
+            date=date(2026, 4, 2),
+            is_working_day=False,
+            is_holiday=True,
+            working_hours=Decimal("0.0"),
+        )
+
+        april_days = [""] * 30
+        april_days[1] = "8"
+        april_days[2] = "8"
+        upload = self._make_worktime_csv_upload(
+            self._worktime_csv_header("2026-04"),
+            [[
+                self._full_name(self.employee),
+                WorktimeAssignment.RecordType.OTHER_ABSENCE.label,
+                "",
+                "",
+                *april_days,
+            ]],
+        )
+
+        response = self.client.post(
+            reverse("worktime_csv_upload"),
+            {
+                "csv_file": upload,
+                "scale": "month",
+                "period": "2026-04",
+                "breakdown": "employees",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "ok": True,
+                "created": 1,
+                "updated": 0,
+                "deleted": 0,
+                "created_assignments": 1,
+            },
+        )
+        absence_assignment = WorktimeAssignment.objects.get(
+            registration__isnull=True,
+            proposal_registration__isnull=True,
+            executor_name=self._full_name(self.employee),
+            record_type=WorktimeAssignment.RecordType.OTHER_ABSENCE,
+        )
+        self.assertEqual(
+            list(
+                WorktimeEntry.objects.filter(assignment=absence_assignment)
+                .order_by("work_date")
+                .values_list("work_date", "hours")
+            ),
+            [(date(2026, 4, 3), Decimal("8.00"))],
+        )
+
+    def test_worktime_csv_upload_adds_calculated_downtime_for_missing_hours(self):
+        country = OKSMCountry.objects.create(
+            number=643,
+            code="643",
+            short_name="Россия",
+            alpha2="RU",
+            alpha3="RUS",
+        )
+        company = GroupMember.objects.create(
+            short_name="IMC Russia",
+            country_name="Россия",
+            country_code="643",
+        )
+        self.employee.employment = company.short_name
+        self.employee.save(update_fields=["employment"])
+        ProductionCalendarDay.objects.create(country=country, date=date(2026, 4, 6), is_working_day=True, working_hours=Decimal("8.0"))
+        ProductionCalendarDay.objects.create(country=country, date=date(2026, 4, 7), is_working_day=True, is_shortened_day=True)
+        assignment = WorktimeAssignment.objects.create(
+            registration=self.registration,
+            employee=self.employee,
+            executor_name=self._full_name(self.employee),
+            source_type=WorktimeAssignment.SourceType.PERFORMER_CONFIRMATION,
+        )
+
+        april_days = [""] * 30
+        april_days[5] = "5"
+        april_days[6] = "2"
+        upload = self._make_worktime_csv_upload(
+            self._worktime_csv_header("2026-04"),
+            [[
+                self._full_name(self.employee),
+                assignment.display_project_code,
+                assignment.display_type_label,
+                assignment.display_project_name,
+                *april_days,
+            ]],
+        )
+
+        response = self.client.post(
+            reverse("worktime_csv_upload"),
+            {
+                "csv_file": upload,
+                "scale": "month",
+                "period": "2026-04",
+                "breakdown": "employees",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "ok": True,
+                "created": 4,
+                "updated": 0,
+                "deleted": 0,
+                "created_assignments": 1,
+            },
+        )
+        downtime_assignment = WorktimeAssignment.objects.get(
+            registration__isnull=True,
+            proposal_registration__isnull=True,
+            executor_name=self._full_name(self.employee),
+            record_type=WorktimeAssignment.RecordType.DOWNTIME,
+        )
+        self.assertTrue(
+            PersonalWorktimeWeekAssignment.objects.filter(
+                assignment=downtime_assignment,
+                week_start=date(2026, 4, 6),
+            ).exists()
+        )
+        self.assertEqual(
+            list(
+                WorktimeEntry.objects.filter(assignment=downtime_assignment)
+                .order_by("work_date")
+                .values_list("work_date", "hours")
+            ),
+            [
+                (date(2026, 4, 6), Decimal("3.00")),
+                (date(2026, 4, 7), SHORTENED_WORKDAY_HOURS - Decimal("2.00")),
+            ],
         )
 
     def test_worktime_csv_upload_reuses_calculated_downtime_assignment(self):

--- a/worktime_app/views.py
+++ b/worktime_app/views.py
@@ -65,6 +65,7 @@ WORKTIME_HOURS_QUANT = Decimal("0.01")
 ZERO_DECIMAL = Decimal("0")
 HUNDRED_DECIMAL = Decimal("100")
 REGULAR_WORKDAY_HOURS = Decimal("8")
+SHORTENED_WORKDAY_HOURS = Decimal("7")
 PERSONAL_WEEK_LIMIT_WEEKS = 2
 PERSONAL_WEEK_LIMIT_ERROR = "Нельзя выбрать слишком далекую будущую неделю. Доступны текущая неделя и только две следующие."
 WORKTIME_ACCESS_ERROR = 'Табель доступен только штатным сотрудникам с правами staff. Пользователи с трудоустройством "Внештатный сотрудник" не допускаются.'
@@ -101,6 +102,12 @@ WORKTIME_COMPOSITION_CATEGORIES = (
 )
 WORKTIME_COMPOSITION_CATEGORY_BY_KEY = {
     category["key"]: category for category in WORKTIME_COMPOSITION_CATEGORIES
+}
+WORKTIME_NON_WORKING_DAY_BLOCKED_RECORD_TYPES = {
+    WorktimeAssignment.RecordType.VACATION,
+    WorktimeAssignment.RecordType.OTHER_ABSENCE,
+    WorktimeAssignment.RecordType.SICK_LEAVE,
+    WorktimeAssignment.RecordType.TIME_OFF,
 }
 WORKTIME_DAILY_HISTOGRAM_SEGMENTS = (
     {
@@ -406,7 +413,7 @@ def _production_calendar_working_hours_for_country(country, visible_days):
         elif item.is_holiday or not item.is_working_day:
             working_hours[work_day] = ZERO_DECIMAL
         elif item.is_shortened_day:
-            working_hours[work_day] = _coerce_worktime_decimal(item.working_hours or REGULAR_WORKDAY_HOURS)
+            working_hours[work_day] = _coerce_worktime_decimal(item.working_hours or SHORTENED_WORKDAY_HOURS)
         else:
             working_hours[work_day] = _coerce_worktime_decimal(item.working_hours or REGULAR_WORKDAY_HOURS)
     return working_hours
@@ -415,6 +422,13 @@ def _production_calendar_working_hours_for_country(country, visible_days):
 def _production_calendar_working_hours_for_user(user, visible_days):
     employee = getattr(user, "employee_profile", None)
     country = _production_calendar_country_for_employee(employee)
+    return _production_calendar_working_hours_for_country(country, visible_days)
+
+
+def _production_calendar_working_hours_for_employee(employee, visible_days):
+    country = _production_calendar_country_for_employee(employee)
+    if country is None:
+        return None
     return _production_calendar_working_hours_for_country(country, visible_days)
 
 
@@ -1384,6 +1398,7 @@ def _build_assignment_row(assignment, visible_days, entry_map, *, breakdown="emp
     is_calculated_downtime = bool(getattr(assignment, "_worktime_calculated_downtime", False))
     histogram_segment_key = _worktime_daily_histogram_segment_key(assignment)
     is_vacation_row = histogram_segment_key == "vacation"
+    blocks_non_working_day_input = _worktime_blocks_non_working_day_input(assignment)
     non_working_days = set(non_working_days or [])
     hidden_downtime_zero_days = set(getattr(assignment, "_worktime_hidden_downtime_zero_days", set()) or [])
     for work_day in visible_days:
@@ -1403,6 +1418,7 @@ def _build_assignment_row(assignment, visible_days, entry_map, *, breakdown="emp
                 "scheduled_hours": scheduled_hours.get(work_day),
                 "is_non_working_day": work_day in non_working_days,
                 "is_vacation_non_working_day": is_vacation_row and work_day in non_working_days,
+                "is_blocked_non_working_day": blocks_non_working_day_input and work_day in non_working_days,
                 "hide_downtime_zero": should_hide_downtime_zero,
             }
         )
@@ -1586,6 +1602,10 @@ def _worktime_daily_histogram_segment_key(assignment):
     if assignment.registration_id is not None:
         return "project"
     return WORKTIME_DAILY_HISTOGRAM_SEGMENT_KEY_BY_RECORD_TYPE.get(getattr(assignment, "record_type", ""))
+
+
+def _worktime_blocks_non_working_day_input(assignment):
+    return getattr(assignment, "record_type", "") in WORKTIME_NON_WORKING_DAY_BLOCKED_RECORD_TYPES
 
 
 def _format_worktime_percentage_value(value):
@@ -1875,7 +1895,7 @@ def _entry_map_with_calculated_downtime(user, assignments, visible_days, entry_m
     }
     display_entry_map = {assignment_id: dict(day_values) for assignment_id, day_values in entry_map.items()}
     for assignment in assignments:
-        if _worktime_daily_histogram_segment_key(assignment) != "vacation":
+        if not _worktime_blocks_non_working_day_input(assignment):
             continue
         day_values = display_entry_map.get(assignment.pk)
         if not day_values:
@@ -2153,13 +2173,13 @@ def _parse_hours_payload(request_post, assignment_ids, month_days):
     return parsed
 
 
-def _remove_personal_vacation_hours_on_non_working_days(user, assignments, visible_days, parsed_values):
-    vacation_assignment_ids = {
+def _remove_personal_blocked_hours_on_non_working_days(user, assignments, visible_days, parsed_values):
+    blocked_assignment_ids = {
         assignment.pk
         for assignment in assignments
-        if _worktime_daily_histogram_segment_key(assignment) == "vacation"
+        if _worktime_blocks_non_working_day_input(assignment)
     }
-    if not vacation_assignment_ids:
+    if not blocked_assignment_ids:
         return parsed_values
 
     working_hours = _production_calendar_working_hours_for_user(user, visible_days)
@@ -2172,10 +2192,178 @@ def _remove_personal_vacation_hours_on_non_working_days(user, assignments, visib
         return parsed_values
 
     sanitized_values = dict(parsed_values)
-    for assignment_id in vacation_assignment_ids:
+    for assignment_id in blocked_assignment_ids:
         for work_day in non_working_days:
             sanitized_values[(assignment_id, work_day)] = None
     return sanitized_values
+
+
+def _assignment_employee_key(assignment):
+    employee = _resolve_assignment_employee(assignment)
+    if employee is not None:
+        return ("employee", employee.pk)
+    executor_name = _normalize_worktime_company_text(getattr(assignment, "executor_name", ""))
+    if executor_name:
+        return ("executor", executor_name.casefold())
+    return None
+
+
+def _manual_employee_assignment(employee, executor_name, record_type):
+    normalized_name, resolved_employee = resolve_employee_and_name(
+        employee=employee,
+        executor_name=executor_name,
+    )
+    if resolved_employee is None or not normalized_name:
+        return None
+    return WorktimeAssignment.objects.filter(
+        registration__isnull=True,
+        proposal_registration__isnull=True,
+        executor_name=normalized_name,
+        source_type=WorktimeAssignment.SourceType.MANUAL_PERSONAL_WEEK,
+        record_type=record_type,
+    ).first()
+
+
+def _remove_csv_blocked_hours_on_non_working_days(assignments_by_id, visible_days, parsed_values):
+    sanitized_values = dict(parsed_values)
+    for assignment in assignments_by_id.values():
+        if not _worktime_blocks_non_working_day_input(assignment):
+            continue
+        employee = _resolve_assignment_employee(assignment)
+        working_hours = _production_calendar_working_hours_for_employee(employee, visible_days)
+        if working_hours is None:
+            continue
+        for work_day in visible_days:
+            key = (assignment.pk, work_day)
+            if key not in sanitized_values:
+                continue
+            if _coerce_worktime_decimal(working_hours.get(work_day, ZERO_DECIMAL)) <= ZERO_DECIMAL:
+                sanitized_values[key] = None
+    return sanitized_values
+
+
+def _apply_csv_calculated_downtime(assignments_by_id, visible_days, range_start, range_end, parsed_values):
+    parsed_values = dict(parsed_values)
+    assignments_by_employee = {}
+    active_days_by_employee = {}
+    for assignment in assignments_by_id.values():
+        employee_key = _assignment_employee_key(assignment)
+        if employee_key is None:
+            continue
+        assignments_by_employee.setdefault(employee_key, []).append(assignment)
+
+    for (assignment_id, work_day), hours in parsed_values.items():
+        if hours is None:
+            continue
+        assignment = assignments_by_id.get(assignment_id)
+        if assignment is None or getattr(assignment, "record_type", "") == WorktimeAssignment.RecordType.DOWNTIME:
+            continue
+        employee_key = _assignment_employee_key(assignment)
+        if employee_key is None:
+            continue
+        active_days_by_employee.setdefault(employee_key, set()).add(work_day)
+
+    if not active_days_by_employee:
+        return parsed_values, [], 0
+
+    existing_entries = {
+        (entry.assignment_id, entry.work_date): entry.hours
+        for entry in WorktimeEntry.objects.filter(
+            assignment_id__in=list(assignments_by_id),
+            work_date__range=(range_start, range_end),
+        ).only("assignment_id", "work_date", "hours")
+    }
+    extra_assignment_ids = []
+    created_assignments_count = 0
+    missing = object()
+
+    for employee_key, active_days in active_days_by_employee.items():
+        employee_assignments = assignments_by_employee.get(employee_key, [])
+        if not employee_assignments:
+            continue
+        sample_assignment = employee_assignments[0]
+        employee = _resolve_assignment_employee(sample_assignment)
+        if employee is None:
+            continue
+        working_hours = _production_calendar_working_hours_for_employee(employee, visible_days)
+        if working_hours is None:
+            continue
+
+        downtime_assignment = next(
+            (
+                assignment
+                for assignment in employee_assignments
+                if getattr(assignment, "record_type", "") == WorktimeAssignment.RecordType.DOWNTIME
+            ),
+            None,
+        )
+        if downtime_assignment is None:
+            downtime_assignment = _manual_employee_assignment(
+                employee,
+                getattr(sample_assignment, "executor_name", ""),
+                WorktimeAssignment.RecordType.DOWNTIME,
+            )
+            if downtime_assignment is not None:
+                assignments_by_id[downtime_assignment.pk] = downtime_assignment
+                employee_assignments.append(downtime_assignment)
+
+        computed_values = {}
+        for work_day in active_days:
+            scheduled_hours = _coerce_worktime_decimal(working_hours.get(work_day, ZERO_DECIMAL))
+            if scheduled_hours <= ZERO_DECIMAL:
+                computed_values[work_day] = None
+                continue
+            other_total = ZERO_DECIMAL
+            for assignment in employee_assignments:
+                if getattr(assignment, "record_type", "") == WorktimeAssignment.RecordType.DOWNTIME:
+                    continue
+                raw_value = parsed_values.get((assignment.pk, work_day), missing)
+                if raw_value is missing:
+                    raw_value = existing_entries.get((assignment.pk, work_day))
+                other_total += _coerce_worktime_decimal(raw_value)
+            downtime_value = max(scheduled_hours - other_total, ZERO_DECIMAL)
+            computed_values[work_day] = downtime_value if downtime_value > ZERO_DECIMAL else None
+
+        if downtime_assignment is None and any(value is not None for value in computed_values.values()):
+            existing_assignment = _manual_employee_assignment(
+                employee,
+                getattr(sample_assignment, "executor_name", ""),
+                WorktimeAssignment.RecordType.DOWNTIME,
+            )
+            positive_week_starts = sorted({
+                _start_of_week(work_day)
+                for work_day, value in computed_values.items()
+                if value is not None
+            })
+            for week_start in positive_week_starts:
+                downtime_assignment, _ = ensure_personal_week_assignment(
+                    registration=None,
+                    proposal_registration=None,
+                    employee=employee,
+                    week_start=week_start,
+                    record_type=WorktimeAssignment.RecordType.DOWNTIME,
+                )
+            if downtime_assignment is None:
+                continue
+            assignments_by_id[downtime_assignment.pk] = downtime_assignment
+            employee_assignments.append(downtime_assignment)
+            if existing_assignment is None:
+                created_assignments_count += 1
+        elif downtime_assignment is not None:
+            positive_week_starts = sorted({
+                _start_of_week(work_day)
+                for work_day, value in computed_values.items()
+                if value is not None
+            })
+            _ensure_worktime_csv_week_links(downtime_assignment, positive_week_starts)
+
+        if downtime_assignment is None:
+            continue
+        extra_assignment_ids.append(downtime_assignment.pk)
+        for work_day, value in computed_values.items():
+            parsed_values[(downtime_assignment.pk, work_day)] = value
+
+    return parsed_values, extra_assignment_ids, created_assignments_count
 
 
 def _remove_general_manual_hours_outside_visible_weeks(assignments, range_start, range_end, parsed_values):
@@ -2364,6 +2552,7 @@ def worktime_csv_upload(request):
         return JsonResponse({"ok": False, "error": exc.message}, status=400)
 
     assignments_by_key, duplicate_keys = _build_worktime_csv_assignment_index(assignments)
+    assignments_by_id = {assignment.pk: assignment for assignment in assignments}
     projects_by_code, projects_by_key, duplicate_project_keys = _build_worktime_csv_project_index()
     proposals_by_code, proposals_by_key, duplicate_proposal_keys = _build_worktime_csv_proposal_index()
     manual_record_types_by_label = _build_worktime_csv_manual_record_type_index()
@@ -2427,6 +2616,7 @@ def worktime_csv_upload(request):
             continue
         if assignment is None:
             continue
+        assignments_by_id[assignment.pk] = assignment
         if assignment_created:
             created_assignments_count += 1
 
@@ -2444,6 +2634,21 @@ def worktime_csv_upload(request):
         if warnings:
             payload["warnings"] = warnings[:50]
         return JsonResponse(payload, status=400)
+
+    parsed_values = _remove_csv_blocked_hours_on_non_working_days(
+        assignments_by_id,
+        month_days,
+        parsed_values,
+    )
+    parsed_values, extra_assignment_ids, extra_created_assignments_count = _apply_csv_calculated_downtime(
+        assignments_by_id,
+        month_days,
+        range_start,
+        range_end,
+        parsed_values,
+    )
+    touched_assignment_ids = sorted({*touched_assignment_ids, *extra_assignment_ids})
+    created_assignments_count += extra_created_assignments_count
 
     sync_result = _sync_worktime_entries(
         parsed_values,
@@ -2840,7 +3045,7 @@ def worktime_save(request):
             error_message=exc.message,
         )
     if personal_only:
-        parsed_values = _remove_personal_vacation_hours_on_non_working_days(
+        parsed_values = _remove_personal_blocked_hours_on_non_working_days(
             request.user,
             assignments,
             visible_days,


### PR DESCRIPTION
## Summary
- Исправлен hover текущей недели в календаре фильтра «Неделя»: праздничные дни больше не перекрываются синим блоком выбранной недели.
- Обновлена логика раздела «Рабочее время» в `views.py`.
- Обновлены тесты для последних изменений по рабочему времени.
## Test plan
- CI/CD pipeline в pull request.