### PR TITLE
Add CSV download for typical sections

### DIFF
--- a/policy_app/templates/policy_app/policy_partial.html
+++ b/policy_app/templates/policy_app/policy_partial.html
@@ -488,6 +488,13 @@
               </button>
             </div>
           </div>
+          <a href="{% url 'section_csv_download' %}"
+             id="sections-csv-download-btn"
+             class="btn btn-primary btn-sm d-flex align-items-center"
+             title="Скачать CSV"
+             role="button">
+            <i class="bi bi-cloud-arrow-down me-2"></i>Скачать CSV
+          </a>
           <button type="button" id="sections-csv-upload-btn"
                   class="btn btn-primary btn-sm d-flex align-items-center">
             <i class="bi bi-cloud-arrow-up me-2"></i>Загрузить CSV

--- a/policy_app/tests.py
+++ b/policy_app/tests.py
@@ -1,3 +1,5 @@
+import csv
+import io
 import json
 from decimal import Decimal
 
@@ -24,6 +26,7 @@ from policy_app.models import (
     SpecialtyTariff,
     Tariff,
     TypicalSection,
+    TypicalSectionSpecialty,
     TypicalServiceComposition,
     TypicalServiceTerm,
 )
@@ -354,6 +357,7 @@ class TypicalSectionViewsTests(TestCase):
         self.assertContains(response, "Типовые разделы (услуги)")
         self.assertContains(response, '<th><i class="bi bi-ban me-1"></i>ТКП</th>', html=False)
         self.assertContains(response, 'aria-label="Исключить из автозаполнения в ТКП"', html=False)
+        self.assertContains(response, 'id="sections-csv-download-btn"', html=False)
 
     def test_create_section_saves_tkp_exclusion_flag(self):
         response = self.client.post(
@@ -399,6 +403,145 @@ class TypicalSectionViewsTests(TestCase):
         self.assertEqual(response.json()["created"], 1)
         self.assertEqual(response.json()["warnings"], [])
         self.assertTrue(TypicalSection.objects.filter(code="SEC-3").exists())
+
+    def test_section_csv_download_exports_current_table_columns(self):
+        owner = GroupMember.objects.create(
+            short_name="IMC",
+            country_name="Россия",
+            country_code="643",
+            country_alpha2="RU",
+            position=1,
+        )
+        department = OrgUnit.objects.create(
+            company=owner,
+            level=1,
+            department_name="Налоговый департамент",
+            short_name="TAX-DEPT",
+            unit_type="expertise",
+            position=1,
+        )
+        expertise = ExpertiseDirection.objects.create(
+            name="Налоги",
+            short_name="TAX",
+            position=1,
+        )
+        specialty = ExpertSpecialty.objects.create(
+            expertise_direction=department,
+            expertise_dir=expertise,
+            specialty="Налоговый due diligence",
+            position=1,
+        )
+        section = TypicalSection.objects.create(
+            product=self.product,
+            code="SEC-4",
+            short_name="tax-dd",
+            short_name_ru="нал-dd",
+            name_en="Tax DD",
+            name_ru="Налоговый ДД",
+            accounting_type="Услуги",
+            expertise_dir=expertise,
+            expertise_direction=department,
+            exclude_from_tkp_autofill=True,
+            position=1,
+        )
+        TypicalSectionSpecialty.objects.create(section=section, specialty=specialty, rank=1)
+
+        response = self.client.get(reverse("section_csv_download"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("typical_sections.csv", response["Content-Disposition"])
+        rows = list(csv.reader(io.StringIO(response.content.decode("utf-8-sig")), delimiter=";"))
+        self.assertEqual(
+            rows[0],
+            [
+                "Продукт",
+                "Код",
+                "Краткое имя EN",
+                "Краткое имя RU",
+                "Наименование раздела (услуги) EN",
+                "Наименование раздела (услуги) RU",
+                "Тип учета",
+                "Исполнитель",
+                "Экспертиза",
+                "Подразделение",
+                "ТКП",
+            ],
+        )
+        self.assertEqual(
+            rows[1],
+            [
+                "SEC",
+                "SEC-4",
+                "tax-dd",
+                "нал-dd",
+                "Tax DD",
+                "Налоговый ДД",
+                "Услуги",
+                "Налоговый due diligence",
+                "TAX",
+                "Налоговый департамент",
+                "Да",
+            ],
+        )
+
+    def test_section_csv_upload_accepts_current_table_export_columns(self):
+        owner = GroupMember.objects.create(
+            short_name="IMC",
+            country_name="Россия",
+            country_code="643",
+            country_alpha2="RU",
+            position=1,
+        )
+        department = OrgUnit.objects.create(
+            company=owner,
+            level=1,
+            department_name="Налоговый департамент",
+            short_name="TAX-DEPT",
+            unit_type="expertise",
+            position=1,
+        )
+        expertise = ExpertiseDirection.objects.create(
+            name="Налоги",
+            short_name="TAX",
+            position=1,
+        )
+        first_specialty = ExpertSpecialty.objects.create(
+            expertise_direction=department,
+            expertise_dir=expertise,
+            specialty="Налоговый due diligence",
+            position=1,
+        )
+        second_specialty = ExpertSpecialty.objects.create(
+            expertise_direction=department,
+            expertise_dir=expertise,
+            specialty="Трансфертное ценообразование",
+            position=2,
+        )
+        csv_file = SimpleUploadedFile(
+            "sections.csv",
+            (
+                "Продукт;Код;Краткое имя EN;Краткое имя RU;"
+                "Наименование раздела (услуги) EN;Наименование раздела (услуги) RU;"
+                "Тип учета;Исполнитель;Экспертиза;Подразделение;ТКП\n"
+                "SEC;SEC-5;tax-dd;нал-dd;Tax DD;Налоговый ДД;Услуги;"
+                "Налоговый due diligence, Трансфертное ценообразование;TAX;Налоговый департамент;Да\n"
+            ).encode("utf-8"),
+            content_type="text/csv",
+        )
+
+        response = self.client.post(reverse("section_csv_upload"), {"csv_file": csv_file})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["created"], 1)
+        self.assertEqual(response.json()["warnings"], [])
+        section = TypicalSection.objects.get(code="SEC-5")
+        self.assertEqual(section.expertise_dir, expertise)
+        self.assertEqual(section.expertise_direction, department)
+        self.assertTrue(section.exclude_from_tkp_autofill)
+        self.assertEqual(
+            list(section.ranked_specialties.values_list("specialty", flat=True)),
+            [first_specialty.pk, second_specialty.pk],
+        )
 
 
 class SectionStructureViewsTests(TestCase):

--- a/policy_app/urls.py
+++ b/policy_app/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     path("sections/<int:pk>/move-up/", views.section_move_up, name="section_move_up"),
     path("sections/<int:pk>/move-down/", views.section_move_down, name="section_move_down"),
     path("policy/section/csv-upload/", views.section_csv_upload, name="section_csv_upload"),
+    path("policy/section/csv-download/", views.section_csv_download, name="section_csv_download"),
     path("policy/structure/create/", views.structure_form_create, name="structure_form_create"),
     path("policy/structure/<int:pk>/edit/", views.structure_form_edit, name="structure_form_edit"),
     path("policy/structure/<int:pk>/delete/", views.structure_delete, name="structure_delete"),

--- a/policy_app/views.py
+++ b/policy_app/views.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.db.models import IntegerField, Max, Q, Value
 from django.db.models.functions import Coalesce
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render, redirect, get_object_or_404
 from django.views.decorators.http import require_http_methods, require_POST
 
@@ -60,6 +60,19 @@ SPECIALTY_TARIFF_FORM_TEMPLATE = "policy_app/specialty_tariff_form.html"
 TARIFF_FORM_TEMPLATE = "policy_app/tariff_form.html"
 HX_TRIGGER_HEADER = "HX-Trigger"
 HX_POLICY_UPDATED_EVENT = "policy-updated"
+SECTION_CSV_HEADERS = [
+    "Продукт",
+    "Код",
+    "Краткое имя EN",
+    "Краткое имя RU",
+    "Наименование раздела (услуги) EN",
+    "Наименование раздела (услуги) RU",
+    "Тип учета",
+    "Исполнитель",
+    "Экспертиза",
+    "Подразделение",
+    "ТКП",
+]
 
 
 def _render_form_with_errors(request, template, context):
@@ -117,6 +130,41 @@ def _get_specialty_tariffs_for_user(user):
 
 def staff_required(user):
     return user.is_authenticated and user.is_staff
+
+
+def _csv_lookup_key(value):
+    return str(value or "").strip().lower()
+
+
+def _split_csv_list_value(value, lookup=None):
+    raw = str(value or "").strip()
+    if not raw or raw in {"—", "-"}:
+        return []
+    lookup = lookup or {}
+    if _csv_lookup_key(raw) in lookup:
+        return [raw]
+
+    values = []
+    for line in raw.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
+        parts = [line]
+        for separator in (",", ";", "|"):
+            parts = [
+                chunk
+                for part in parts
+                for chunk in (
+                    [part] if _csv_lookup_key(part) in lookup else part.split(separator)
+                )
+            ]
+        values.extend(
+            item.strip()
+            for item in parts
+            if item.strip() and item.strip() not in {"—", "-"}
+        )
+    return values
+
+
+def _csv_truthy(value):
+    return _csv_lookup_key(value) in {"1", "true", "yes", "y", "да", "д", "on", "checked", "истина", "+", "x", "✓"}
 
 # Вспомогательные функции для устранения дублирования
 def _policy_context(request):
@@ -711,10 +759,22 @@ def section_csv_upload(request):
     if len(rows) < 2:
         return JsonResponse({"ok": False, "error": "Файл должен содержать заголовок и хотя бы одну строку данных."}, status=400)
 
-    products_by_name = {p.short_name.strip().lower(): p for p in Product.objects.all()}
+    products_by_name = {_csv_lookup_key(p.short_name): p for p in Product.objects.all()}
+    expertise_dirs = {}
+    for direction in ExpertiseDirection.objects.all():
+        for label in (direction.short_name, direction.name):
+            key = _csv_lookup_key(label)
+            if key:
+                expertise_dirs[key] = direction
     expertise_units = {
-        u.department_name.strip().lower(): u
+        key: u
         for u in OrgUnit.objects.filter(Q(unit_type="expertise") | Q(unit_type="administrative", level=1))
+        for key in {_csv_lookup_key(u.department_name), _csv_lookup_key(u.short_name)}
+        if key
+    }
+    specialties_by_name = {
+        _csv_lookup_key(s.specialty): s
+        for s in ExpertSpecialty.objects.exclude(specialty="").all()
     }
     data_rows = rows[1:]
     created = 0
@@ -734,12 +794,21 @@ def section_csv_upload(request):
         name_en = row[4].strip() if len(row) > 4 else ""
         name_ru = row[5].strip() if len(row) > 5 else ""
         accounting_type = row[6].strip() if len(row) > 6 else "Раздел"
-        if len(row) > 8:
+        executor_raw = ""
+        expertise_dir_name = ""
+        tkp_raw = ""
+        if len(row) >= len(SECTION_CSV_HEADERS):
+            executor_raw = row[7].strip()
+            expertise_dir_name = row[8].strip()
+            expertise_name = row[9].strip()
+            tkp_raw = row[10].strip()
+        elif len(row) > 8:
+            executor_raw = row[7].strip()
             expertise_name = row[8].strip()
         else:
             expertise_name = row[7].strip() if len(row) > 7 else ""
 
-        product = products_by_name.get(product_name.lower())
+        product = products_by_name.get(_csv_lookup_key(product_name))
         if not product:
             warnings.append(f"Строка {i}: продукт «{product_name}» не найден. Доступные: {', '.join(products_by_name.keys())}.")
             continue
@@ -763,15 +832,21 @@ def section_csv_upload(request):
             warnings.append(f"Строка {i}: неизвестный тип учета «{accounting_type}». Допустимые: {', '.join(dict(TypicalSection.ACCOUNTING_TYPE_CHOICES).keys())}. Установлено «Раздел».")
             accounting_type = "Раздел"
 
+        expertise_dir = None
+        if expertise_dir_name:
+            expertise_dir = expertise_dirs.get(_csv_lookup_key(expertise_dir_name))
+            if not expertise_dir:
+                warnings.append(f"Строка {i}: экспертиза «{expertise_dir_name}» не найдена. Поле оставлено пустым.")
+
         expertise_direction = None
         if expertise_name:
-            expertise_direction = expertise_units.get(expertise_name.lower())
+            expertise_direction = expertise_units.get(_csv_lookup_key(expertise_name))
             if not expertise_direction:
-                warnings.append(f"Строка {i}: направление экспертизы «{expertise_name}» не найдено. Поле оставлено пустым.")
+                warnings.append(f"Строка {i}: подразделение «{expertise_name}» не найдено. Поле оставлено пустым.")
 
         position = _next_position(TypicalSection, {"product": product})
         try:
-            TypicalSection.objects.create(
+            section = TypicalSection.objects.create(
                 product=product,
                 code=code,
                 short_name=short_name,
@@ -779,14 +854,66 @@ def section_csv_upload(request):
                 name_en=name_en,
                 name_ru=name_ru,
                 accounting_type=accounting_type,
+                expertise_dir=expertise_dir,
                 expertise_direction=expertise_direction,
+                exclude_from_tkp_autofill=_csv_truthy(tkp_raw),
                 position=position,
             )
+            missing_specialties = []
+            for rank, specialty_name in enumerate(_split_csv_list_value(executor_raw, specialties_by_name), start=1):
+                specialty = specialties_by_name.get(_csv_lookup_key(specialty_name))
+                if not specialty:
+                    missing_specialties.append(specialty_name)
+                    continue
+                TypicalSectionSpecialty.objects.create(section=section, specialty=specialty, rank=rank)
+            if missing_specialties:
+                warnings.append(f"Строка {i}: исполнители не найдены: {', '.join(missing_specialties)}.")
             created += 1
         except Exception as exc:
             warnings.append(f"Строка {i}: ошибка сохранения — {exc}")
 
     return JsonResponse({"ok": True, "created": created, "warnings": warnings})
+
+
+@login_required
+@user_passes_test(staff_required)
+@require_http_methods(["GET"])
+def section_csv_download(request):
+    output = io.StringIO()
+    output.write("\ufeff")
+    writer = csv.writer(output, delimiter=";", lineterminator="\n")
+    writer.writerow(SECTION_CSV_HEADERS)
+
+    sections = (
+        TypicalSection.objects.select_related("product", "expertise_dir", "expertise_direction")
+        .prefetch_related("ranked_specialties", "ranked_specialties__specialty")
+        .all()
+    )
+    for section in sections:
+        executor = "\n".join(
+            rs.specialty.specialty
+            for rs in section.ranked_specialties.all()
+            if rs.specialty and rs.specialty.specialty
+        )
+        writer.writerow(
+            [
+                section.product.short_name,
+                section.code,
+                section.short_name,
+                section.short_name_ru,
+                section.name_en,
+                section.name_ru,
+                section.accounting_type,
+                executor,
+                section.expertise_dir.short_name if section.expertise_dir else "",
+                section.expertise_direction.department_name if section.expertise_direction else "",
+                "Да" if section.exclude_from_tkp_autofill else "Нет",
+            ]
+        )
+
+    response = HttpResponse(output.getvalue(), content_type="text/csv; charset=utf-8")
+    response["Content-Disposition"] = 'attachment; filename="typical_sections.csv"'
+    return response
 
 
 # --- Типовая структура раздела ---

--- a/proposals_app/forms.py
+++ b/proposals_app/forms.py
@@ -3125,6 +3125,17 @@ class ProposalTemplateForm(forms.ModelForm):
         self.group_short_name_map = {str(m.pk): (m.short_name or "").strip() for m in members_qs}
         self.product_short_name_map = {str(p.pk): (p.short_name or "").strip() for p in products_qs}
 
+        original_group_ids = (
+            self._template_scope_ids(self.instance, "group_members", self.instance.group_member_id)
+            if self.instance and self.instance.pk
+            else []
+        )
+        original_product_ids = (
+            self._template_scope_ids(self.instance, "products", self.instance.product_id)
+            if self.instance and self.instance.pk
+            else []
+        )
+
         selected_group_ids, self.is_all_groups_selected = self._selected_ids(
             "group_member_ids",
             self.instance.group_members.all() if self.instance and self.instance.pk else [],
@@ -3169,7 +3180,10 @@ class ProposalTemplateForm(forms.ModelForm):
         self.version_map = version_map
 
         self.current_base = ""
-        self.current_scope_key = self._scope_key(selected_group_ids, selected_product_ids)
+        self.current_scope_key = self._scope_key(
+            original_group_ids if self.instance and self.instance.pk else selected_group_ids,
+            original_product_ids if self.instance and self.instance.pk else selected_product_ids,
+        )
         self.current_version = ""
         if self.instance and self.instance.pk:
             self.current_base = self.instance.sample_name or ""

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -526,6 +526,43 @@ class ProposalDocumentGenerationTests(TestCase):
         template = form.save()
         self.assertEqual(template.version, "3")
 
+    def test_proposal_template_edit_allocates_next_version_when_scope_changes(self):
+        second_group = GroupMember.objects.create(
+            short_name="KAP",
+            country_name="Казахстан",
+            country_code="398",
+            country_alpha2="KZ",
+            position=2,
+        )
+        target_template = ProposalTemplate.objects.create(
+            group_member=second_group,
+            product=self.product,
+            sample_name="KZ Шаблон ТКП_KAP_DD",
+            version="4",
+            file="proposal_templates/target.docx",
+        )
+        target_template.group_members.set([second_group])
+        target_template.products.set([self.product])
+        self.template.version = "2"
+        self.template.file = "proposal_templates/original.docx"
+        self.template.save(update_fields=["version", "file"])
+
+        form = ProposalTemplateForm(
+            data={
+                "group_member_ids": [str(second_group.pk)],
+                "product_ids": [str(self.product.pk)],
+                "sample_name": self.template.sample_name,
+                "version": self.template.version,
+            },
+            instance=self.template,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        template = form.save()
+
+        self.assertEqual(template.version, "5")
+        self.assertEqual(set(template.group_members.values_list("pk", flat=True)), {second_group.pk})
+
     @patch("ai_app.proposals_app.document_generation._get_cloud_upload_user")
     @patch("ai_app.proposals_app.document_generation.cloud_upload_file", return_value=True)
     def test_create_documents_generates_docx_and_uploads_it_to_workspace_folder(


### PR DESCRIPTION
## Summary
- Added CSV download for the “Типовые разделы (услуги)” table in Products.
- Updated section CSV import to support the current table structure, including expertise, department, TKP flag, and multiple specialties in one “Исполнитель” cell.
- Added/updated tests for CSV upload/download behavior and related form changes.
## Test plan
- python3 manage.py test policy_app.tests.TypicalSectionViewsTests
- python3 manage.py test policy_app