### PR TITLE
Add TKP DOCX payment schedule support

### DIFF
--- a/contracts_app/docx_processor.py
+++ b/contracts_app/docx_processor.py
@@ -344,6 +344,44 @@ def _apply_paragraph_alignment(p_pr, alignment: str | None) -> None:
     p_pr.append(jc)
 
 
+def _apply_paragraph_style(p_pr, style_id: str | None) -> None:
+    style_id = str(style_id or "").strip()
+    if not style_id:
+        return
+    from docx.oxml import OxmlElement
+
+    p_style = p_pr.find(qn("w:pStyle"))
+    if p_style is None:
+        p_style = OxmlElement("w:pStyle")
+        p_pr.insert(0, p_style)
+    p_style.set(qn("w:val"), style_id)
+
+
+def _apply_paragraph_left_indent(p_pr, left_indent_cm) -> None:
+    if left_indent_cm in (None, ""):
+        return
+    try:
+        left_twips = int(round(Cm(float(left_indent_cm)).twips))
+    except (TypeError, ValueError):
+        return
+    from docx.oxml import OxmlElement
+
+    indent = p_pr.find(qn("w:ind"))
+    if indent is None:
+        indent = OxmlElement("w:ind")
+        p_pr.append(indent)
+    indent.set(qn("w:left"), str(max(0, left_twips)))
+
+
+def _apply_contextual_spacing(p_pr, enabled) -> None:
+    if not enabled:
+        return
+    from docx.oxml import OxmlElement
+
+    if p_pr.find(qn("w:contextualSpacing")) is None:
+        p_pr.append(OxmlElement("w:contextualSpacing"))
+
+
 def _insert_rich_paragraphs(
     anchor,
     parent,
@@ -352,6 +390,7 @@ def _insert_rich_paragraphs(
     bullet_num_id: str,
     multilevel_num_id: str,
     bullet_style_id: str,
+    list_paragraph_style_id: str,
     source_rPr,
     render_plain: bool = False,
     language_code: str | None = None,
@@ -387,7 +426,14 @@ def _insert_rich_paragraphs(
             num_pr.append(ilvl)
             num_pr.append(num_id)
             p_pr.append(num_pr)
+        paragraph_style = str(item.get("paragraph_style") or "").strip()
+        paragraph_style_id = str(item.get("paragraph_style_id") or "").strip()
+        if paragraph_style == "list_paragraph" and not paragraph_style_id:
+            paragraph_style_id = list_paragraph_style_id
+        _apply_paragraph_style(p_pr, paragraph_style_id)
         _apply_paragraph_alignment(p_pr, item.get("alignment"))
+        _apply_paragraph_left_indent(p_pr, item.get("left_indent_cm"))
+        _apply_contextual_spacing(p_pr, item.get("contextual_spacing"))
         if len(p_pr):
             new_p.append(p_pr)
         runs = item.get("runs") if isinstance(item.get("runs"), list) else []
@@ -492,6 +538,7 @@ def _replace_list_in_paragraph(
     bullet_num_id: str,
     multilevel_num_id: str,
     bullet_style_id: str,
+    list_paragraph_style_id: str = "",
     plain_list_keys: set[str] | None = None,
     default_language_code: str | None = None,
 ) -> bool:
@@ -574,6 +621,7 @@ def _replace_list_in_paragraph(
             bullet_num_id=bullet_num_id,
             multilevel_num_id=multilevel_num_id,
             bullet_style_id=bullet_style_id,
+            list_paragraph_style_id=list_paragraph_style_id,
             source_rPr=source_rPr,
             render_plain=is_plain_list,
             language_code=language_code,
@@ -1149,6 +1197,34 @@ def _find_bullet_style_id(doc) -> str:
         return ""
 
 
+def _find_list_paragraph_style_id(doc) -> str:
+    style_name = "Payment Schedule Paragraph"
+    for style in doc.styles:
+        if style.name == style_name:
+            try:
+                p_pr = style.element.get_or_add_pPr()
+                num_pr = p_pr.find(qn("w:numPr"))
+                if num_pr is not None:
+                    p_pr.remove(num_pr)
+            except Exception:
+                pass
+            return style.style_id
+    try:
+        from docx.enum.style import WD_STYLE_TYPE
+        style = doc.styles.add_style(style_name, WD_STYLE_TYPE.PARAGRAPH)
+        style.base_style = doc.styles["Normal"]
+        try:
+            p_pr = style.element.get_or_add_pPr()
+            num_pr = p_pr.find(qn("w:numPr"))
+            if num_pr is not None:
+                p_pr.remove(num_pr)
+        except Exception:
+            pass
+        return style.style_id
+    except Exception:
+        return "PaymentScheduleParagraph"
+
+
 # ---------------------------------------------------------------------------
 
 def _process_paragraphs(
@@ -1167,6 +1243,7 @@ def _process_list_paragraphs(
     bullet_num_id: str,
     multilevel_num_id: str,
     bullet_style_id: str,
+    list_paragraph_style_id: str = "",
     plain_list_keys: set[str] | None = None,
     default_language_code: str | None = None,
 ) -> None:
@@ -1174,7 +1251,7 @@ def _process_list_paragraphs(
         _replace_list_in_paragraph(
             para, list_replacements,
             bullet_num_id, multilevel_num_id, bullet_style_id,
-            plain_list_keys, default_language_code,
+            list_paragraph_style_id, plain_list_keys, default_language_code,
         )
 
 
@@ -1186,6 +1263,7 @@ def _process_tables(
     bullet_num_id: str = "",
     multilevel_num_id: str = "",
     bullet_style_id: str = "",
+    list_paragraph_style_id: str = "",
     plain_list_keys: set[str] | None = None,
     default_language_code: str | None = None,
 ) -> None:
@@ -1202,12 +1280,12 @@ def _process_tables(
                     _process_list_paragraphs(
                         cell.paragraphs, list_replacements,
                         bullet_num_id, multilevel_num_id, bullet_style_id,
-                        plain_list_keys, default_language_code,
+                        list_paragraph_style_id, plain_list_keys, default_language_code,
                     )
                 _process_paragraphs(cell.paragraphs, replacements, language_code=default_language_code)
                 _process_tables(
                     cell.tables, replacements, table_replacements, list_replacements,
-                    bullet_num_id, multilevel_num_id, bullet_style_id,
+                    bullet_num_id, multilevel_num_id, bullet_style_id, list_paragraph_style_id,
                     plain_list_keys, default_language_code,
                 )
 
@@ -1481,6 +1559,7 @@ def process_template(
     bullet_num_id = ""
     multilevel_num_id = ""
     bullet_style_id = ""
+    list_paragraph_style_id = ""
 
     if table_replacements:
         _process_table_placeholders(
@@ -1499,16 +1578,18 @@ def process_template(
         except Exception:
             pass
         bullet_style_id = _find_bullet_style_id(doc)
+        list_paragraph_style_id = _find_list_paragraph_style_id(doc)
         _process_list_paragraphs(
             doc.paragraphs, list_replacements,
-            bullet_num_id, multilevel_num_id, bullet_style_id,
+            bullet_num_id, multilevel_num_id, bullet_style_id, list_paragraph_style_id,
             plain_list_keys, default_language_code,
         )
 
     _process_paragraphs(doc.paragraphs, replacements, language_code=default_language_code)
     _process_tables(
         doc.tables, replacements, table_replacements, list_replacements,
-        bullet_num_id, multilevel_num_id, bullet_style_id, plain_list_keys, default_language_code,
+        bullet_num_id, multilevel_num_id, bullet_style_id, list_paragraph_style_id,
+        plain_list_keys, default_language_code,
     )
 
     for section in doc.sections:
@@ -1527,7 +1608,7 @@ def process_template(
                 if list_replacements:
                     _process_list_paragraphs(
                         header_footer.paragraphs, list_replacements,
-                        bullet_num_id, multilevel_num_id, bullet_style_id,
+                        bullet_num_id, multilevel_num_id, bullet_style_id, list_paragraph_style_id,
                         plain_list_keys, default_language_code,
                     )
                 _process_paragraphs(
@@ -1537,7 +1618,7 @@ def process_template(
                 )
                 _process_tables(
                     header_footer.tables, replacements, table_replacements, list_replacements,
-                    bullet_num_id, multilevel_num_id, bullet_style_id,
+                    bullet_num_id, multilevel_num_id, bullet_style_id, list_paragraph_style_id,
                     plain_list_keys, default_language_code,
                 )
 

--- a/contracts_app/tests.py
+++ b/contracts_app/tests.py
@@ -391,3 +391,48 @@ class ContractVariableResolverTests(TestCase):
         self.assertEqual(replacements["{{corr_account}}"], "30101810400000000225")
         self.assertEqual(replacements["{{corr_bank_settlement_account}}"], "30101810945250000225")
         self.assertEqual(replacements["{{legacy_bank_swift}}"], "SABRRUMM")
+
+    def test_contacts_short_name_falls_back_to_performer_employee_person_record(self):
+        user = get_user_model().objects.create_user(
+            username="resolver-performer-person",
+            password="secret",
+        )
+        person = PersonRecord.objects.create(
+            last_name="Петров",
+            first_name="Петр",
+            middle_name="Петрович",
+            position=1,
+        )
+        employee = Employee.objects.create(user=user, person_record=person)
+        product = Product.objects.create(
+            short_name="DD",
+            name_en="Due Diligence",
+            name_ru="ДД",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+        )
+        project = ProjectRegistration.objects.create(
+            number=7003,
+            type=product,
+            name="Проект без профиля эксперта",
+            year=2026,
+        )
+        performer = Performer.objects.create(
+            registration=project,
+            employee=employee,
+            executor="Петров Петр Петрович",
+        )
+        variables = [
+            ContractVariable(
+                key="{{short_name}}",
+                source_section="contacts",
+                source_table="persons",
+                source_column="short_name",
+            ),
+        ]
+
+        replacements, lists = resolve_variables(performer, variables)
+
+        self.assertEqual(lists, {})
+        self.assertEqual(replacements["{{short_name}}"], "Петров П.П.")

--- a/contracts_app/variable_resolver.py
+++ b/contracts_app/variable_resolver.py
@@ -92,8 +92,13 @@ def _contract_person(ep: ExpertProfile | None):
     return getattr(employee, "person_record", None) if employee else None
 
 
-def _person_short_name(ep: ExpertProfile, _p: Performer) -> str:
-    person = _contract_person(ep)
+def _performer_person(p: Performer | None):
+    employee = getattr(p, "employee", None) if p else None
+    return getattr(employee, "person_record", None) if employee else None
+
+
+def _person_short_name(ep: ExpertProfile, p: Performer) -> str:
+    person = _contract_person(ep) or _performer_person(p)
     if not person:
         return ""
     last_name = str(getattr(person, "last_name", "") or "").strip()

--- a/core/column_registry.py
+++ b/core/column_registry.py
@@ -99,7 +99,8 @@ COLUMN_REGISTRY = {
                     "product": "Продукт",
                     "service_goal": "Цели оказания услуг",
                     "service_goal_genitive": "Цели оказания услуг в родительном падеже",
-                    "report_title": "Название отчета",
+                    "report_title": "Титул отчета/ТКП",
+                    "product_name": "Название продукта",
                 },
             },
             "section_structure": {

--- a/core/proposal_registry_columns.py
+++ b/core/proposal_registry_columns.py
@@ -102,6 +102,7 @@ PROPOSAL_REGISTRY_UI_COLUMNS = [
         "label": "Заказчик: регион",
         "split_prefix": "Заказчик: ",
         "split_suffix": "регион",
+        "split_inline": True,
         "variable_available": True,
     },
     {
@@ -157,6 +158,7 @@ PROPOSAL_REGISTRY_UI_COLUMNS = [
         "label": "Владелец: регион",
         "split_prefix": "Владелец: ",
         "split_suffix": "регион",
+        "split_inline": True,
         "variable_available": True,
     },
     {

--- a/core/static/core/css/site.css
+++ b/core/static/core/css/site.css
@@ -3199,6 +3199,24 @@ html.proposal-progress-cursor * {
   margin-top: 0;
 }
 
+#proposals-pane .proposal-payment-schedule-editor {
+  padding-bottom: 2rem;
+}
+
+#proposals-pane .proposal-payment-stage-block {
+  border-top: 1px solid #dee2e6;
+  padding-top: 1.25rem;
+}
+
+#proposals-pane .proposal-payment-stage-block + .proposal-payment-stage-block {
+  margin-top: 2rem !important;
+}
+
+#proposals-pane .proposal-payment-stage-title {
+  display: block;
+  margin-top: 0;
+}
+
 #proposals-pane .proposal-terms-table .proposal-terms-stage-col {
   width: 5.5rem;
   min-width: 5.5rem;

--- a/core/static/core/js/proposals-panels.js
+++ b/core/static/core/js/proposals-panels.js
@@ -119,10 +119,10 @@
     }
 
     const rootHrefAttrs = rootUrl
-      ? ' href="#proposals" data-bs-toggle="tab" hx-get="' + rootUrl + '" hx-target="#proposals-pane" hx-swap="outerHTML"'
+      ? ' href="#proposals" hx-get="' + rootUrl + '" hx-target="#proposals-pane" hx-swap="outerHTML"'
       : '';
     const currentHrefAttrs = currentUrl
-      ? ' href="#proposals" data-bs-toggle="tab" hx-get="' + currentUrl + '" hx-target="#proposals-pane" hx-swap="outerHTML"'
+      ? ' href="#proposals" hx-get="' + currentUrl + '" hx-target="#proposals-pane" hx-swap="outerHTML"'
       : '';
 
     heading.innerHTML = ''
@@ -5405,14 +5405,74 @@
       return Number.isFinite(value) ? value : 0;
     }
 
-    function syncFinalReportPercent() {
-      const advanceInput = form.querySelector('[name="advance_percent"]');
-      const preliminaryInput = form.querySelector('[name="preliminary_report_percent"]');
-      const finalInput = form.querySelector('[name="final_report_percent"]');
+    function syncFinalReportPercent(group) {
+      const scope = group || form;
+      const advanceInput = scope.querySelector('[name="advance_percent"]');
+      const preliminaryInput = scope.querySelector('[name="preliminary_report_percent"]');
+      const finalInput = scope.querySelector('[name="final_report_percent"]');
       if (!advanceInput || !preliminaryInput || !finalInput) return;
 
       const result = 100 - parsePercentValue(advanceInput) - parsePercentValue(preliminaryInput);
       finalInput.value = result.toFixed(2).replace(/\.00$/, '').replace(/(\.\d)0$/, '$1');
+    }
+
+    function syncAllFinalReportPercents() {
+      const groups = qa('.js-proposal-payment-group', form);
+      if (groups.length) {
+        groups.forEach(syncFinalReportPercent);
+        return;
+      }
+      syncFinalReportPercent(form);
+    }
+
+    function copyPaymentDefaultsFromFirstStage() {
+      const stageBlocks = qa('.proposal-payment-stage-block', form);
+      const firstBlock = stageBlocks[0];
+      if (!firstBlock) return;
+      const fieldNames = [
+        'advance_percent',
+        'advance_term_days',
+        'preliminary_report_percent',
+        'preliminary_report_term_days',
+        'final_report_percent',
+        'final_report_term_days',
+      ];
+      stageBlocks.slice(1).forEach(function (block) {
+        fieldNames.forEach(function (fieldName) {
+          const target = block.querySelector('[name="' + fieldName + '"]');
+          const source = firstBlock.querySelector('[name="' + fieldName + '"]');
+          if (!target || !source || String(target.value || '').trim()) return;
+          target.value = source.value || '';
+        });
+      });
+    }
+
+    function syncPaymentScheduleMode() {
+      const toggle = form.querySelector('input[type="checkbox"][name="payment_schedule_common"]');
+      const commonFields = form.querySelector('.js-proposal-payment-common-fields');
+      const stageFields = form.querySelector('.js-proposal-payment-stage-fields');
+      const isCommon = !toggle || toggle.checked;
+      commonFields?.classList.toggle('d-none', !isCommon);
+      stageFields?.classList.toggle('d-none', isCommon);
+      if (commonFields) {
+        commonFields.querySelectorAll('input, select, textarea').forEach(function (input) {
+          if (input.name === 'final_report_percent') return;
+          input.disabled = !isCommon;
+        });
+      }
+      if (stageFields) {
+        stageFields.querySelectorAll('input, select, textarea').forEach(function (input) {
+          if (input.name === 'final_report_percent') {
+            input.disabled = true;
+            return;
+          }
+          input.disabled = isCommon;
+        });
+      }
+      if (!isCommon) {
+        copyPaymentDefaultsFromFirstStage();
+      }
+      syncAllFinalReportPercents();
     }
 
     function syncAssetOwnerFromCustomer(reason) {
@@ -5805,8 +5865,9 @@
       const metaEl = form.querySelector('#proposal-type-meta');
       const serviceStagesContainer = form.querySelector('#proposal-service-stages-container');
       const commercialStagesContainer = form.querySelector('#proposal-commercial-stages-container');
+      const paymentStagesContainer = form.querySelector('#proposal-payment-stages-container');
       const termsTbody = form.querySelector('#proposal-stage-terms-tbody');
-      if (!container || !addBtn || !metaEl || !serviceStagesContainer || !commercialStagesContainer || !termsTbody) return null;
+      if (!container || !addBtn || !metaEl || !serviceStagesContainer || !commercialStagesContainer || !paymentStagesContainer || !termsTbody) return null;
       if (form.dataset.stageProductsBound === '1') return form.__proposalStageProductsApi || null;
       form.dataset.stageProductsBound = '1';
 
@@ -5846,6 +5907,10 @@
 
       function getCommercialBlocks() {
         return Array.from(commercialStagesContainer.querySelectorAll('[data-proposal-stage-kind="commercial"]'));
+      }
+
+      function getPaymentBlocks() {
+        return Array.from(paymentStagesContainer.querySelectorAll('[data-proposal-stage-kind="payment"]'));
       }
 
       function getSummaryCommercialBlock() {
@@ -5993,6 +6058,17 @@
           commercialBlocks = getCommercialBlocks();
         }
 
+        let paymentBlocks = getPaymentBlocks();
+        while (paymentBlocks.length < getProductRows().length && paymentBlocks.length) {
+          const clone = cloneStageBlock(paymentBlocks[paymentBlocks.length - 1]);
+          paymentStagesContainer.appendChild(clone);
+          paymentBlocks = getPaymentBlocks();
+        }
+        while (paymentBlocks.length > getProductRows().length && paymentBlocks.length > 1) {
+          paymentBlocks[paymentBlocks.length - 1].remove();
+          paymentBlocks = getPaymentBlocks();
+        }
+
         let termRows = getStageTermRows();
         while (termRows.length < getProductRows().length && termRows.length) {
           termsTbody.insertBefore(cloneTermsRow(termRows[termRows.length - 1]), getTotalsRow());
@@ -6008,16 +6084,20 @@
         const productRows = getProductRows();
         const serviceBlocks = getServiceBlocks();
         const commercialBlocks = getCommercialBlocks();
+        const paymentBlocks = getPaymentBlocks();
         const termRows = getStageTermRows();
         const hasMultipleStages = productRows.length > 1;
         const summaryCommercialBlock = getSummaryCommercialBlock();
-        function buildStageTitle(baseTitle, rank, productId) {
-          if (!hasMultipleStages) return baseTitle;
+        function buildStageLabel(rank, productId) {
           const product = productById.get(String(productId || '').trim()) || null;
           const shortLabel = String(product?.short_label || '').trim();
           return shortLabel
-            ? baseTitle + ': Этап ' + rank + ' ' + shortLabel
-            : baseTitle + ': Этап ' + rank;
+            ? 'Этап ' + rank + ' ' + shortLabel
+            : 'Этап ' + rank;
+        }
+        function buildStageTitle(baseTitle, rank, productId) {
+          if (!hasMultipleStages) return baseTitle;
+          return baseTitle + ': ' + buildStageLabel(rank, productId);
         }
         productRows.forEach(function (row, index) {
           const rank = index + 1;
@@ -6027,6 +6107,7 @@
           row.querySelector('.proposal-product-badge').textContent = rank;
           const serviceBlock = serviceBlocks[index];
           const commercialBlock = commercialBlocks[index];
+          const paymentBlock = paymentBlocks[index];
           const termRow = termRows[index];
           [serviceBlock, commercialBlock].forEach(function (block) {
             if (!block) return;
@@ -6042,6 +6123,13 @@
               }
             });
           });
+          if (paymentBlock) {
+            paymentBlock.dataset.proposalStageKey = stageUid;
+            paymentBlock.querySelectorAll('.proposal-payment-stage-title').forEach(function (title) {
+              title.textContent = buildStageLabel(rank, productId);
+            });
+            paymentBlock.classList.toggle('mt-4', index > 0);
+          }
           if (termRow) {
             termRow.dataset.proposalStageKey = stageUid;
             const stageInput = termRow.querySelector('.proposal-stage-label-input');
@@ -6601,6 +6689,7 @@
         syncStageTerms();
         applyProposalReportTermsLockState();
         syncSummaryCommercialBlock();
+        syncPaymentScheduleMode();
         form.dispatchEvent(new CustomEvent('proposal-stage-products-changed'));
       }
 
@@ -6792,8 +6881,12 @@
     const objectsApi = attachProposalObjectsTable(form);
     attachProposalAssetsToLegalEntitiesSync(form, assetsApi, legalEntitiesApi);
     attachProposalLegalEntitiesToObjectsSync(form, legalEntitiesApi, objectsApi);
-    form.querySelector('[name="advance_percent"]')?.addEventListener('input', syncFinalReportPercent);
-    form.querySelector('[name="preliminary_report_percent"]')?.addEventListener('input', syncFinalReportPercent);
+    form.addEventListener('input', function (event) {
+      if (!['advance_percent', 'preliminary_report_percent'].includes(event.target?.name)) return;
+      syncFinalReportPercent(event.target.closest('.js-proposal-payment-group') || form);
+    });
+    form.querySelector('input[type="checkbox"][name="payment_schedule_common"]')?.addEventListener('change', syncPaymentScheduleMode);
+    syncPaymentScheduleMode();
     qa('.js-proposal-report-terms-lock', form).forEach(function (icon) {
       icon.addEventListener('click', function () {
         proposalReportTermsEditMode = !proposalReportTermsEditMode;

--- a/policy_app/admin.py
+++ b/policy_app/admin.py
@@ -215,6 +215,7 @@ class ServiceGoalReportAdmin(TimestampedAdmin):
         "service_goal",
         "service_goal_genitive",
         "report_title",
+        "product_name",
         "updated_at",
     )
     list_editable = ("position",)
@@ -226,6 +227,7 @@ class ServiceGoalReportAdmin(TimestampedAdmin):
         "service_goal",
         "service_goal_genitive",
         "report_title",
+        "product_name",
     )
     ordering = ("product__short_name", "position", "id")
     fieldsets = (
@@ -236,6 +238,7 @@ class ServiceGoalReportAdmin(TimestampedAdmin):
                 "service_goal",
                 "service_goal_genitive",
                 "report_title",
+                "product_name",
             ),
         }),
         ("Служебные поля", {

--- a/policy_app/forms.py
+++ b/policy_app/forms.py
@@ -541,7 +541,7 @@ class ServiceGoalReportForm(forms.ModelForm):
 
     class Meta:
         model = ServiceGoalReport
-        fields = ["product", "service_goal", "service_goal_genitive", "report_title"]
+        fields = ["product", "service_goal", "service_goal_genitive", "report_title", "product_name"]
         widgets = {
             "service_goal": forms.Textarea(attrs={
                 "class": "form-control",
@@ -555,8 +555,12 @@ class ServiceGoalReportForm(forms.ModelForm):
             }),
             "report_title": forms.Textarea(attrs={
                 "class": "form-control",
-                "placeholder": "Название отчета",
+                "placeholder": "Титул отчета/ТКП",
                 "rows": 4,
+            }),
+            "product_name": forms.TextInput(attrs={
+                "class": "form-control",
+                "placeholder": "Название продукта",
             }),
         }
 

--- a/policy_app/migrations/0042_servicegoalreport_product_name_and_report_title_label.py
+++ b/policy_app/migrations/0042_servicegoalreport_product_name_and_report_title_label.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("policy_app", "0041_create_group_direction_director"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="servicegoalreport",
+            name="report_title",
+            field=models.TextField(
+                blank=True,
+                default="",
+                verbose_name="Титул отчета/ТКП",
+            ),
+        ),
+        migrations.AddField(
+            model_name="servicegoalreport",
+            name="product_name",
+            field=models.TextField(
+                blank=True,
+                default="",
+                verbose_name="Название продукта",
+            ),
+        ),
+    ]

--- a/policy_app/models.py
+++ b/policy_app/models.py
@@ -534,7 +534,8 @@ class ServiceGoalReport(models.Model):
         blank=True,
         default="",
     )
-    report_title = models.TextField("Название отчета", blank=True, default="")
+    report_title = models.TextField("Титул отчета/ТКП", blank=True, default="")
+    product_name = models.TextField("Название продукта", blank=True, default="")
     position = models.PositiveIntegerField("Позиция", default=0, db_index=True)
 
     created_at = models.DateTimeField(auto_now_add=True)

--- a/policy_app/templates/policy_app/policy_partial.html
+++ b/policy_app/templates/policy_app/policy_partial.html
@@ -318,7 +318,8 @@
                 <th>Продукт</th>
                 <th>Цели оказания услуг</th>
                 <th>Цели оказания услуг в родительном падеже</th>
-                <th>Название отчета</th>
+                <th>Титул отчета/ТКП</th>
+                <th>Название продукта</th>
             </tr>
             </thead>
             <tbody>
@@ -343,9 +344,10 @@
                     <td>{{ item.service_goal }}</td>
                     <td>{{ item.service_goal_genitive }}</td>
                     <td>{{ item.report_title }}</td>
+                    <td>{{ item.product_name }}</td>
                 </tr>
             {% empty %}
-                <tr><td colspan="5" class="text-muted">Пока нет данных.</td></tr>
+                <tr><td colspan="6" class="text-muted">Пока нет данных.</td></tr>
             {% endfor %}
             </tbody>
         </table>

--- a/policy_app/templates/policy_app/service_goal_report_form.html
+++ b/policy_app/templates/policy_app/service_goal_report_form.html
@@ -34,8 +34,12 @@
       {{ form.service_goal_genitive }}
     </div>
     <div class="mb-3">
-      <label class="form-label">Название отчета</label>
+      <label class="form-label">Титул отчета/ТКП</label>
       {{ form.report_title }}
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Название продукта</label>
+      {{ form.product_name }}
     </div>
 
     {% if form.errors %}

--- a/policy_app/tests.py
+++ b/policy_app/tests.py
@@ -457,6 +457,7 @@ class ServiceGoalReportViewsTests(TestCase):
             service_goal="Подготовка заключения",
             service_goal_genitive="Подготовки заключения",
             report_title="Итоговый отчет",
+            product_name="Налоговый обзор",
             position=1,
         )
 
@@ -464,8 +465,11 @@ class ServiceGoalReportViewsTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Цели услуг и названия отчетов")
+        self.assertContains(response, "Титул отчета/ТКП")
+        self.assertContains(response, "Название продукта")
         self.assertContains(response, "Подготовка заключения")
         self.assertContains(response, "Подготовки заключения")
+        self.assertContains(response, "Налоговый обзор")
         self.assertContains(response, 'id="service-goal-reports-actions"', html=False)
 
     def test_create_service_goal_report_saves_row(self):
@@ -476,6 +480,7 @@ class ServiceGoalReportViewsTests(TestCase):
                 "service_goal": "Подготовка документов",
                 "service_goal_genitive": "Подготовки документов",
                 "report_title": "Отчет по документам",
+                "product_name": "Документарная проверка",
             },
         )
 
@@ -485,6 +490,7 @@ class ServiceGoalReportViewsTests(TestCase):
         self.assertEqual(item.service_goal, "Подготовка документов")
         self.assertEqual(item.service_goal_genitive, "Подготовки документов")
         self.assertEqual(item.report_title, "Отчет по документам")
+        self.assertEqual(item.product_name, "Документарная проверка")
         self.assertEqual(item.position, 1)
 
     def test_service_goal_report_form_renders_product_picker_with_display_name(self):
@@ -495,6 +501,8 @@ class ServiceGoalReportViewsTests(TestCase):
         self.assertContains(response, "policy-product-select")
         self.assertContains(response, 'data-short-label="TAX"', html=False)
         self.assertContains(response, "TAX Tax")
+        self.assertContains(response, "Титул отчета/ТКП")
+        self.assertContains(response, "Название продукта")
 
         form = ServiceGoalReportForm()
         labels = [label for _, label in form.fields["product"].choices]

--- a/projects_app/tests.py
+++ b/projects_app/tests.py
@@ -876,6 +876,24 @@ class ExpertProjectVisibilityTests(TestCase):
         self.assertNotContains(response, self.declined_project.short_uid)
         self.assertNotContains(response, "Отклоненный актив")
 
+    def test_group_expert_with_empty_employee_role_is_still_filtered(self):
+        self.employee.role = ""
+        self.employee.save(update_fields=["role"])
+        expert_group, _ = Group.objects.get_or_create(name=EXPERT_GROUP)
+        self.user.groups.add(expert_group)
+
+        projects_response = self.client.get(reverse("projects_partial"))
+        performers_response = self.client.get(reverse("performers_partial"))
+
+        self.assertEqual(projects_response.status_code, 200)
+        self.assertContains(projects_response, self.confirmed_project.name)
+        self.assertNotContains(projects_response, self.declined_project.name)
+        self.assertNotContains(projects_response, "Отклоненный актив")
+        self.assertEqual(performers_response.status_code, 200)
+        self.assertContains(performers_response, self.confirmed_project.name)
+        self.assertNotContains(performers_response, self.declined_project.name)
+        self.assertNotContains(performers_response, "Отклоненный актив")
+
 
 class CloudStorageProjectRoutingTests(TestCase):
     def setUp(self):

--- a/projects_app/views.py
+++ b/projects_app/views.py
@@ -84,8 +84,13 @@ def staff_required(user):
 
 def _confirmed_project_ids_for_expert(user):
     employee = getattr(user, "employee_profile", None)
-    if getattr(employee, "role", "") != EXPERT_GROUP:
+    is_expert = getattr(employee, "role", "") == EXPERT_GROUP
+    if not is_expert and user and getattr(user, "is_authenticated", False):
+        is_expert = user.groups.filter(name=EXPERT_GROUP).exists()
+    if not is_expert:
         return None
+    if not employee:
+        return []
     return list(
         Performer.objects
         .filter(

--- a/proposals_app/forms.py
+++ b/proposals_app/forms.py
@@ -201,7 +201,9 @@ def _proposal_variable_registry():
     from core.column_registry import COLUMN_REGISTRY
 
     proposals = COLUMN_REGISTRY.get("proposals", {})
+    products = COLUMN_REGISTRY.get("products", {})
     registry = proposals.get("tables", {}).get("registry", {})
+    service_goals = products.get("tables", {}).get("service_goals_and_report_titles", {})
     return {
         "proposals": {
             "label": proposals.get("label", "ТКП"),
@@ -209,7 +211,16 @@ def _proposal_variable_registry():
                 "registry": {
                     "label": registry.get("label", "Реестр ТКП"),
                     "columns": registry.get("columns", {}),
-                }
+                },
+            },
+        },
+        "products": {
+            "label": products.get("label", "Продукты"),
+            "tables": {
+                "service_goals_and_report_titles": {
+                    "label": service_goals.get("label", "Цели услуг и названия отчетов"),
+                    "columns": service_goals.get("columns", {}),
+                },
             },
         }
     }
@@ -605,6 +616,11 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
         ],
         widget=forms.HiddenInput(attrs={"id": "proposal-service-composition-mode"}),
     )
+    payment_schedule_common = forms.BooleanField(
+        label="Общий для всех этапов",
+        required=False,
+        initial=True,
+    )
 
     _decimal_text_fields = (
         "service_term_months",
@@ -788,6 +804,7 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
 
         self._bootstrapify()
         self.fields["asset_owner_matches_customer"].widget.attrs["class"] = "form-check-input"
+        self.fields["payment_schedule_common"].widget.attrs["class"] = "form-check-input"
 
         if self.instance and self.instance.pk and "assets_payload" not in self.data:
             self.fields["assets_payload"].initial = json.dumps(
@@ -958,6 +975,18 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
         elif "service_composition_mode" not in self.data:
             self.fields["service_composition_mode"].initial = "sections"
 
+        self.payment_schedule_common_enabled = self._is_payment_schedule_common_enabled()
+        self.fields["payment_schedule_common"].initial = self.payment_schedule_common_enabled
+        if not self.payment_schedule_common_enabled:
+            for field_name in (
+                "advance_percent",
+                "advance_term_days",
+                "preliminary_report_percent",
+                "preliminary_report_term_days",
+                "final_report_term_days",
+            ):
+                self.fields[field_name].widget.attrs["disabled"] = True
+
         if not self.instance.pk and "group_member" not in self.data:
             self.fields["group_member"].initial = (
                 GroupMember.objects.filter(country_alpha2="RU").order_by("position", "id").values_list("pk", flat=True).first()
@@ -1000,6 +1029,20 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
         self.stage_rows = self._build_stage_rows()
         self.summary_commercial_row = self._build_summary_commercial_row()
 
+    def _is_payment_schedule_common_enabled(self):
+        if self.is_bound:
+            if "payment_schedule_common" not in self.data:
+                return True
+            return self.fields["payment_schedule_common"].widget.value_from_datadict(
+                self.data,
+                self.files,
+                "payment_schedule_common",
+            )
+        stored_stages = list(getattr(self.instance, "stage_payloads_json", None) or [])
+        if any(isinstance(payload, dict) and payload.get("payment_schedule_common") is False for payload in stored_stages):
+            return False
+        return True
+
     def _default_stage_commercial_totals_payload(self):
         payload = {
             "discount_percent": "5",
@@ -1017,6 +1060,12 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
             **self._default_stage_commercial_totals_payload(),
             **(payload or {}),
         }
+
+    @staticmethod
+    def _stage_display_value(value, default=""):
+        if value in (None, ""):
+            value = default
+        return "" if value is None else str(value)
 
     def _serialize_instance_commercial_rows(self):
         if not self.instance or not self.instance.pk:
@@ -1076,6 +1125,12 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
             "preliminary_report_date": "",
             "final_report_term_weeks": "",
             "final_report_date": "",
+            "advance_percent": str(self.fields["advance_percent"].initial or ""),
+            "advance_term_days": str(self.fields["advance_term_days"].initial or ""),
+            "preliminary_report_percent": str(self.fields["preliminary_report_percent"].initial or ""),
+            "preliminary_report_term_days": str(self.fields["preliminary_report_term_days"].initial or ""),
+            "final_report_percent": str(self.initial.get("final_report_percent") or ""),
+            "final_report_term_days": str(self.fields["final_report_term_days"].initial or ""),
         }
 
     def _build_stage_rows_from_bound_data(self):
@@ -1097,6 +1152,12 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
             "preliminary_report_date",
             "final_report_term_weeks",
             "final_report_date",
+            "advance_percent",
+            "advance_term_days",
+            "preliminary_report_percent",
+            "preliminary_report_term_days",
+            "final_report_percent",
+            "final_report_term_days",
         )
         rows_map = {name: _proposal_request_list(self.data, name) for name in field_names}
         product_ids = {
@@ -1181,6 +1242,28 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
                 "final_report_date": (
                     rows_map["final_report_date"][index] if index < len(rows_map["final_report_date"]) else ""
                 ).strip(),
+                "advance_percent": (
+                    rows_map["advance_percent"][index] if index < len(rows_map["advance_percent"]) else ""
+                ).strip(),
+                "advance_term_days": (
+                    rows_map["advance_term_days"][index] if index < len(rows_map["advance_term_days"]) else ""
+                ).strip(),
+                "preliminary_report_percent": (
+                    rows_map["preliminary_report_percent"][index]
+                    if index < len(rows_map["preliminary_report_percent"])
+                    else ""
+                ).strip(),
+                "preliminary_report_term_days": (
+                    rows_map["preliminary_report_term_days"][index]
+                    if index < len(rows_map["preliminary_report_term_days"])
+                    else ""
+                ).strip(),
+                "final_report_percent": (
+                    rows_map["final_report_percent"][index] if index < len(rows_map["final_report_percent"]) else ""
+                ).strip(),
+                "final_report_term_days": (
+                    rows_map["final_report_term_days"][index] if index < len(rows_map["final_report_term_days"]) else ""
+                ).strip(),
             }
             has_data = any(
                 row[key]
@@ -1251,6 +1334,30 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
                         "preliminary_report_date": str(payload.get("preliminary_report_date") or ""),
                         "final_report_term_weeks": str(payload.get("final_report_term_weeks") or ""),
                         "final_report_date": str(payload.get("final_report_date") or ""),
+                        "advance_percent": self._stage_display_value(
+                            payload.get("advance_percent"),
+                            instance.advance_percent,
+                        ),
+                        "advance_term_days": self._stage_display_value(
+                            payload.get("advance_term_days"),
+                            instance.advance_term_days,
+                        ),
+                        "preliminary_report_percent": self._stage_display_value(
+                            payload.get("preliminary_report_percent"),
+                            instance.preliminary_report_percent,
+                        ),
+                        "preliminary_report_term_days": self._stage_display_value(
+                            payload.get("preliminary_report_term_days"),
+                            instance.preliminary_report_term_days,
+                        ),
+                        "final_report_percent": self._stage_display_value(
+                            payload.get("final_report_percent"),
+                            instance.final_report_percent,
+                        ),
+                        "final_report_term_days": self._stage_display_value(
+                            payload.get("final_report_term_days"),
+                            instance.final_report_term_days,
+                        ),
                     }
                 )
             if normalized_rows:
@@ -1287,6 +1394,30 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
                 "preliminary_report_date": _format_stage_date(instance.preliminary_report_date),
                 "final_report_term_weeks": str(instance.final_report_term_weeks or ""),
                 "final_report_date": _format_stage_date(instance.final_report_date),
+                "advance_percent": self._stage_display_value(
+                    instance.advance_percent,
+                    self.fields["advance_percent"].initial,
+                ),
+                "advance_term_days": self._stage_display_value(
+                    instance.advance_term_days,
+                    self.fields["advance_term_days"].initial,
+                ),
+                "preliminary_report_percent": self._stage_display_value(
+                    instance.preliminary_report_percent,
+                    self.fields["preliminary_report_percent"].initial,
+                ),
+                "preliminary_report_term_days": self._stage_display_value(
+                    instance.preliminary_report_term_days,
+                    self.fields["preliminary_report_term_days"].initial,
+                ),
+                "final_report_percent": self._stage_display_value(
+                    instance.final_report_percent,
+                    self.initial.get("final_report_percent"),
+                ),
+                "final_report_term_days": self._stage_display_value(
+                    instance.final_report_term_days,
+                    self.fields["final_report_term_days"].initial,
+                ),
             }
         ]
 
@@ -1337,6 +1468,24 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
         if not raw:
             return None
         return self._parse_payload_decimal(raw, f"Этап {row_index}: поле «{field_label}» заполнено некорректно.")
+
+    def _parse_stage_percent(self, value, *, row_index, field_label):
+        parsed = self._parse_stage_decimal(value, row_index=row_index, field_label=field_label)
+        if parsed is not None and (parsed < 0 or parsed > 100):
+            raise forms.ValidationError(f"Этап {row_index}: поле «{field_label}» должно быть в диапазоне от 0% до 100%.")
+        return parsed
+
+    def _parse_stage_integer(self, value, *, row_index, field_label):
+        raw = str(value or "").strip()
+        if not raw:
+            return None
+        try:
+            parsed = int(raw)
+        except (TypeError, ValueError):
+            raise forms.ValidationError(f"Этап {row_index}: поле «{field_label}» заполнено некорректно.")
+        if parsed < 0:
+            raise forms.ValidationError(f"Этап {row_index}: поле «{field_label}» должно быть не меньше 0.")
+        return parsed
 
     def _load_stage_json(self, raw, *, row_index, field_label, expected_type, default):
         raw = str(raw or "").strip()
@@ -1841,6 +1990,47 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
             if service_composition_mode not in {"sections", "customer_tz"}:
                 service_composition_mode = "sections"
             service_composition_customer_tz = str(row.get("service_composition_customer_tz") or "").strip()
+            if self.payment_schedule_common_enabled:
+                advance_percent = self.cleaned_data.get("advance_percent")
+                advance_term_days = self.cleaned_data.get("advance_term_days")
+                preliminary_report_percent = self.cleaned_data.get("preliminary_report_percent")
+                preliminary_report_term_days = self.cleaned_data.get("preliminary_report_term_days")
+                final_report_percent = self.cleaned_data.get("final_report_percent")
+                final_report_term_days = self.cleaned_data.get("final_report_term_days")
+            else:
+                advance_percent = self._parse_stage_percent(
+                    row.get("advance_percent"),
+                    row_index=rank,
+                    field_label="Размер предоплаты в процентах",
+                )
+                advance_term_days = self._parse_stage_integer(
+                    row.get("advance_term_days"),
+                    row_index=rank,
+                    field_label="Срок предоплаты в календарных днях",
+                )
+                preliminary_report_percent = self._parse_stage_percent(
+                    row.get("preliminary_report_percent"),
+                    row_index=rank,
+                    field_label="Размер оплаты Предварительного отчёта в процентах",
+                )
+                preliminary_report_term_days = self._parse_stage_integer(
+                    row.get("preliminary_report_term_days"),
+                    row_index=rank,
+                    field_label="Срок оплаты Предварительного отчёта в календарных днях",
+                )
+                final_report_percent = self._calculate_final_report_percent(
+                    advance_percent=row.get("advance_percent"),
+                    preliminary_report_percent=row.get("preliminary_report_percent"),
+                )
+                if final_report_percent < 0 or final_report_percent > 100:
+                    raise forms.ValidationError(
+                        f"Этап {rank}: рассчитанный размер оплаты Итогового отчёта должен быть в диапазоне от 0% до 100%."
+                    )
+                final_report_term_days = self._parse_stage_integer(
+                    row.get("final_report_term_days"),
+                    row_index=rank,
+                    field_label="Срок оплаты Итогового отчёта в календарных днях",
+                )
 
             stage_payloads.append(
                 {
@@ -1901,6 +2091,12 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
                         row_index=rank,
                         field_label="Дата Итогового отчёта",
                     ),
+                    "advance_percent": advance_percent,
+                    "advance_term_days": advance_term_days,
+                    "preliminary_report_percent": preliminary_report_percent,
+                    "preliminary_report_term_days": preliminary_report_term_days,
+                    "final_report_percent": final_report_percent,
+                    "final_report_term_days": final_report_term_days,
                 }
             )
         self.cleaned_type_ids = cleaned_product_ids
@@ -2003,6 +2199,13 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
             cleaned["preliminary_report_date"] = last_stage["preliminary_report_date"]
             cleaned["final_report_term_weeks"] = last_stage["final_report_term_weeks"]
             cleaned["final_report_date"] = last_stage["final_report_date"]
+            if not self.payment_schedule_common_enabled:
+                cleaned["advance_percent"] = last_stage["advance_percent"]
+                cleaned["advance_term_days"] = last_stage["advance_term_days"]
+                cleaned["preliminary_report_percent"] = last_stage["preliminary_report_percent"]
+                cleaned["preliminary_report_term_days"] = last_stage["preliminary_report_term_days"]
+                cleaned["final_report_percent"] = last_stage["final_report_percent"]
+                cleaned["final_report_term_days"] = last_stage["final_report_term_days"]
 
         return cleaned
 
@@ -2073,6 +2276,13 @@ class ProposalRegistrationForm(BootstrapMixin, forms.ModelForm):
                 "preliminary_report_date": _format_stage_date(item["preliminary_report_date"]),
                 "final_report_term_weeks": str(item["final_report_term_weeks"] or ""),
                 "final_report_date": _format_stage_date(item["final_report_date"]),
+                "payment_schedule_common": self.payment_schedule_common_enabled,
+                "advance_percent": self._serialize_payload_decimal(item["advance_percent"]),
+                "advance_term_days": item["advance_term_days"],
+                "preliminary_report_percent": self._serialize_payload_decimal(item["preliminary_report_percent"]),
+                "preliminary_report_term_days": item["preliminary_report_term_days"],
+                "final_report_percent": self._serialize_payload_decimal(item["final_report_percent"]),
+                "final_report_term_days": item["final_report_term_days"],
             }
             for item in stage_payloads
         ]
@@ -2859,19 +3069,18 @@ class ProposalDispatchForm(BootstrapMixin, forms.ModelForm):
         return instance
 
 
+PROPOSAL_TEMPLATE_ALL_VALUE = "__all__"
+
+
 class ProposalTemplateForm(forms.ModelForm):
     class Meta:
         model = ProposalTemplate
         fields = [
-            "group_member",
-            "product",
             "sample_name",
             "version",
             "file",
         ]
         widgets = {
-            "group_member": forms.Select(attrs={"class": "form-select"}),
-            "product": forms.Select(attrs={"class": "form-select"}),
             "sample_name": forms.TextInput(
                 attrs={"class": "form-control readonly-field", "readonly": True, "tabindex": "-1"}
             ),
@@ -2891,26 +3100,49 @@ class ProposalTemplateForm(forms.ModelForm):
             self._orig_version = self.instance.version or ""
 
         order_map = _proposal_group_member_order_map()
-        members_qs = GroupMember.objects.all()
-        self.fields["group_member"].queryset = members_qs
-        self.fields["group_member"].label_from_instance = (
-            lambda obj: _proposal_group_member_label(obj, order_map.get(obj.pk, 0))
-        )
-        self.fields["group_member"].required = True
-
-        self.fields["product"].queryset = Product.objects.order_by("position", "id")
-        self.fields["product"].label_from_instance = lambda obj: obj.short_name
+        members_qs = list(GroupMember.objects.all())
+        products_qs = list(Product.objects.order_by("position", "id"))
         self.fields["file"].required = not (self.instance and self.instance.pk and self.instance.file)
+        self.fields["sample_name"].required = False
+        self.fields["version"].required = False
 
         self.group_alpha2_map = {str(m.pk): (m.country_alpha2 or "").strip().upper() for m in members_qs}
         self.group_short_name_map = {str(m.pk): (m.short_name or "").strip() for m in members_qs}
+        self.product_short_name_map = {str(p.pk): (p.short_name or "").strip() for p in products_qs}
 
-        existing = ProposalTemplate.objects.select_related("product", "group_member").all()
+        selected_group_ids, self.is_all_groups_selected = self._selected_ids(
+            "group_member_ids",
+            self.instance.group_members.all() if self.instance and self.instance.pk else [],
+            getattr(self.instance, "group_member_id", None) if self.instance and self.instance.pk else None,
+        )
+        selected_product_ids, self.is_all_products_selected = self._selected_ids(
+            "product_ids",
+            self.instance.products.all() if self.instance and self.instance.pk else [],
+            getattr(self.instance, "product_id", None) if self.instance and self.instance.pk else None,
+        )
+        self.selected_group_ids = {str(value) for value in selected_group_ids}
+        self.selected_product_ids = {str(value) for value in selected_product_ids}
+        self.group_options = [
+            {
+                "id": member.pk,
+                "label": _proposal_group_member_label(member, order_map.get(member.pk, 0)),
+            }
+            for member in members_qs
+        ]
+        self.product_options = [
+            {
+                "id": product.pk,
+                "label": product.short_name or str(product),
+            }
+            for product in products_qs
+        ]
+
+        existing = ProposalTemplate.objects.all()
         if self.instance and self.instance.pk:
             existing = existing.exclude(pk=self.instance.pk)
         version_map = {}
         for template in existing:
-            key = f"{template.group_member_id or ''}:{template.product_id or ''}"
+            key = template.sample_name or ""
             try:
                 version = int(template.version)
             except (ValueError, TypeError):
@@ -2918,37 +3150,82 @@ class ProposalTemplateForm(forms.ModelForm):
             version_map[key] = max(version_map.get(key, 0), version)
         self.version_map = version_map
 
-        self.current_pair = ""
+        self.current_base = ""
         self.current_version = ""
         if self.instance and self.instance.pk:
-            self.current_pair = f"{self.instance.group_member_id or ''}:{self.instance.product_id or ''}"
+            self.current_base = self.instance.sample_name or ""
             self.current_version = self.instance.version or ""
+
+    def _posted_values(self, name):
+        if not self.is_bound:
+            return None
+        if hasattr(self.data, "getlist"):
+            return self.data.getlist(name)
+        value = self.data.get(name)
+        if value is None:
+            return []
+        return value if isinstance(value, list) else [value]
+
+    def _selected_ids(self, field_name, existing_items, legacy_id):
+        posted = self._posted_values(field_name)
+        if posted is not None:
+            if PROPOSAL_TEMPLATE_ALL_VALUE in posted or not posted:
+                return [], True
+            return [int(value) for value in posted if str(value).isdigit()], False
+
+        existing_ids = [item.pk for item in existing_items]
+        if existing_ids:
+            return existing_ids, False
+        if legacy_id:
+            return [legacy_id], False
+        return [], True
+
+    def clean(self):
+        cleaned = super().clean()
+        for field_name, model, label in (
+            ("group_member_ids", GroupMember, "Группа"),
+            ("product_ids", Product, "Продукт"),
+        ):
+            values = self._posted_values(field_name) or []
+            if PROPOSAL_TEMPLATE_ALL_VALUE in values or not values:
+                cleaned[field_name] = []
+                continue
+            selected_ids = [int(value) for value in values if str(value).isdigit()]
+            existing_ids = set(model.objects.filter(pk__in=selected_ids).values_list("pk", flat=True))
+            if existing_ids != set(selected_ids):
+                raise forms.ValidationError(f"В поле «{label}» выбраны несуществующие значения.")
+            cleaned[field_name] = selected_ids
+        return cleaned
 
     def save(self, commit=True):
         import os
 
         instance = super().save(commit=False)
-        alpha2 = ""
-        short_name = ""
-        if instance.group_member_id:
-            alpha2 = (instance.group_member.country_alpha2 or "").strip().upper()
-            short_name = (instance.group_member.short_name or "").strip()
-        product_short = ""
-        if instance.product_id:
-            product_short = (instance.product.short_name or "").strip()
+        group_ids = self.cleaned_data.get("group_member_ids") or []
+        product_ids = self.cleaned_data.get("product_ids") or []
+        groups = list(GroupMember.objects.filter(pk__in=group_ids))
+        products = list(Product.objects.filter(pk__in=product_ids).order_by("position", "id"))
+        groups_by_id = {group.pk: group for group in groups}
+        groups = [groups_by_id[group_id] for group_id in group_ids if group_id in groups_by_id]
+
+        instance.group_member = groups[0] if groups else None
+        instance.product = products[0] if products else None
+
+        alpha2 = "-".join((group.country_alpha2 or "").strip().upper() for group in groups if group.country_alpha2) or "Все"
+        short_name = "-".join((group.short_name or "").strip() for group in groups if group.short_name) or "Все"
+        product_short = "-".join((product.short_name or "").strip() for product in products if product.short_name) or "Все"
 
         prefix = " ".join(part for part in [alpha2, "Шаблон ТКП"] if part)
         tail = "_".join(part for part in [short_name, product_short] if part)
         base_name = "_".join(part for part in [prefix, tail] if part)
-        pair_key = f"{instance.group_member_id or ''}:{instance.product_id or ''}"
         existing = ProposalTemplate.objects.all()
 
-        if instance.pk and pair_key == self.current_pair:
+        if instance.pk and base_name == self.current_base:
             version = self._orig_version or "1"
         else:
             if instance.pk:
                 existing = existing.exclude(pk=instance.pk)
-            version = str(self._next_version(existing, instance.group_member_id, instance.product_id))
+            version = str(self._next_version(existing, base_name))
 
         instance.sample_name = base_name
         instance.version = version
@@ -2973,13 +3250,15 @@ class ProposalTemplateForm(forms.ModelForm):
 
         if commit:
             instance.save()
+            instance.group_members.set(groups)
+            instance.products.set(products)
         return instance
 
     @staticmethod
-    def _next_version(qs, group_member_id, product_id):
+    def _next_version(qs, base_name):
         max_version = 0
         for template in qs:
-            if template.group_member_id != group_member_id or template.product_id != product_id:
+            if (template.sample_name or "") != base_name:
                 continue
             try:
                 version = int(template.version)
@@ -3098,8 +3377,12 @@ class ProposalVariableForm(forms.ModelForm):
         col = cleaned.get("source_column", "")
         if not (sec and tbl and col):
             raise forms.ValidationError("Необходимо заполнить поля Раздел, Таблица и Столбец.")
-        if sec != "proposals" or tbl != "registry":
-            raise forms.ValidationError("Для переменных ТКП доступен только раздел «ТКП» и таблица «Реестр ТКП».")
+        allowed_sources = {
+            ("proposals", "registry"),
+            ("products", "service_goals_and_report_titles"),
+        }
+        if (sec, tbl) not in allowed_sources:
+            raise forms.ValidationError("Для переменных ТКП выберите доступную таблицу.")
         from core.column_registry import validate_column_ref
 
         if not validate_column_ref(sec, tbl, col):

--- a/proposals_app/migrations/0045_seed_payment_schedule_variable.py
+++ b/proposals_app/migrations/0045_seed_payment_schedule_variable.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+from django.db.models import Max
+
+
+def seed_payment_schedule_variable(apps, schema_editor):
+    ProposalVariable = apps.get_model("proposals_app", "ProposalVariable")
+    if ProposalVariable.objects.filter(key="[[payment_schedule]]").exists():
+        return
+
+    max_position = ProposalVariable.objects.aggregate(m=Max("position"))["m"] or 0
+    ProposalVariable.objects.create(
+        key="[[payment_schedule]]",
+        description="График оплаты",
+        is_computed=True,
+        position=max_position + 1,
+        source_section="",
+        source_table="",
+        source_column="",
+    )
+
+
+def remove_payment_schedule_variable(apps, schema_editor):
+    return
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("proposals_app", "0044_alter_proposalregistration_status"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            seed_payment_schedule_variable,
+            remove_payment_schedule_variable,
+        ),
+    ]

--- a/proposals_app/migrations/0046_proposaltemplate_multiselect_scope.py
+++ b/proposals_app/migrations/0046_proposaltemplate_multiselect_scope.py
@@ -1,0 +1,71 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def copy_legacy_template_scope(apps, schema_editor):
+    ProposalTemplate = apps.get_model("proposals_app", "ProposalTemplate")
+    for template in ProposalTemplate.objects.all():
+        if template.group_member_id:
+            template.group_members.add(template.group_member_id)
+        if template.product_id:
+            template.products.add(template.product_id)
+
+
+def noop_reverse(apps, schema_editor):
+    return
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("group_app", "0001_initial"),
+        ("policy_app", "0042_servicegoalreport_product_name_and_report_title_label"),
+        ("proposals_app", "0045_seed_payment_schedule_variable"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="proposaltemplate",
+            name="group_member",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="proposal_templates",
+                to="group_app.groupmember",
+                verbose_name="Группа",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="proposaltemplate",
+            name="product",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="proposal_templates",
+                to="policy_app.product",
+                verbose_name="Продукт",
+            ),
+        ),
+        migrations.AddField(
+            model_name="proposaltemplate",
+            name="group_members",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="proposal_template_sets",
+                to="group_app.groupmember",
+                verbose_name="Группы",
+            ),
+        ),
+        migrations.AddField(
+            model_name="proposaltemplate",
+            name="products",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="proposal_template_sets",
+                to="policy_app.product",
+                verbose_name="Продукты",
+            ),
+        ),
+        migrations.RunPython(copy_legacy_template_scope, noop_reverse),
+    ]

--- a/proposals_app/models.py
+++ b/proposals_app/models.py
@@ -571,12 +571,27 @@ class ProposalTemplate(models.Model):
         on_delete=models.SET_NULL,
         related_name="proposal_templates",
         null=True,
+        blank=True,
     )
     product = models.ForeignKey(
         "policy_app.Product",
         verbose_name="Продукт",
-        on_delete=models.CASCADE,
+        on_delete=models.SET_NULL,
         related_name="proposal_templates",
+        null=True,
+        blank=True,
+    )
+    group_members = models.ManyToManyField(
+        "group_app.GroupMember",
+        verbose_name="Группы",
+        related_name="proposal_template_sets",
+        blank=True,
+    )
+    products = models.ManyToManyField(
+        "policy_app.Product",
+        verbose_name="Продукты",
+        related_name="proposal_template_sets",
+        blank=True,
     )
     sample_name = models.CharField("Наименование образца", max_length=512)
     version = models.CharField("Версия", max_length=128, blank=True, default="")
@@ -626,6 +641,8 @@ class ProposalVariable(models.Model):
         if not sec:
             return ""
         tbl = sec["tables"].get(self.source_table)
+        if not tbl and self.source_section == "proposals" and self.source_table == "service_goals_and_report_titles":
+            tbl = COLUMN_REGISTRY.get("products", {}).get("tables", {}).get("service_goals_and_report_titles")
         if not tbl:
             return ""
         col_label = tbl["columns"].get(self.source_column, "")

--- a/proposals_app/templates/proposals_app/proposal_form_page.html
+++ b/proposals_app/templates/proposals_app/proposal_form_page.html
@@ -478,42 +478,109 @@
       </div>
       <div class="w-100"></div>
 
-      <div class="col-4">
-        <label class="form-label">{{ form.advance_percent.label }}</label>
-        <div class="proposal-inline-percent">
-          {{ form.advance_percent }}
-          <span class="proposal-inline-percent__suffix" aria-hidden="true">%</span>
-        </div>
-      </div>
-      <div class="col-4">
-        <label class="form-label">{{ form.advance_term_days.label }}</label>
-        {{ form.advance_term_days }}
-      </div>
-      <div class="w-100"></div>
+      <div class="col-12">
+        <label class="form-label mb-2">График оплаты</label>
+        <div class="proposal-assets-editor proposal-payment-schedule-editor">
+          <div class="form-check mb-3">
+            <input type="hidden" name="payment_schedule_common" value="false">
+            {{ form.payment_schedule_common }}
+            <label class="form-check-label" for="{{ form.payment_schedule_common.id_for_label }}">
+              {{ form.payment_schedule_common.label }}
+            </label>
+          </div>
 
-      <div class="col-4">
-        <label class="form-label">{{ form.preliminary_report_percent.label }}</label>
-        <div class="proposal-inline-percent">
-          {{ form.preliminary_report_percent }}
-          <span class="proposal-inline-percent__suffix" aria-hidden="true">%</span>
-        </div>
-      </div>
-      <div class="col-4">
-        <label class="form-label">{{ form.preliminary_report_term_days.label }}</label>
-        {{ form.preliminary_report_term_days }}
-      </div>
-      <div class="w-100"></div>
+          <div class="proposal-payment-common-fields js-proposal-payment-common-fields{% if not form.payment_schedule_common_enabled %} d-none{% endif %}">
+            <div class="row g-3 js-proposal-payment-group">
+              <div class="col-12 col-lg-4">
+                <label class="form-label">{{ form.advance_percent.label }}</label>
+                <div class="proposal-inline-percent">
+                  {{ form.advance_percent }}
+                  <span class="proposal-inline-percent__suffix" aria-hidden="true">%</span>
+                </div>
+              </div>
+              <div class="col-12 col-lg-4">
+                <label class="form-label">{{ form.advance_term_days.label }}</label>
+                {{ form.advance_term_days }}
+              </div>
+              <div class="w-100"></div>
 
-      <div class="col-4">
-        <label class="form-label">{{ form.final_report_percent.label }}</label>
-        <div class="proposal-inline-percent">
-          {{ form.final_report_percent }}
-          <span class="proposal-inline-percent__suffix" aria-hidden="true">%</span>
+              <div class="col-12 col-lg-4">
+                <label class="form-label">{{ form.preliminary_report_percent.label }}</label>
+                <div class="proposal-inline-percent">
+                  {{ form.preliminary_report_percent }}
+                  <span class="proposal-inline-percent__suffix" aria-hidden="true">%</span>
+                </div>
+              </div>
+              <div class="col-12 col-lg-4">
+                <label class="form-label">{{ form.preliminary_report_term_days.label }}</label>
+                {{ form.preliminary_report_term_days }}
+              </div>
+              <div class="w-100"></div>
+
+              <div class="col-12 col-lg-4">
+                <label class="form-label">{{ form.final_report_percent.label }}</label>
+                <div class="proposal-inline-percent">
+                  {{ form.final_report_percent }}
+                  <span class="proposal-inline-percent__suffix" aria-hidden="true">%</span>
+                </div>
+              </div>
+              <div class="col-12 col-lg-4">
+                <label class="form-label">{{ form.final_report_term_days.label }}</label>
+                {{ form.final_report_term_days }}
+              </div>
+            </div>
+          </div>
+
+          <div id="proposal-payment-stages-container" class="proposal-payment-stages-container js-proposal-payment-stage-fields{% if form.payment_schedule_common_enabled %} d-none{% endif %}">
+            {% for stage in form.stage_rows %}
+              <div class="proposal-payment-stage-block{% if not forloop.first %} mt-4{% endif %}"
+                   data-proposal-stage-root="1"
+                   data-proposal-stage-kind="payment"
+                   data-proposal-stage-key="{{ stage.rank }}">
+                <div class="form-label mb-2 proposal-payment-stage-title">Этап {{ stage.rank }}{% if stage.product_short_label %} {{ stage.product_short_label }}{% endif %}</div>
+                <div class="row g-3 js-proposal-payment-group">
+                  <div class="col-12 col-lg-4">
+                    <label class="form-label">{{ form.advance_percent.label }}</label>
+                    <div class="proposal-inline-percent">
+                      <input type="number" name="advance_percent" min="0" max="100" step="1" class="form-control" value="{{ stage.advance_percent }}"{% if form.payment_schedule_common_enabled %} disabled{% endif %}>
+                      <span class="proposal-inline-percent__suffix" aria-hidden="true">%</span>
+                    </div>
+                  </div>
+                  <div class="col-12 col-lg-4">
+                    <label class="form-label">{{ form.advance_term_days.label }}</label>
+                    <input type="number" name="advance_term_days" min="0" step="1" class="form-control" value="{{ stage.advance_term_days }}"{% if form.payment_schedule_common_enabled %} disabled{% endif %}>
+                  </div>
+                  <div class="w-100"></div>
+
+                  <div class="col-12 col-lg-4">
+                    <label class="form-label">{{ form.preliminary_report_percent.label }}</label>
+                    <div class="proposal-inline-percent">
+                      <input type="number" name="preliminary_report_percent" min="0" max="100" step="1" class="form-control" value="{{ stage.preliminary_report_percent }}"{% if form.payment_schedule_common_enabled %} disabled{% endif %}>
+                      <span class="proposal-inline-percent__suffix" aria-hidden="true">%</span>
+                    </div>
+                  </div>
+                  <div class="col-12 col-lg-4">
+                    <label class="form-label">{{ form.preliminary_report_term_days.label }}</label>
+                    <input type="number" name="preliminary_report_term_days" min="0" step="1" class="form-control" value="{{ stage.preliminary_report_term_days }}"{% if form.payment_schedule_common_enabled %} disabled{% endif %}>
+                  </div>
+                  <div class="w-100"></div>
+
+                  <div class="col-12 col-lg-4">
+                    <label class="form-label">{{ form.final_report_percent.label }}</label>
+                    <div class="proposal-inline-percent">
+                      <input type="number" name="final_report_percent" min="0" max="100" step="0.01" class="form-control readonly-field" value="{{ stage.final_report_percent }}" readonly tabindex="-1" disabled>
+                      <span class="proposal-inline-percent__suffix" aria-hidden="true">%</span>
+                    </div>
+                  </div>
+                  <div class="col-12 col-lg-4">
+                    <label class="form-label">{{ form.final_report_term_days.label }}</label>
+                    <input type="number" name="final_report_term_days" min="0" step="1" class="form-control" value="{{ stage.final_report_term_days }}"{% if form.payment_schedule_common_enabled %} disabled{% endif %}>
+                  </div>
+                </div>
+              </div>
+            {% endfor %}
+          </div>
         </div>
-      </div>
-      <div class="col-4">
-        <label class="form-label">{{ form.final_report_term_days.label }}</label>
-        {{ form.final_report_term_days }}
       </div>
     </div>
 

--- a/proposals_app/templates/proposals_app/proposal_template_form.html
+++ b/proposals_app/templates/proposals_app/proposal_template_form.html
@@ -19,15 +19,67 @@
   <div class="modal-body modal-body-scroll">
     {% csrf_token %}
     <div class="row g-2">
-      <div class="col-12">
+      <div class="col-6">
         <label class="form-label">Группа</label>
-        {{ form.group_member }}
+        <div class="dropdown" id="pt-group-dropdown">
+          <button class="form-select text-start" type="button"
+                  id="pt-group-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false"
+                  style="cursor:pointer; background-color:#fff;">
+            <span class="js-pt-group-label">Все</span>
+          </button>
+          <div class="dropdown-menu p-3" aria-labelledby="pt-group-toggle"
+               style="min-width: 100%; max-height: 240px; overflow-y: auto;">
+            <div class="form-check mb-2">
+              <input class="form-check-input js-pt-group" type="checkbox"
+                     name="group_member_ids" value="__all__" id="pt-group-all"
+                     {% if form.is_all_groups_selected %}checked{% endif %}>
+              <label class="form-check-label" for="pt-group-all">Все</label>
+            </div>
+            <hr class="dropdown-divider">
+            {% for opt in form.group_options %}
+              <div class="form-check">
+                <input class="form-check-input js-pt-group" type="checkbox"
+                       name="group_member_ids" value="{{ opt.id }}" id="pt-group-{{ opt.id }}"
+                       {% if opt.id|stringformat:"s" in form.selected_group_ids %}checked{% endif %}>
+                <label class="form-check-label" for="pt-group-{{ opt.id }}">{{ opt.label }}</label>
+              </div>
+            {% empty %}
+              <div class="text-muted small">Нет групп</div>
+            {% endfor %}
+          </div>
+        </div>
       </div>
       <div class="col-6">
         <label class="form-label">Продукт</label>
-        {{ form.product }}
+        <div class="dropdown" id="pt-product-dropdown">
+          <button class="form-select text-start" type="button"
+                  id="pt-product-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false"
+                  style="cursor:pointer; background-color:#fff;">
+            <span class="js-pt-product-label">Все</span>
+          </button>
+          <div class="dropdown-menu p-3" aria-labelledby="pt-product-toggle"
+               style="min-width: 100%; max-height: 240px; overflow-y: auto;">
+            <div class="form-check mb-2">
+              <input class="form-check-input js-pt-product" type="checkbox"
+                     name="product_ids" value="__all__" id="pt-product-all"
+                     {% if form.is_all_products_selected %}checked{% endif %}>
+              <label class="form-check-label" for="pt-product-all">Все</label>
+            </div>
+            <hr class="dropdown-divider">
+            {% for opt in form.product_options %}
+              <div class="form-check">
+                <input class="form-check-input js-pt-product" type="checkbox"
+                       name="product_ids" value="{{ opt.id }}" id="pt-product-{{ opt.id }}"
+                       {% if opt.id|stringformat:"s" in form.selected_product_ids %}checked{% endif %}>
+                <label class="form-check-label" for="pt-product-{{ opt.id }}">{{ opt.label }}</label>
+              </div>
+            {% empty %}
+              <div class="text-muted small">Нет продуктов</div>
+            {% endfor %}
+          </div>
+        </div>
       </div>
-      <div class="col-4">
+      <div class="col-10">
         <label class="form-label">Наименование образца</label>
         {{ form.sample_name }}
       </div>
@@ -49,54 +101,90 @@
 
 {{ form.group_alpha2_map|json_script:"pt-data-group-alpha2-map" }}
 {{ form.group_short_name_map|json_script:"pt-data-group-short-name-map" }}
+{{ form.product_short_name_map|json_script:"pt-data-product-short-name-map" }}
 {{ form.version_map|json_script:"pt-data-version-map" }}
-{{ form.current_pair|json_script:"pt-data-current-pair" }}
+{{ form.current_base|json_script:"pt-data-current-base" }}
 {{ form.current_version|json_script:"pt-data-current-ver" }}
 
 <script>
 (function() {
   function _jsonEl(id) { return JSON.parse(document.getElementById(id).textContent); }
+  const ALL_VAL = "__all__";
 
   const groupAlpha2Map = _jsonEl("pt-data-group-alpha2-map");
   const groupShortNameMap = _jsonEl("pt-data-group-short-name-map");
+  const productShortNameMap = _jsonEl("pt-data-product-short-name-map");
   const versionMap = _jsonEl("pt-data-version-map");
-  const currentPair = _jsonEl("pt-data-current-pair");
+  const currentBase = _jsonEl("pt-data-current-base");
   const currentVersion = _jsonEl("pt-data-current-ver");
 
-  const groupSel = document.getElementById("id_group_member");
-  const productSel = document.getElementById("id_product");
+  const groupDropdown = document.getElementById("pt-group-dropdown");
+  const productDropdown = document.getElementById("pt-product-dropdown");
+  const groupChecks = groupDropdown ? Array.from(groupDropdown.querySelectorAll(".js-pt-group")) : [];
+  const productChecks = productDropdown ? Array.from(productDropdown.querySelectorAll(".js-pt-product")) : [];
+  const groupAll = document.getElementById("pt-group-all");
+  const productAll = document.getElementById("pt-product-all");
+  const groupLabel = groupDropdown?.querySelector(".js-pt-group-label");
+  const productLabel = productDropdown?.querySelector(".js-pt-product-label");
   const sampleInp = document.getElementById("id_sample_name");
   const versionInp = document.getElementById("id_version");
 
-  function computePair() {
-    return (groupSel?.value || "") + ":" + (productSel?.value || "");
+  function selectedSpecificValues(checks) {
+    return checks.filter(cb => cb.checked && cb.value !== ALL_VAL).map(cb => cb.value);
+  }
+
+  function selectedLabel(checks, allCb) {
+    if (allCb && allCb.checked) return "Все";
+    const selected = checks.filter(cb => cb.checked && cb.value !== ALL_VAL);
+    if (!selected.length) return "Все";
+    if (selected.length === 1) return selected[0].nextElementSibling?.textContent?.trim() || "";
+    return selected.length + " выбрано";
+  }
+
+  function syncDropdown(checks, allCb, labelEl) {
+    if (labelEl) labelEl.textContent = selectedLabel(checks, allCb);
   }
 
   function computeBase() {
-    const alpha2 = groupAlpha2Map[groupSel?.value] || "";
-    const shortName = groupShortNameMap[groupSel?.value] || "";
-    const productShort = productSel?.value ? (productSel.selectedOptions[0]?.textContent?.trim() || "") : "";
+    const groupIds = selectedSpecificValues(groupChecks);
+    const productIds = selectedSpecificValues(productChecks);
+    const alpha2 = groupIds.map(id => groupAlpha2Map[id]).filter(Boolean).join("-") || "Все";
+    const shortName = groupIds.map(id => groupShortNameMap[id]).filter(Boolean).join("-") || "Все";
+    const productShort = productIds.map(id => productShortNameMap[id]).filter(Boolean).join("-") || "Все";
     const prefix = [alpha2, "Шаблон ТКП"].filter(Boolean).join(" ");
     const tail = [shortName, productShort].filter(Boolean).join("_");
     return [prefix, tail].filter(Boolean).join("_");
   }
 
-  function getNextVersion(pair) {
-    if (pair && pair === currentPair) return currentVersion || "1";
-    return String((versionMap[pair] || 0) + 1);
+  function getNextVersion(base) {
+    if (base && base === currentBase) return currentVersion || "1";
+    return String((versionMap[base] || 0) + 1);
   }
 
   function rebuild() {
     if (!sampleInp || !versionInp) return;
-    const pair = computePair();
-    sampleInp.value = computeBase();
-    versionInp.value = getNextVersion(pair);
+    const base = computeBase();
+    sampleInp.value = base;
+    versionInp.value = getNextVersion(base);
   }
 
-  [groupSel, productSel].forEach(function(el) {
-    if (el) el.addEventListener("change", rebuild);
-  });
+  function attachDropdown(checks, allCb, labelEl) {
+    checks.forEach(cb => {
+      cb.addEventListener("change", function() {
+        if (this.value === ALL_VAL && this.checked) {
+          checks.forEach(item => { if (item.value !== ALL_VAL) item.checked = false; });
+        } else if (this.value !== ALL_VAL && this.checked && allCb) {
+          allCb.checked = false;
+        }
+        syncDropdown(checks, allCb, labelEl);
+        rebuild();
+      });
+    });
+    syncDropdown(checks, allCb, labelEl);
+  }
 
+  attachDropdown(groupChecks, groupAll, groupLabel);
+  attachDropdown(productChecks, productAll, productLabel);
   rebuild();
 })();
 </script>

--- a/proposals_app/templates/proposals_app/proposals_partial.html
+++ b/proposals_app/templates/proposals_app/proposals_partial.html
@@ -489,7 +489,7 @@
                 </div>
               </td>
               <td class="text-nowrap">{{ template.group_display }}</td>
-              <td class="text-nowrap">{{ template.product.short_name }}</td>
+              <td class="text-nowrap">{{ template.products_display }}</td>
               <td>{{ template.sample_name }}</td>
               <td class="text-nowrap">{{ template.version }}</td>
               <td class="text-nowrap">{% if template.file %}{{ template.sample_name }}{% else %}—{% endif %}</td>

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -25,6 +25,7 @@ from docx.oxml.ns import qn
 from classifiers_app.models import BusinessEntityRecord, BusinessEntityIdentifierRecord, LegalEntityRecord, OKSMCountry, OKVCurrency
 from contacts_app.models import CitizenshipRecord, PersonRecord
 from core.models import CloudStorageSettings
+from core.proposal_registry_columns import get_proposal_registry_ui_columns
 from experts_app.models import ExpertContractDetails, ExpertProfile, ExpertProfileSpecialty, ExpertSpecialty
 from group_app.models import GroupMember, OrgUnit
 from letters_app.models import LetterTemplate
@@ -54,7 +55,13 @@ from .document_generation import (
     get_proposal_docx_source_token_payload,
     store_generated_documents,
 )
-from .forms import ProposalDispatchForm, ProposalRegistrationForm, _proposal_variable_column_choices
+from .forms import (
+    ProposalDispatchForm,
+    ProposalRegistrationForm,
+    ProposalTemplateForm,
+    _proposal_variable_column_choices,
+    _proposal_variable_table_choices,
+)
 from .forms import ProposalVariableForm
 from .models import (
     ProposalAsset,
@@ -326,6 +333,124 @@ class ProposalDocumentGenerationTests(TestCase):
         }
         self.proposal.save(update_fields=["commercial_totals_json"])
 
+    def test_proposal_template_form_saves_multiple_groups_and_products(self):
+        second_group = GroupMember.objects.create(
+            short_name="KAP",
+            country_name="Казахстан",
+            country_code="398",
+            country_alpha2="KZ",
+            position=2,
+        )
+        second_product = Product.objects.create(
+            short_name="JORC",
+            name_en="JORC Report",
+            name_ru="JORC",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Отчётность",
+            position=2,
+        )
+        form = ProposalTemplateForm(
+            data={
+                "group_member_ids": [str(self.group_member.pk), str(second_group.pk)],
+                "product_ids": [str(self.product.pk), str(second_product.pk)],
+                "sample_name": "",
+                "version": "",
+            },
+            files={
+                "file": SimpleUploadedFile(
+                    "proposal-template.docx",
+                    b"template-bytes",
+                    content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                )
+            },
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        template = form.save()
+
+        self.assertEqual(
+            set(template.group_members.values_list("pk", flat=True)),
+            {self.group_member.pk, second_group.pk},
+        )
+        self.assertEqual(
+            set(template.products.values_list("pk", flat=True)),
+            {self.product.pk, second_product.pk},
+        )
+        self.assertEqual(template.group_member_id, self.group_member.pk)
+        self.assertEqual(template.product_id, self.product.pk)
+
+    def test_find_proposal_template_matches_multistage_products_by_subset(self):
+        from .views import _find_proposal_template
+
+        second_product = Product.objects.create(
+            short_name="JORC",
+            name_en="JORC Report",
+            name_ru="JORC",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Отчётность",
+            position=2,
+        )
+        third_product = Product.objects.create(
+            short_name="VAL",
+            name_en="Valuation",
+            name_ru="Оценка",
+            consulting_type="Горный",
+            service_category="Оценка",
+            service_subtype="Оценка активов",
+            position=3,
+        )
+        self.proposal.type = second_product
+        self.proposal.save(update_fields=["type"])
+        ProposalRegistrationProduct.objects.create(proposal=self.proposal, product=self.product, rank=1)
+        ProposalRegistrationProduct.objects.create(proposal=self.proposal, product=second_product, rank=2)
+
+        too_narrow = ProposalTemplate.objects.create(
+            group_member=self.group_member,
+            product=self.product,
+            sample_name="Узкий шаблон",
+            version="1",
+        )
+        too_narrow.group_members.set([self.group_member])
+        too_narrow.products.set([self.product])
+        matching = ProposalTemplate.objects.create(
+            group_member=self.group_member,
+            product=self.product,
+            sample_name="Многоэтапный шаблон",
+            version="2",
+        )
+        matching.group_members.set([self.group_member])
+        matching.products.set([self.product, second_product, third_product])
+
+        found = _find_proposal_template(
+            self.proposal,
+            [too_narrow, matching],
+        )
+
+        self.assertEqual(found, matching)
+
+    def test_find_proposal_template_all_group_and_products_match_any_proposal(self):
+        from .views import _find_proposal_template
+
+        all_template = ProposalTemplate.objects.create(
+            group_member=None,
+            product=None,
+            sample_name="Все Шаблон ТКП_Все_Все",
+            version="1",
+        )
+
+        found = _find_proposal_template(self.proposal, [all_template])
+
+        self.assertEqual(found, all_template)
+
+    def test_find_proposal_template_keeps_legacy_single_product_fallback(self):
+        from .views import _find_proposal_template
+
+        found = _find_proposal_template(self.proposal, [self.template])
+
+        self.assertEqual(found, self.template)
+
     @patch("ai_app.proposals_app.document_generation._get_cloud_upload_user")
     @patch("ai_app.proposals_app.document_generation.cloud_upload_file", return_value=True)
     def test_create_documents_generates_docx_and_uploads_it_to_workspace_folder(
@@ -523,6 +648,43 @@ class ProposalDocumentGenerationTests(TestCase):
             self.assertNotIn("w:numPr", paragraph._element.xml)
             self.assertNotIn("w:pStyle", paragraph._element.xml)
             self.assertIn('w:lang w:val="ru-RU"', paragraph._element.xml)
+
+    def test_process_template_inserts_payment_schedule_with_indented_payment_lines(self):
+        template_doc = Document()
+        template_doc.add_paragraph("[[payment_schedule]]")
+        buffer = BytesIO()
+        template_doc.save(buffer)
+
+        generated_bytes = process_template(
+            buffer.getvalue(),
+            {},
+            list_replacements={
+                "[[payment_schedule]]": [
+                    {"runs": [{"text": "общий для всех этапов:"}]},
+                    {
+                        "runs": [{"text": "40% — предоплата при подписании контракта."}],
+                        "paragraph_style": "list_paragraph",
+                        "left_indent_cm": 1.0,
+                        "contextual_spacing": True,
+                    },
+                ]
+            },
+            default_language_code="ru-RU",
+        )
+
+        generated_doc = Document(BytesIO(generated_bytes))
+        heading = generated_doc.paragraphs[0]
+        payment_line = generated_doc.paragraphs[1]
+
+        self.assertEqual(heading.text, "общий для всех этапов:")
+        self.assertEqual(payment_line.text, "40% — предоплата при подписании контракта.")
+        self.assertNotIn("w:numPr", payment_line._element.xml)
+        self.assertNotIn("w:ind", heading._element.xml)
+        self.assertIn("w:pStyle", payment_line._element.xml)
+        self.assertIn("PaymentScheduleParagraph", payment_line._element.xml)
+        self.assertIn("w:ind", payment_line._element.xml)
+        self.assertIn("w:left", payment_line._element.xml)
+        self.assertIn("w:contextualSpacing", payment_line._element.xml)
 
     def test_process_template_applies_default_language_to_scalar_replacements(self):
         template_doc = Document()
@@ -2297,6 +2459,71 @@ class ProposalRegistrationFormTests(TestCase):
         self.assertEqual(form.fields["final_report_term_days"].initial, 15)
         self.assertEqual(form.fields["advance_percent"].widget.attrs["step"], "1")
         self.assertEqual(form.fields["preliminary_report_percent"].widget.attrs["step"], "1")
+        self.assertTrue(form.fields["payment_schedule_common"].initial)
+        self.assertTrue(form.payment_schedule_common_enabled)
+
+    def test_form_saves_per_stage_payment_schedule_when_not_common(self):
+        group_member = GroupMember.objects.create(
+            short_name="IMC Montan",
+            country_name="Россия",
+            country_code="643",
+            country_alpha2="RU",
+            position=1,
+        )
+        first_product = Product.objects.create(
+            short_name="TDD",
+            name_en="Technical Due Diligence",
+            name_ru="ТДД",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=1,
+        )
+        second_product = Product.objects.create(
+            short_name="JORC",
+            name_en="JORC Report",
+            name_ru="JORC",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Оптимизация",
+            position=2,
+        )
+        payload = QueryDict("", mutable=True)
+        payload.update(
+            {
+                "number": "3333",
+                "group_member": str(group_member.pk),
+                "name": "Мультиэтапное ТКП",
+                "kind": ProposalRegistration.ProposalKind.REGULAR,
+                "status": ProposalRegistration.ProposalStatus.FINAL,
+                "year": "2026",
+                "payment_schedule_common": "false",
+            }
+        )
+        payload.setlist("type", [str(first_product.pk), str(second_product.pk)])
+        payload.setlist("advance_percent", ["30", "50"])
+        payload.setlist("advance_term_days", ["5", "10"])
+        payload.setlist("preliminary_report_percent", ["20", "30"])
+        payload.setlist("preliminary_report_term_days", ["6", "7"])
+        payload.setlist("final_report_term_days", ["14", "21"])
+
+        form = ProposalRegistrationForm(data=payload)
+
+        self.assertFalse(form.payment_schedule_common_enabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        proposal = form.save(commit=False)
+
+        self.assertEqual(proposal.advance_percent, Decimal("50"))
+        self.assertEqual(proposal.advance_term_days, 10)
+        self.assertEqual(proposal.preliminary_report_percent, Decimal("30"))
+        self.assertEqual(proposal.preliminary_report_term_days, 7)
+        self.assertEqual(proposal.final_report_percent, Decimal("20.00"))
+        self.assertEqual(proposal.final_report_term_days, 21)
+        self.assertFalse(proposal.stage_payloads_json[0]["payment_schedule_common"])
+        self.assertEqual(proposal.stage_payloads_json[0]["advance_percent"], "30")
+        self.assertEqual(proposal.stage_payloads_json[0]["final_report_percent"], "50.00")
+        self.assertEqual(proposal.stage_payloads_json[1]["advance_percent"], "50")
+        self.assertEqual(proposal.stage_payloads_json[1]["final_report_percent"], "20.00")
 
     def test_form_includes_final_report_term_weeks_decimal_field(self):
         form = ProposalRegistrationForm()
@@ -2404,6 +2631,49 @@ class ProposalRegistrationFormTests(TestCase):
             ("country_full_name", "Наименование страны (полное)"),
             _proposal_variable_column_choices("proposals", "registry"),
         )
+
+    def test_proposal_variable_form_accepts_service_goal_report_binding(self):
+        form = ProposalVariableForm(
+            data={
+                "key": "{{product_name}}",
+                "description": "Название продукта",
+                "source_section": "products",
+                "source_table": "service_goals_and_report_titles",
+                "source_column": "product_name",
+            }
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertIn(
+            ("service_goals_and_report_titles", "Цели услуг и названия отчетов"),
+            _proposal_variable_table_choices("products"),
+        )
+        self.assertIn(
+            ("product_name", "Название продукта"),
+            _proposal_variable_column_choices("products", "service_goals_and_report_titles"),
+        )
+
+        variable = ProposalVariable(
+            key="{{product_name}}",
+            source_section="products",
+            source_table="service_goals_and_report_titles",
+            source_column="product_name",
+        )
+        self.assertEqual(
+            variable.binding_display,
+            "Значения столбца «Название продукта» из таблицы «Цели услуг и названия отчетов» раздела «Продукты»",
+        )
+
+    def test_proposal_region_headers_render_inline(self):
+        columns = {
+            column["source_column"]: column
+            for column in get_proposal_registry_ui_columns()
+        }
+
+        self.assertTrue(columns["registration_region"]["split_inline"])
+        self.assertEqual(columns["registration_region"]["label"], "Заказчик: регион")
+        self.assertTrue(columns["asset_owner_region"]["split_inline"])
+        self.assertEqual(columns["asset_owner_region"]["label"], "Владелец: регион")
 
     def test_proposal_variable_form_locks_computed_variable_fields(self):
         variable = ProposalVariable.objects.create(
@@ -2977,6 +3247,193 @@ class ProposalRegistrationFormTests(TestCase):
             [ProposalVariable(key="{{preliminary_payment_percentage_full}}", is_computed=True)],
         )
         self.assertEqual(replacements["{{preliminary_payment_percentage_full}}"], "70%")
+
+    def test_resolve_payment_schedule_for_single_product_has_no_header_or_indent(self):
+        product = Product.objects.create(
+            short_name="DD",
+            name_en="Due Diligence",
+            name_ru="ДД",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=1,
+        )
+        proposal = ProposalRegistration(
+            type=product,
+            advance_percent="40",
+            advance_term_days=10,
+            preliminary_report_percent="40",
+            preliminary_report_term_days=7,
+            final_report_percent="20",
+            final_report_term_days=15,
+        )
+
+        _, lists, _ = resolve_variables(
+            proposal,
+            [ProposalVariable(key="[[payment_schedule]]", is_computed=True)],
+        )
+        items = lists["[[payment_schedule]]"]
+        texts = [item["runs"][0]["text"] for item in items]
+
+        self.assertEqual(len(items), 3)
+        self.assertEqual(items[0]["left_indent_cm"], 1.0)
+        self.assertEqual(items[0]["paragraph_style"], "list_paragraph")
+        self.assertTrue(items[0]["contextual_spacing"])
+        self.assertEqual(
+            texts,
+            [
+                "40% — предоплата при подписании контракта — в течение 10 календарных дней.",
+                "40% — в течение 7 календарных дней после предоставления Предварительного отчёта "
+                "и подписания Акта № 1 на 80% суммы договора.",
+                "20% — после сдачи Итогового отчёта — в течение 15 календарных дней после подписания "
+                "Акта №\u00a02 на оставшуюся сумму.",
+            ],
+        )
+
+    def test_resolve_payment_schedule_for_common_multistage_schedule(self):
+        group_member = GroupMember.objects.create(
+            short_name="IMC Montan",
+            country_name="Россия",
+            country_code="643",
+            country_alpha2="RU",
+            position=1,
+        )
+        first_product = Product.objects.create(
+            short_name="A",
+            name_en="Alpha",
+            name_ru="Альфа",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=1,
+        )
+        second_product = Product.objects.create(
+            short_name="B",
+            name_en="Beta",
+            name_ru="Бета",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Оптимизация",
+            position=2,
+        )
+        proposal = ProposalRegistration.objects.create(
+            number=3333,
+            group_member=group_member,
+            type=second_product,
+            name="Общий график",
+            year=2026,
+            advance_percent="40",
+            advance_term_days=10,
+            preliminary_report_percent="40",
+            preliminary_report_term_days=7,
+            final_report_percent="20",
+            final_report_term_days=15,
+        )
+        ProposalRegistrationProduct.objects.bulk_create(
+            [
+                ProposalRegistrationProduct(proposal=proposal, product=first_product, rank=1),
+                ProposalRegistrationProduct(proposal=proposal, product=second_product, rank=2),
+            ]
+        )
+
+        _, lists, _ = resolve_variables(
+            proposal,
+            [ProposalVariable(key="[[payment_schedule]]", is_computed=True)],
+        )
+        items = lists["[[payment_schedule]]"]
+
+        self.assertEqual(items[0]["runs"][0]["text"], "общий для всех этапов:")
+        self.assertEqual(items[0]["left_indent_cm"], 1.0)
+        self.assertNotIn("paragraph_style", items[0])
+        self.assertEqual(items[1]["left_indent_cm"], 1.0)
+        self.assertEqual(items[1]["paragraph_style"], "list_paragraph")
+        self.assertTrue(items[1]["contextual_spacing"])
+        self.assertEqual(
+            items[1]["runs"][0]["text"],
+            "40% — предоплата при подписании контракта — в течение 10 календарных дней.",
+        )
+
+    def test_resolve_payment_schedule_for_per_stage_schedule_uses_stage_payloads(self):
+        group_member = GroupMember.objects.create(
+            short_name="IMC Montan",
+            country_name="Россия",
+            country_code="643",
+            country_alpha2="RU",
+            position=1,
+        )
+        first_product = Product.objects.create(
+            short_name="TDD",
+            name_en="Technical Due Diligence",
+            name_ru="ТДД",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=1,
+        )
+        second_product = Product.objects.create(
+            short_name="JORC",
+            name_en="JORC Report",
+            name_ru="JORC",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Оптимизация",
+            position=2,
+        )
+        ServiceGoalReport.objects.create(product=first_product, product_name="Технический аудит", position=1)
+        ServiceGoalReport.objects.create(product=second_product, product_name="Отчёт JORC", position=1)
+        proposal = ProposalRegistration.objects.create(
+            number=3333,
+            group_member=group_member,
+            type=second_product,
+            name="Поэтапный график",
+            year=2026,
+            stage_payloads_json=[
+                {
+                    "rank": 1,
+                    "product_id": first_product.pk,
+                    "payment_schedule_common": False,
+                    "advance_percent": "30",
+                    "advance_term_days": 5,
+                    "preliminary_report_percent": "20",
+                    "preliminary_report_term_days": 6,
+                    "final_report_percent": "50",
+                    "final_report_term_days": 14,
+                },
+                {
+                    "rank": 2,
+                    "product_id": second_product.pk,
+                    "payment_schedule_common": False,
+                    "advance_percent": "50",
+                    "advance_term_days": 10,
+                    "preliminary_report_percent": "30",
+                    "preliminary_report_term_days": 7,
+                    "final_report_percent": "20",
+                    "final_report_term_days": 21,
+                },
+            ],
+        )
+        ProposalRegistrationProduct.objects.bulk_create(
+            [
+                ProposalRegistrationProduct(proposal=proposal, product=first_product, rank=1),
+                ProposalRegistrationProduct(proposal=proposal, product=second_product, rank=2),
+            ]
+        )
+
+        _, lists, _ = resolve_variables(
+            proposal,
+            [ProposalVariable(key="[[payment_schedule]]", is_computed=True)],
+        )
+        texts = [item["runs"][0]["text"] for item in lists["[[payment_schedule]]"]]
+
+        self.assertEqual(texts[0], "Этап 1 — Технический аудит:")
+        self.assertEqual(texts[1], "30% — предоплата при подписании контракта — в течение 5 календарных дней.")
+        self.assertIn("на 50% суммы договора", texts[2])
+        self.assertEqual(texts[4], "Этап 2 — Отчёт JORC:")
+        self.assertEqual(texts[5], "50% — предоплата при подписании контракта — в течение 10 календарных дней.")
+        self.assertEqual(lists["[[payment_schedule]]"][1]["left_indent_cm"], 1.0)
+        self.assertEqual(lists["[[payment_schedule]]"][1]["paragraph_style"], "list_paragraph")
+        self.assertTrue(lists["[[payment_schedule]]"][1]["contextual_spacing"])
+        self.assertNotIn("left_indent_cm", lists["[[payment_schedule]]"][4])
 
     def test_resolve_preliminary_report_term_month_uses_month_declension(self):
         cases = [
@@ -4662,6 +5119,9 @@ class ProposalFormContextTests(TestCase):
         self.assertContains(response, 'id="proposal-service-stages-container"', html=False)
         self.assertContains(response, 'id="proposal-commercial-stages-container"', html=False)
         self.assertContains(response, 'id="proposal-stage-terms-tbody"', html=False)
+        self.assertContains(response, "График оплаты", html=False)
+        self.assertContains(response, "Общий для всех этапов", html=False)
+        self.assertContains(response, 'name="payment_schedule_common"', html=False)
         self.assertContains(response, "Состав услуг / техническое задание", html=False)
         self.assertContains(response, "Коммерческое предложение", html=False)
         self.assertNotContains(response, "Состав услуг / техническое задание: Этап 1", html=False)

--- a/proposals_app/variable_resolver.py
+++ b/proposals_app/variable_resolver.py
@@ -219,6 +219,32 @@ def _proposal_service_goal_genitive(proposal) -> str:
     return item.service_goal_genitive or ""
 
 
+def _service_goal_report_value(product_id, field_name: str) -> str:
+    if not product_id:
+        return ""
+    item = (
+        ServiceGoalReport.objects.filter(product_id=product_id)
+        .order_by("position", "id")
+        .only(field_name)
+        .first()
+    )
+    if not item:
+        return ""
+    return str(getattr(item, field_name, "") or "")
+
+
+def _proposal_service_goal(proposal) -> str:
+    return _service_goal_report_value(getattr(proposal, "type_id", None), "service_goal")
+
+
+def _proposal_report_title(proposal) -> str:
+    return _service_goal_report_value(getattr(proposal, "type_id", None), "report_title")
+
+
+def _proposal_product_name(proposal) -> str:
+    return _service_goal_report_value(getattr(proposal, "type_id", None), "product_name")
+
+
 def _proposal_tkp_preliminary(proposal) -> str:
     try:
         from proposals_app.models import ProposalRegistration
@@ -659,6 +685,134 @@ def _proposal_final_report_term_days(proposal) -> str:
     return str(proposal.final_report_term_days or "")
 
 
+def _payment_schedule_decimal(value) -> Decimal:
+    try:
+        return Decimal(str(value if value not in (None, "") else "0"))
+    except (InvalidOperation, TypeError, ValueError):
+        return Decimal("0")
+
+
+def _payment_schedule_days(value) -> str:
+    return "" if value in (None, "") else str(value)
+
+
+def _payment_schedule_product_name(product) -> str:
+    product_id = getattr(product, "pk", None)
+    name = _service_goal_report_value(product_id, "product_name")
+    if name:
+        return name
+    return (
+        str(getattr(product, "name_ru", "") or "").strip()
+        or str(getattr(product, "short_name", "") or "").strip()
+        or str(product or "").strip()
+    )
+
+
+def _payment_schedule_values(source) -> dict[str, str]:
+    advance_percent = source.get("advance_percent") if isinstance(source, dict) else getattr(source, "advance_percent", None)
+    advance_term_days = source.get("advance_term_days") if isinstance(source, dict) else getattr(source, "advance_term_days", None)
+    preliminary_percent = (
+        source.get("preliminary_report_percent")
+        if isinstance(source, dict)
+        else getattr(source, "preliminary_report_percent", None)
+    )
+    preliminary_term_days = (
+        source.get("preliminary_report_term_days")
+        if isinstance(source, dict)
+        else getattr(source, "preliminary_report_term_days", None)
+    )
+    final_percent = source.get("final_report_percent") if isinstance(source, dict) else getattr(source, "final_report_percent", None)
+    final_term_days = source.get("final_report_term_days") if isinstance(source, dict) else getattr(source, "final_report_term_days", None)
+    return {
+        "prepayment_payment_percentage": _format_percent(advance_percent, strip_trailing_zeros=True),
+        "prepayment_payment_days": _payment_schedule_days(advance_term_days),
+        "preliminary_payment_percentage": _format_percent(preliminary_percent, strip_trailing_zeros=True),
+        "preliminary_payment_days": _payment_schedule_days(preliminary_term_days),
+        "preliminary_payment_percentage_full": _format_percent(
+            _payment_schedule_decimal(advance_percent) + _payment_schedule_decimal(preliminary_percent),
+            strip_trailing_zeros=True,
+        ),
+        "final_payment_percentage": _format_percent(final_percent, strip_trailing_zeros=True),
+        "final_payment_days": _payment_schedule_days(final_term_days),
+    }
+
+
+def _payment_schedule_payment_paragraphs(source) -> list[dict[str, object]]:
+    values = _payment_schedule_values(source)
+    paragraph_format = {
+        "paragraph_style": "list_paragraph",
+        "left_indent_cm": 1.0,
+        "contextual_spacing": True,
+    }
+    return [
+        {
+            "runs": [
+                {
+                    "text": (
+                        f"{values['prepayment_payment_percentage']} — предоплата при подписании контракта — "
+                        f"в течение {values['prepayment_payment_days']} календарных дней."
+                    )
+                }
+            ],
+            **paragraph_format,
+        },
+        {
+            "runs": [
+                {
+                    "text": (
+                        f"{values['preliminary_payment_percentage']} — в течение "
+                        f"{values['preliminary_payment_days']} календарных дней после предоставления "
+                        "Предварительного отчёта и подписания Акта № 1 на "
+                        f"{values['preliminary_payment_percentage_full']} суммы договора."
+                    )
+                }
+            ],
+            **paragraph_format,
+        },
+        {
+            "runs": [
+                {
+                    "text": (
+                        f"{values['final_payment_percentage']} — после сдачи Итогового отчёта — "
+                        f"в течение {values['final_payment_days']} календарных дней после подписания "
+                        "Акта №\u00a02 на оставшуюся сумму."
+                    )
+                }
+            ],
+            **paragraph_format,
+        },
+    ]
+
+
+def _proposal_payment_schedule(proposal) -> list[dict[str, object]]:
+    products = list(proposal.ordered_products()) if getattr(proposal, "pk", None) else []
+    if not products and getattr(proposal, "type_id", None):
+        products = [proposal.type]
+    stage_payloads = [item for item in (getattr(proposal, "stage_payloads_json", None) or []) if isinstance(item, dict)]
+    is_common = not any(payload.get("payment_schedule_common") is False for payload in stage_payloads)
+    if len(products) <= 1:
+        source = stage_payloads[0] if stage_payloads and not is_common else proposal
+        return _payment_schedule_payment_paragraphs(source)
+
+    result: list[dict[str, object]] = []
+    if is_common:
+        result.append({"runs": [{"text": "общий для всех этапов:"}], "left_indent_cm": 1.0})
+        result.extend(_payment_schedule_payment_paragraphs(proposal))
+        return result
+
+    payload_by_product_id = {
+        str(payload.get("product_id") or ""): payload
+        for payload in stage_payloads
+        if str(payload.get("product_id") or "").strip()
+    }
+    for index, product in enumerate(products, start=1):
+        product_id = str(getattr(product, "pk", "") or "")
+        source = payload_by_product_id.get(product_id) or (stage_payloads[index - 1] if index - 1 < len(stage_payloads) else {})
+        result.append({"runs": [{"text": f"Этап {index} — {_payment_schedule_product_name(product)}:"}]})
+        result.extend(_payment_schedule_payment_paragraphs(source))
+    return result
+
+
 def _computed_year(_proposal) -> str:
     return str(_today().year)
 
@@ -712,6 +866,10 @@ FIELD_MAP = {
     ("proposals", "registry", "preliminary_report_term"): _proposal_preliminary_report_term_days,
     ("proposals", "registry", "final_report_percent"): _proposal_final_report_percent,
     ("proposals", "registry", "final_report_term"): _proposal_final_report_term_days,
+    ("products", "service_goals_and_report_titles", "service_goal"): _proposal_service_goal,
+    ("products", "service_goals_and_report_titles", "service_goal_genitive"): _proposal_service_goal_genitive,
+    ("products", "service_goals_and_report_titles", "report_title"): _proposal_report_title,
+    ("products", "service_goals_and_report_titles", "product_name"): _proposal_product_name,
 }
 
 
@@ -733,6 +891,7 @@ COMPUTED_MAP = {
 COMPUTED_LIST_MAP = {
     "[[actives_name]]": _proposal_actives_name_list,
     "[[scope_of_work]]": _proposal_scope_of_work,
+    "[[payment_schedule]]": _proposal_payment_schedule,
 }
 
 COMPUTED_TABLE_MAP = {

--- a/proposals_app/views.py
+++ b/proposals_app/views.py
@@ -1016,16 +1016,31 @@ def _proposals_context(request=None, user=None, *, debug_nextcloud_links=False):
         "currency",
     ).prefetch_related("product_links__product").all()
     _attach_proposal_folder_urls(proposals, user=user, request=request, debug_nextcloud_links=debug_nextcloud_links)
-    proposal_templates = list(ProposalTemplate.objects.select_related("group_member", "product").all())
+    proposal_templates = list(
+        ProposalTemplate.objects
+        .select_related("group_member", "product")
+        .prefetch_related("group_members", "products")
+        .all()
+    )
     proposal_variables = ProposalVariable.objects.all()
     order_map = _proposal_group_member_order_map()
     for template in proposal_templates:
-        if template.group_member_id:
-            template.group_display = _proposal_group_member_short(
-                template.group_member, order_map.get(template.group_member_id, 0)
-            )
-        else:
-            template.group_display = ""
+        groups = list(template.group_members.all())
+        if not groups and template.group_member_id:
+            groups = [template.group_member]
+        template.group_display = (
+            ", ".join(_proposal_group_member_short(group, order_map.get(group.pk, 0)) for group in groups)
+            if groups
+            else "Все"
+        )
+        products = list(template.products.all())
+        if not products and template.product_id:
+            products = [template.product]
+        template.products_display = (
+            ", ".join(product.short_name or str(product) for product in products)
+            if products
+            else "Все"
+        )
     has_active_smtp_connection = False
     if user:
         has_active_smtp_connection = ExternalSMTPAccount.objects.filter(
@@ -1557,15 +1572,43 @@ def _parse_proposal_sent_at(raw_value: str):
     return value.replace(second=0, microsecond=0)
 
 
+def _proposal_template_group_ids(template):
+    groups = list(template.group_members.all())
+    if groups:
+        return {group.pk for group in groups}
+    if template.group_member_id:
+        return {template.group_member_id}
+    return set()
+
+
+def _proposal_template_product_ids(template):
+    products = list(template.products.all())
+    if products:
+        return {product.pk for product in products}
+    if template.product_id:
+        return {template.product_id}
+    return set()
+
+
+def _proposal_selected_product_ids(proposal):
+    products = list(proposal.ordered_products()) if getattr(proposal, "pk", None) else []
+    if not products and getattr(proposal, "type_id", None):
+        return {proposal.type_id}
+    return {product.pk for product in products if getattr(product, "pk", None)}
+
+
 def _find_proposal_template(proposal, templates):
-    if not proposal.type_id:
+    proposal_product_ids = _proposal_selected_product_ids(proposal)
+    if not proposal_product_ids:
         return None
 
     candidates = []
     for template in templates:
-        if template.product_id != proposal.type_id:
+        template_product_ids = _proposal_template_product_ids(template)
+        if template_product_ids and not proposal_product_ids.issubset(template_product_ids):
             continue
-        if template.group_member_id and template.group_member_id != proposal.group_member_id:
+        template_group_ids = _proposal_template_group_ids(template)
+        if template_group_ids and proposal.group_member_id not in template_group_ids:
             continue
         candidates.append(template)
 
@@ -1580,7 +1623,10 @@ def _find_proposal_template(proposal, templates):
 
     candidates.sort(
         key=lambda template: (
-            1 if template.group_member_id == proposal.group_member_id else 0,
+            1 if _proposal_template_group_ids(template) else 0,
+            1 if _proposal_template_product_ids(template) else 0,
+            -len(_proposal_template_group_ids(template)),
+            -len(_proposal_template_product_ids(template)),
             _version_key(template),
             template.pk,
         ),
@@ -2149,6 +2195,7 @@ def proposal_dispatch_create_documents(request):
         ProposalRegistration.objects
         .filter(pk__in=proposal_ids)
         .select_related("group_member", "type", "country", "currency")
+        .prefetch_related("product_links__product")
         .order_by("position", "id")
     )
     if len(proposals) != len(proposal_ids):
@@ -2157,6 +2204,7 @@ def proposal_dispatch_create_documents(request):
     templates = list(
         ProposalTemplate.objects
         .select_related("group_member", "product")
+        .prefetch_related("group_members", "products")
         .filter(file__gt="")
     )
     variables = list(

--- a/staticfiles/core/js/proposals-panels.js
+++ b/staticfiles/core/js/proposals-panels.js
@@ -112,10 +112,10 @@
     }
 
     const rootHrefAttrs = rootUrl
-      ? ' href="#proposals" data-bs-toggle="tab" hx-get="' + rootUrl + '" hx-target="#proposals-pane" hx-swap="outerHTML"'
+      ? ' href="#proposals" hx-get="' + rootUrl + '" hx-target="#proposals-pane" hx-swap="outerHTML"'
       : '';
     const currentHrefAttrs = currentUrl
-      ? ' href="#proposals" data-bs-toggle="tab" hx-get="' + currentUrl + '" hx-target="#proposals-pane" hx-swap="outerHTML"'
+      ? ' href="#proposals" hx-get="' + currentUrl + '" hx-target="#proposals-pane" hx-swap="outerHTML"'
       : '';
 
     heading.innerHTML = ''
@@ -5149,14 +5149,74 @@
       return Number.isFinite(value) ? value : 0;
     }
 
-    function syncFinalReportPercent() {
-      const advanceInput = form.querySelector('[name="advance_percent"]');
-      const preliminaryInput = form.querySelector('[name="preliminary_report_percent"]');
-      const finalInput = form.querySelector('[name="final_report_percent"]');
+    function syncFinalReportPercent(group) {
+      const scope = group || form;
+      const advanceInput = scope.querySelector('[name="advance_percent"]');
+      const preliminaryInput = scope.querySelector('[name="preliminary_report_percent"]');
+      const finalInput = scope.querySelector('[name="final_report_percent"]');
       if (!advanceInput || !preliminaryInput || !finalInput) return;
 
       const result = 100 - parsePercentValue(advanceInput) - parsePercentValue(preliminaryInput);
       finalInput.value = result.toFixed(2).replace(/\.00$/, '').replace(/(\.\d)0$/, '$1');
+    }
+
+    function syncAllFinalReportPercents() {
+      const groups = qa('.js-proposal-payment-group', form);
+      if (groups.length) {
+        groups.forEach(syncFinalReportPercent);
+        return;
+      }
+      syncFinalReportPercent(form);
+    }
+
+    function copyPaymentDefaultsFromFirstStage() {
+      const stageBlocks = qa('.proposal-payment-stage-block', form);
+      const firstBlock = stageBlocks[0];
+      if (!firstBlock) return;
+      const fieldNames = [
+        'advance_percent',
+        'advance_term_days',
+        'preliminary_report_percent',
+        'preliminary_report_term_days',
+        'final_report_percent',
+        'final_report_term_days',
+      ];
+      stageBlocks.slice(1).forEach(function (block) {
+        fieldNames.forEach(function (fieldName) {
+          const target = block.querySelector('[name="' + fieldName + '"]');
+          const source = firstBlock.querySelector('[name="' + fieldName + '"]');
+          if (!target || !source || String(target.value || '').trim()) return;
+          target.value = source.value || '';
+        });
+      });
+    }
+
+    function syncPaymentScheduleMode() {
+      const toggle = form.querySelector('input[type="checkbox"][name="payment_schedule_common"]');
+      const commonFields = form.querySelector('.js-proposal-payment-common-fields');
+      const stageFields = form.querySelector('.js-proposal-payment-stage-fields');
+      const isCommon = !toggle || toggle.checked;
+      commonFields?.classList.toggle('d-none', !isCommon);
+      stageFields?.classList.toggle('d-none', isCommon);
+      if (commonFields) {
+        commonFields.querySelectorAll('input, select, textarea').forEach(function (input) {
+          if (input.name === 'final_report_percent') return;
+          input.disabled = !isCommon;
+        });
+      }
+      if (stageFields) {
+        stageFields.querySelectorAll('input, select, textarea').forEach(function (input) {
+          if (input.name === 'final_report_percent') {
+            input.disabled = true;
+            return;
+          }
+          input.disabled = isCommon;
+        });
+      }
+      if (!isCommon) {
+        copyPaymentDefaultsFromFirstStage();
+      }
+      syncAllFinalReportPercents();
     }
 
     function syncAssetOwnerFromCustomer(reason) {
@@ -5621,8 +5681,12 @@
     attachProposalCommercialTable(form, assetsApi);
     attachProposalAssetsToLegalEntitiesSync(form, assetsApi, legalEntitiesApi);
     attachProposalLegalEntitiesToObjectsSync(form, legalEntitiesApi, objectsApi);
-    form.querySelector('[name="advance_percent"]')?.addEventListener('input', syncFinalReportPercent);
-    form.querySelector('[name="preliminary_report_percent"]')?.addEventListener('input', syncFinalReportPercent);
+    form.addEventListener('input', function (event) {
+      if (!['advance_percent', 'preliminary_report_percent'].includes(event.target?.name)) return;
+      syncFinalReportPercent(event.target.closest('.js-proposal-payment-group') || form);
+    });
+    form.querySelector('input[type="checkbox"][name="payment_schedule_common"]')?.addEventListener('change', syncPaymentScheduleMode);
+    syncPaymentScheduleMode();
     qa('.js-proposal-report-terms-lock', form).forEach(function (icon) {
       icon.addEventListener('click', function () {
         proposalReportTermsEditMode = !proposalReportTermsEditMode;


### PR DESCRIPTION
## Summary
- Added computed `[[payment_schedule]]` variable for TKP DOCX generation with single-product, common multi-stage, and per-stage payment schedules.
- Added access to product service goal/report title variables and multi-select group/product matching for TKP templates.
- Updated DOCX rich paragraph formatting for indented payment text without bullets and preserved local regression coverage.
## Test plan
- `python3 manage.py test proposals_app.tests.ProposalRegistrationFormTests proposals_app.tests.ProposalDocumentGenerationTests`