### PR TITLE
Restructure cloud storage folders

### DIFF
--- a/core/cloud_paths.py
+++ b/core/cloud_paths.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+
+PROPOSALS_SECTION_FOLDER = "01 ТКП"
+PROJECTS_SECTION_FOLDER = "02 Проекты"
+LEGACY_PROPOSALS_SECTION_FOLDER = "ТКП"
+
+
+def normalize_cloud_path(path: str) -> str:
+    raw = str(path or "").strip().replace("\\", "/")
+    parts = [part.strip() for part in raw.split("/") if part.strip()]
+    if not parts:
+        return "/"
+    return "/" + "/".join(parts)
+
+
+def join_cloud_path(base: str, *children: str) -> str:
+    current = normalize_cloud_path(base)
+    for child in children:
+        child_parts = [part.strip() for part in str(child or "").replace("\\", "/").split("/") if part.strip()]
+        for part in child_parts:
+            current = f"{current.rstrip('/')}/{part}" if current != "/" else f"/{part}"
+    return current
+
+
+def cloud_year_folder(year) -> str:
+    return str(year) if year else "Без года"
+
+
+def parent_cloud_path(path: str) -> str:
+    normalized = normalize_cloud_path(path)
+    if normalized == "/":
+        return "/"
+    parent = normalized.rsplit("/", 1)[0]
+    return parent or "/"
+
+
+def replace_cloud_path_prefix(path: str, old_prefix: str, new_prefix: str) -> str:
+    normalized_path = normalize_cloud_path(path)
+    normalized_old = normalize_cloud_path(old_prefix)
+    normalized_new = normalize_cloud_path(new_prefix)
+    if normalized_path == normalized_old:
+        return normalized_new
+    if normalized_path.startswith(f"{normalized_old}/"):
+        return f"{normalized_new}{normalized_path[len(normalized_old):]}"
+    return normalized_path

--- a/core/static/core/js/proposals-panels.js
+++ b/core/static/core/js/proposals-panels.js
@@ -4331,7 +4331,7 @@
           refreshBtn.setAttribute('aria-label', 'Обновить курс Банка России на текущую дату');
           refreshBtn.innerHTML = '<i class="bi bi-arrow-clockwise" aria-hidden="true"></i>';
           refreshBtn.addEventListener('click', async function () {
-            const refreshUrl = form.dataset.cbrRateRefreshUrl || '';
+            const refreshUrl = formRoot.dataset.cbrRateRefreshUrl || '';
             if (!refreshUrl || refreshBtn.disabled) return;
             document.documentElement.classList.add('proposal-progress-cursor');
             refreshBtn.classList.add('is-loading');

--- a/nextcloud_app/api.py
+++ b/nextcloud_app/api.py
@@ -140,6 +140,42 @@ class NextcloudApiClient:
                 )
         return normalized
 
+    def move_resource(
+        self,
+        owner_user_id: str,
+        source_path: str,
+        target_path: str,
+        *,
+        overwrite: bool = False,
+    ) -> str:
+        source = self._normalize_folder_path(source_path)
+        target = self._normalize_folder_path(target_path)
+        if source == "/" or target == "/":
+            raise NextcloudApiError("Nextcloud root folder cannot be moved.")
+        if source == target:
+            return target
+
+        parent = "/" + "/".join(target.strip("/").split("/")[:-1])
+        if parent and parent != "/":
+            self.ensure_folder(owner_user_id, parent)
+
+        response = self._dav_request(
+            "MOVE",
+            self._webdav_path(owner_user_id, source),
+            headers={
+                "Destination": self._webdav_path(owner_user_id, target),
+                "Overwrite": "T" if overwrite else "F",
+            },
+            allow_statuses={201, 204, 404, 412},
+        )
+        if response.status_code in (201, 204):
+            return target
+        if response.status_code == 404:
+            raise NextcloudApiError(f"Nextcloud DAV error 404: исходная папка не найдена `{source}`.")
+        if response.status_code == 412:
+            raise NextcloudApiError(f"Nextcloud DAV error 412: целевая папка уже существует `{target}`.")
+        raise NextcloudApiError(f"Nextcloud DAV error {response.status_code}: не удалось переместить `{source}`.")
+
     def ensure_user_share(
         self,
         owner_user_id: str,

--- a/nextcloud_app/management/commands/migrate_cloud_storage_structure.py
+++ b/nextcloud_app/management/commands/migrate_cloud_storage_structure.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from checklists_app.models import (
+    ChecklistItemFolder,
+    ProjectWorkspace,
+    SourceDataItemFolder,
+    SourceDataSectionFolder,
+    SourceDataWorkspace,
+)
+from core.cloud_paths import (
+    LEGACY_PROPOSALS_SECTION_FOLDER,
+    PROJECTS_SECTION_FOLDER,
+    PROPOSALS_SECTION_FOLDER,
+    join_cloud_path,
+    normalize_cloud_path,
+    replace_cloud_path_prefix,
+)
+from core.models import CloudStorageSettings
+from nextcloud_app.api import NextcloudApiClient, NextcloudApiError
+from projects_app.models import Performer
+from proposals_app.models import ProposalRegistration
+from yandexdisk_app.models import YandexDiskAccount, YandexDiskSelection
+
+
+@dataclass(frozen=True)
+class PathChange:
+    model_label: str
+    pk: int
+    field: str
+    old_path: str
+    new_path: str
+
+
+@dataclass(frozen=True)
+class MoveOperation:
+    source_path: str
+    target_path: str
+
+
+PATH_FIELDS = (
+    (ProposalRegistration, ("proposal_workspace_disk_path", "proposal_workspace_target_path", "docx_file_link", "pdf_file_link")),
+    (ProjectWorkspace, ("disk_path",)),
+    (ChecklistItemFolder, ("disk_path",)),
+    (SourceDataWorkspace, ("disk_path",)),
+    (SourceDataSectionFolder, ("disk_path",)),
+    (SourceDataItemFolder, ("disk_path",)),
+    (Performer, ("contract_project_disk_folder",)),
+    (YandexDiskSelection, ("resource_path",)),
+)
+
+
+class Command(BaseCommand):
+    help = "Migrates cloud folder paths to the 01 ТКП / 02 Проекты structure."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--old-root", required=True, help="Current/legacy root path, for example /Projects.")
+        parser.add_argument(
+            "--new-root",
+            default="",
+            help="Target root path. Defaults to the configured Nextcloud root path.",
+        )
+        parser.add_argument(
+            "--storage",
+            choices=("primary", "nextcloud", "yandex_disk", "both"),
+            default="primary",
+            help="Which cloud backend should receive physical move operations.",
+        )
+        parser.add_argument("--yandex-user", default="", help="Username/email for Yandex.Disk move operations.")
+        parser.add_argument("--overwrite", action="store_true", help="Allow replacing target folders during move.")
+        parser.add_argument("--apply", action="store_true", help="Apply folder moves and database path updates.")
+
+    def handle(self, *args, **options):
+        old_root = normalize_cloud_path(options["old_root"])
+        settings_obj = CloudStorageSettings.get_solo()
+        raw_new_root = options["new_root"] or settings_obj.nextcloud_root_path or ""
+        if not str(raw_new_root).strip():
+            raise CommandError("Target root is empty. Pass --new-root or configure Nextcloud root path.")
+        new_root = normalize_cloud_path(raw_new_root)
+
+        changes = self._collect_path_changes(old_root, new_root)
+        moves = self._collect_move_operations(changes, old_root, new_root)
+
+        mode = "APPLY" if options["apply"] else "DRY-RUN"
+        self.stdout.write(f"{mode}: {len(moves)} folder move(s), {len(changes)} database path update(s).")
+        for move in moves:
+            self.stdout.write(f"MOVE {move.source_path} -> {move.target_path}")
+        for change in changes:
+            self.stdout.write(
+                f"DB {change.model_label}#{change.pk}.{change.field}: "
+                f"{change.old_path} -> {change.new_path}"
+            )
+
+        if not options["apply"]:
+            self.stdout.write(self.style.WARNING("Dry-run only. Re-run with --apply to perform changes."))
+            return
+
+        storage = self._resolve_storage(options["storage"], settings_obj)
+        if moves:
+            self._apply_moves(storage, moves, options)
+        self._apply_database_changes(changes)
+        self.stdout.write(self.style.SUCCESS("Cloud storage structure migration completed."))
+
+    def _collect_path_changes(self, old_root: str, new_root: str) -> list[PathChange]:
+        changes: list[PathChange] = []
+        for model, fields in PATH_FIELDS:
+            model_label = model._meta.label
+            for field in fields:
+                for pk, raw_value in model.objects.exclude(**{field: ""}).values_list("pk", field):
+                    old_value = str(raw_value or "").strip()
+                    if not old_value:
+                        continue
+                    new_value = self._transform_path(old_value, old_root, new_root)
+                    if new_value != normalize_cloud_path(old_value):
+                        changes.append(PathChange(model_label, pk, field, old_value, new_value))
+        return changes
+
+    def _transform_path(self, path: str, old_root: str, new_root: str) -> str:
+        normalized = normalize_cloud_path(path)
+        if normalized == old_root:
+            return new_root
+
+        rootless_legacy_tkp = join_cloud_path("/", LEGACY_PROPOSALS_SECTION_FOLDER)
+        transformed = replace_cloud_path_prefix(
+            normalized,
+            rootless_legacy_tkp,
+            join_cloud_path("/", PROPOSALS_SECTION_FOLDER),
+        )
+        if transformed != normalized:
+            return transformed
+
+        legacy_tkp = join_cloud_path(old_root, LEGACY_PROPOSALS_SECTION_FOLDER)
+        target_tkp = join_cloud_path(new_root, PROPOSALS_SECTION_FOLDER)
+        transformed = replace_cloud_path_prefix(normalized, legacy_tkp, target_tkp)
+        if transformed != normalized:
+            return transformed
+
+        for section in (PROPOSALS_SECTION_FOLDER, PROJECTS_SECTION_FOLDER):
+            transformed = replace_cloud_path_prefix(
+                normalized,
+                join_cloud_path(old_root, section),
+                join_cloud_path(new_root, section),
+            )
+            if transformed != normalized:
+                return transformed
+
+        if not normalized.startswith(f"{old_root}/"):
+            return normalized
+
+        relative = normalized[len(old_root):].lstrip("/")
+        first_part = relative.split("/", 1)[0]
+        if self._is_project_year_segment(first_part):
+            return join_cloud_path(new_root, PROJECTS_SECTION_FOLDER, relative)
+        return normalized
+
+    def _collect_move_operations(
+        self,
+        changes: list[PathChange],
+        old_root: str,
+        new_root: str,
+    ) -> list[MoveOperation]:
+        operations: dict[tuple[str, str], MoveOperation] = {}
+        for change in changes:
+            operation = self._move_operation_for_path(change.old_path, old_root, new_root)
+            if operation is None:
+                continue
+            operations[(operation.source_path, operation.target_path)] = operation
+        return sorted(operations.values(), key=lambda item: item.source_path)
+
+    def _move_operation_for_path(self, path: str, old_root: str, new_root: str) -> MoveOperation | None:
+        normalized = normalize_cloud_path(path)
+        legacy_tkp = join_cloud_path(old_root, LEGACY_PROPOSALS_SECTION_FOLDER)
+        if normalized == legacy_tkp or normalized.startswith(f"{legacy_tkp}/"):
+            return MoveOperation(legacy_tkp, join_cloud_path(new_root, PROPOSALS_SECTION_FOLDER))
+
+        for section in (PROPOSALS_SECTION_FOLDER, PROJECTS_SECTION_FOLDER):
+            section_root = join_cloud_path(old_root, section)
+            if normalized == section_root or normalized.startswith(f"{section_root}/"):
+                return MoveOperation(section_root, join_cloud_path(new_root, section))
+
+        if not normalized.startswith(f"{old_root}/"):
+            return None
+
+        relative = normalized[len(old_root):].lstrip("/")
+        first_part = relative.split("/", 1)[0]
+        if self._is_project_year_segment(first_part):
+            return MoveOperation(
+                join_cloud_path(old_root, first_part),
+                join_cloud_path(new_root, PROJECTS_SECTION_FOLDER, first_part),
+            )
+        return None
+
+    def _apply_moves(self, storage: str, moves: list[MoveOperation], options: dict) -> None:
+        if storage in {"nextcloud", "both"}:
+            client = NextcloudApiClient()
+            if not client.is_configured:
+                raise CommandError("Nextcloud is not configured for physical move operations.")
+            for move in moves:
+                try:
+                    client.move_resource(
+                        client.username,
+                        move.source_path,
+                        move.target_path,
+                        overwrite=options["overwrite"],
+                    )
+                except NextcloudApiError as exc:
+                    raise CommandError(str(exc)) from exc
+
+        if storage in {"yandex_disk", "both"}:
+            from yandexdisk_app.service import move_resource
+
+            user = self._resolve_yandex_user(options.get("yandex_user") or "")
+            for move in moves:
+                if not move_resource(user, move.source_path, move.target_path, overwrite=options["overwrite"]):
+                    raise CommandError(f"Could not move Yandex.Disk resource {move.source_path} -> {move.target_path}.")
+
+    def _apply_database_changes(self, changes: list[PathChange]) -> None:
+        model_map = {model._meta.label: model for model, _fields in PATH_FIELDS}
+        with transaction.atomic():
+            for change in changes:
+                model = model_map[change.model_label]
+                model.objects.filter(pk=change.pk).update(**{change.field: change.new_path})
+
+    def _resolve_storage(self, storage: str, settings_obj: CloudStorageSettings) -> str:
+        if storage != "primary":
+            return storage
+        return settings_obj.primary_storage
+
+    def _resolve_yandex_user(self, username: str):
+        User = get_user_model()
+        if username:
+            user = User.objects.filter(username=username).first() or User.objects.filter(email=username).first()
+            if user is None:
+                raise CommandError(f"Yandex.Disk user `{username}` not found.")
+            if not YandexDiskAccount.objects.filter(user=user, access_token__gt="").exists():
+                raise CommandError(f"Yandex.Disk user `{username}` does not have an access token.")
+            return user
+
+        account = YandexDiskAccount.objects.filter(access_token__gt="").select_related("user").first()
+        if account is None:
+            raise CommandError("No Yandex.Disk account with an access token found. Pass --yandex-user.")
+        return account.user
+
+    @staticmethod
+    def _is_project_year_segment(value: str) -> bool:
+        return value == "Без года" or value.isdigit()

--- a/nextcloud_app/management/commands/migrate_cloud_storage_structure.py
+++ b/nextcloud_app/management/commands/migrate_cloud_storage_structure.py
@@ -115,24 +115,25 @@ class Command(BaseCommand):
                     old_value = str(raw_value or "").strip()
                     if not old_value:
                         continue
-                    new_value = self._transform_path(old_value, old_root, new_root)
+                    new_value = self._transform_path(old_value, old_root, new_root, field=field)
                     if new_value != normalize_cloud_path(old_value):
                         changes.append(PathChange(model_label, pk, field, old_value, new_value))
         return changes
 
-    def _transform_path(self, path: str, old_root: str, new_root: str) -> str:
+    def _transform_path(self, path: str, old_root: str, new_root: str, *, field: str = "") -> str:
         normalized = normalize_cloud_path(path)
         if normalized == old_root:
             return new_root
 
-        rootless_legacy_tkp = join_cloud_path("/", LEGACY_PROPOSALS_SECTION_FOLDER)
-        transformed = replace_cloud_path_prefix(
-            normalized,
-            rootless_legacy_tkp,
-            join_cloud_path("/", PROPOSALS_SECTION_FOLDER),
-        )
-        if transformed != normalized:
-            return transformed
+        if field == "proposal_workspace_target_path":
+            rootless_legacy_tkp = join_cloud_path("/", LEGACY_PROPOSALS_SECTION_FOLDER)
+            transformed = replace_cloud_path_prefix(
+                normalized,
+                rootless_legacy_tkp,
+                join_cloud_path("/", PROPOSALS_SECTION_FOLDER),
+            )
+            if transformed != normalized:
+                return transformed
 
         legacy_tkp = join_cloud_path(old_root, LEGACY_PROPOSALS_SECTION_FOLDER)
         target_tkp = join_cloud_path(new_root, PROPOSALS_SECTION_FOLDER)
@@ -149,10 +150,10 @@ class Command(BaseCommand):
             if transformed != normalized:
                 return transformed
 
-        if not normalized.startswith(f"{old_root}/"):
+        relative = self._relative_to_root(normalized, old_root)
+        if relative is None:
             return normalized
 
-        relative = normalized[len(old_root):].lstrip("/")
         first_part = relative.split("/", 1)[0]
         if self._is_project_year_segment(first_part):
             return join_cloud_path(new_root, PROJECTS_SECTION_FOLDER, relative)
@@ -183,10 +184,10 @@ class Command(BaseCommand):
             if normalized == section_root or normalized.startswith(f"{section_root}/"):
                 return MoveOperation(section_root, join_cloud_path(new_root, section))
 
-        if not normalized.startswith(f"{old_root}/"):
+        relative = self._relative_to_root(normalized, old_root)
+        if relative is None:
             return None
 
-        relative = normalized[len(old_root):].lstrip("/")
         first_part = relative.split("/", 1)[0]
         if self._is_project_year_segment(first_part):
             return MoveOperation(
@@ -249,3 +250,15 @@ class Command(BaseCommand):
     @staticmethod
     def _is_project_year_segment(value: str) -> bool:
         return value == "Без года" or value.isdigit()
+
+    @staticmethod
+    def _relative_to_root(path: str, root: str) -> str | None:
+        normalized_path = normalize_cloud_path(path)
+        normalized_root = normalize_cloud_path(root)
+        if normalized_path == normalized_root:
+            return ""
+        if normalized_root == "/":
+            return normalized_path.lstrip("/")
+        if normalized_path.startswith(f"{normalized_root}/"):
+            return normalized_path[len(normalized_root):].lstrip("/")
+        return None

--- a/nextcloud_app/tests.py
+++ b/nextcloud_app/tests.py
@@ -1,6 +1,7 @@
+from io import StringIO
 from unittest.mock import Mock, call, patch
 
-from checklists_app.models import ProjectWorkspace
+from checklists_app.models import ProjectWorkspace, SourceDataWorkspace
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.test import Client, TestCase, override_settings
@@ -9,7 +10,7 @@ from core.models import CloudStorageSettings
 from group_app.models import GroupMember
 from policy_app.models import Product
 from proposals_app.models import ProposalRegistration
-from projects_app.models import ProjectRegistration, RegistrationWorkspaceFolder
+from projects_app.models import Performer, ProjectRegistration, RegistrationWorkspaceFolder
 from users_app.models import Employee
 from yandexdisk_app.workspace import _build_project_folder_name, WorkspaceResult
 from nextcloud_app.api import NextcloudApiError
@@ -484,7 +485,7 @@ class NextcloudWorkspaceTests(TestCase):
 
     def test_create_basic_project_workspace_creates_folders_and_grants_editor_access(self):
         project_folder = _build_project_folder_name(self.project)
-        project_path = f"/Corporate Root/2026/{project_folder}"
+        project_path = f"/Corporate Root/02 Проекты/2026/{project_folder}"
         client = Mock()
         client.is_configured = True
         client.username = "cloud-admin"
@@ -502,7 +503,8 @@ class NextcloudWorkspaceTests(TestCase):
         self.assertEqual(
             client.ensure_folder.call_args_list,
             [
-                call("cloud-admin", "/Corporate Root/2026"),
+                call("cloud-admin", "/Corporate Root/02 Проекты"),
+                call("cloud-admin", "/Corporate Root/02 Проекты/2026"),
                 call("cloud-admin", project_path),
                 call("cloud-admin", f"{project_path}/01 Документы"),
                 call("cloud-admin", f"{project_path}/01 Документы/02 Письма"),
@@ -524,7 +526,7 @@ class NextcloudWorkspaceTests(TestCase):
         settings_obj.save()
 
         project_folder = _build_project_folder_name(self.project)
-        project_path = f"/2026/{project_folder}"
+        project_path = f"/02 Проекты/2026/{project_folder}"
         client = Mock()
         client.is_configured = True
         client.username = "cloud-admin"
@@ -543,7 +545,8 @@ class NextcloudWorkspaceTests(TestCase):
         self.assertEqual(
             client.ensure_folder.call_args_list,
             [
-                call("cloud-admin", "/2026"),
+                call("cloud-admin", "/02 Проекты"),
+                call("cloud-admin", "/02 Проекты/2026"),
                 call("cloud-admin", project_path),
                 call("cloud-admin", f"{project_path}/01 Документы"),
                 call("cloud-admin", f"{project_path}/01 Документы/02 Письма"),
@@ -577,10 +580,11 @@ class NextcloudWorkspaceTests(TestCase):
             return "/" + "/".join(part for part in str(path).replace("\\", "/").split("/") if part)
         client.ensure_folder.side_effect = [
             NextcloudApiError("429 rate limit"),
-            "/Corporate Root/2026",
-            "/Corporate Root/2026/Проект 6001 DD Проект Nextcloud",
-            "/Corporate Root/2026/Проект 6001 DD Проект Nextcloud/01 Документы",
-            "/Corporate Root/2026/Проект 6001 DD Проект Nextcloud/01 Документы/02 Письма",
+            "/Corporate Root/02 Проекты",
+            "/Corporate Root/02 Проекты/2026",
+            "/Corporate Root/02 Проекты/2026/Проект 6001 DD Проект Nextcloud",
+            "/Corporate Root/02 Проекты/2026/Проект 6001 DD Проект Nextcloud/01 Документы",
+            "/Corporate Root/02 Проекты/2026/Проект 6001 DD Проект Nextcloud/01 Документы/02 Письма",
         ]
         client.ensure_user_share.return_value = Mock()
         client.build_files_url.return_value = "https://cloud.example.com/apps/files/files?dir=/test"
@@ -651,18 +655,18 @@ class NextcloudProposalWorkspaceTests(TestCase):
         folder_name = f"{self.proposal.short_uid} {self.product.short_name} Сделка _ Восток"
         workspace_path = create_proposal_workspace(self.author, self.proposal, client=client)
 
-        self.assertEqual(workspace_path, f"/Corporate Root/ТКП/2026/{folder_name}")
+        self.assertEqual(workspace_path, f"/Corporate Root/01 ТКП/2026/{folder_name}")
         self.assertEqual(
             client.ensure_folder.call_args_list,
             [
-                call("cloud-admin", "/Corporate Root/ТКП"),
-                call("cloud-admin", "/Corporate Root/ТКП/2026"),
-                call("cloud-admin", f"/Corporate Root/ТКП/2026/{folder_name}"),
+                call("cloud-admin", "/Corporate Root/01 ТКП"),
+                call("cloud-admin", "/Corporate Root/01 ТКП/2026"),
+                call("cloud-admin", f"/Corporate Root/01 ТКП/2026/{folder_name}"),
             ],
         )
         client.ensure_user_share.assert_called_once_with(
             "cloud-admin",
-            f"/Corporate Root/ТКП/2026/{folder_name}",
+            f"/Corporate Root/01 ТКП/2026/{folder_name}",
             f"ncstaff-{self.author.pk}",
             permissions=15,
         )
@@ -694,13 +698,137 @@ class NextcloudProposalWorkspaceTests(TestCase):
         folder_name = f"{self.proposal.short_uid} {self.product.short_name} Сделка _ Восток"
         workspace_path = create_proposal_workspace(self.author, self.proposal, client=client)
 
-        self.assertEqual(workspace_path, f"/Corporate Root/ТКП/2026/{folder_name}")
+        self.assertEqual(workspace_path, f"/Corporate Root/01 ТКП/2026/{folder_name}")
         mocked_ensure_account.assert_called_once()
         client.ensure_user_share.assert_called_once_with(
             "cloud-admin",
-            f"/Corporate Root/ТКП/2026/{folder_name}",
+            f"/Corporate Root/01 ТКП/2026/{folder_name}",
             f"ncstaff-{self.author.pk}",
             permissions=15,
+        )
+
+
+@override_settings(
+    NEXTCLOUD_PROVISIONING_BASE_URL="https://cloud.example.com",
+    NEXTCLOUD_PROVISIONING_USERNAME="cloud-admin",
+    NEXTCLOUD_PROVISIONING_TOKEN="token",
+    NEXTCLOUD_OIDC_PROVIDER_ID=1,
+)
+class CloudStorageStructureMigrationTests(TestCase):
+    def setUp(self):
+        settings_obj = CloudStorageSettings.get_solo()
+        settings_obj.primary_storage = CloudStorageSettings.PrimaryStorage.NEXTCLOUD
+        settings_obj.nextcloud_root_path = "/Corporate Root"
+        settings_obj.save()
+
+        self.user = User.objects.create_user(username="migration-user")
+        self.group_member = GroupMember.objects.create(
+            short_name="IMC Montan",
+            country_name="Россия",
+            country_code="643",
+            country_alpha2="RU",
+            position=1,
+        )
+        self.product = Product.objects.create(
+            short_name="DD",
+            name_en="Due Diligence",
+            name_ru="ДД",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+        )
+        self.proposal = ProposalRegistration.objects.create(
+            number=3333,
+            group_member=self.group_member,
+            type=self.product,
+            name="Миграция ТКП",
+            year=2026,
+            proposal_workspace_disk_path="/Corporate Root/ТКП/2026/333300RU DD Миграция ТКП",
+            proposal_workspace_target_path="/ТКП/2026/333300RU DD Миграция ТКП",
+            docx_file_link="/Corporate Root/ТКП/2026/333300RU DD Миграция ТКП/offer.docx",
+        )
+        self.project = ProjectRegistration.objects.create(
+            number=6001,
+            type=self.product,
+            name="Миграция проекта",
+            year=2026,
+        )
+        self.project_folder = f"{self.project.short_uid} DD Миграция проекта"
+        ProjectWorkspace.objects.create(
+            project=self.project,
+            disk_path=f"/Corporate Root/2026/{self.project_folder}",
+            created_by=self.user,
+        )
+        SourceDataWorkspace.objects.create(
+            project=self.project,
+            disk_path=f"/Corporate Root/2026/{self.project_folder}/05 Исходные данные",
+            created_by=self.user,
+        )
+        self.performer = Performer.objects.create(
+            registration=self.project,
+            executor="Иванов Иван Иванович",
+            contract_project_disk_folder=f"/Corporate Root/2026/{self.project_folder}/09 Договоры/000 Иванов ИИ",
+        )
+
+    def test_migrate_cloud_storage_structure_dry_run_does_not_update_database(self):
+        out = StringIO()
+
+        call_command(
+            "migrate_cloud_storage_structure",
+            "--old-root",
+            "/Corporate Root",
+            "--new-root",
+            "/Corporate Root",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        self.assertIn("DRY-RUN", output)
+        self.assertIn("MOVE /Corporate Root/ТКП -> /Corporate Root/01 ТКП", output)
+        self.assertIn("MOVE /Corporate Root/2026 -> /Corporate Root/02 Проекты/2026", output)
+        self.proposal.refresh_from_db()
+        self.assertEqual(
+            self.proposal.proposal_workspace_disk_path,
+            "/Corporate Root/ТКП/2026/333300RU DD Миграция ТКП",
+        )
+
+    @patch("nextcloud_app.api.NextcloudApiClient.move_resource")
+    def test_migrate_cloud_storage_structure_apply_moves_folders_and_updates_database(self, mocked_move):
+        call_command(
+            "migrate_cloud_storage_structure",
+            "--old-root",
+            "/Corporate Root",
+            "--new-root",
+            "/Corporate Root",
+            "--apply",
+            stdout=StringIO(),
+        )
+
+        mocked_move.assert_has_calls(
+            [
+                call("cloud-admin", "/Corporate Root/2026", "/Corporate Root/02 Проекты/2026", overwrite=False),
+                call("cloud-admin", "/Corporate Root/ТКП", "/Corporate Root/01 ТКП", overwrite=False),
+            ],
+            any_order=True,
+        )
+        self.proposal.refresh_from_db()
+        self.assertEqual(
+            self.proposal.proposal_workspace_disk_path,
+            "/Corporate Root/01 ТКП/2026/333300RU DD Миграция ТКП",
+        )
+        self.assertEqual(
+            self.proposal.proposal_workspace_target_path,
+            "/01 ТКП/2026/333300RU DD Миграция ТКП",
+        )
+        workspace = ProjectWorkspace.objects.get(project=self.project)
+        self.assertEqual(
+            workspace.disk_path,
+            f"/Corporate Root/02 Проекты/2026/{self.project_folder}",
+        )
+        self.performer.refresh_from_db()
+        self.assertEqual(
+            self.performer.contract_project_disk_folder,
+            f"/Corporate Root/02 Проекты/2026/{self.project_folder}/09 Договоры/000 Иванов ИИ",
         )
 
 

--- a/nextcloud_app/tests.py
+++ b/nextcloud_app/tests.py
@@ -792,6 +792,55 @@ class CloudStorageStructureMigrationTests(TestCase):
             "/Corporate Root/ТКП/2026/333300RU DD Миграция ТКП",
         )
 
+    def test_migrate_cloud_storage_structure_handles_slash_old_root(self):
+        self.proposal.proposal_workspace_disk_path = "/ТКП/2026/333300RU DD Миграция ТКП"
+        self.proposal.proposal_workspace_target_path = "/ТКП/2026/333300RU DD Миграция ТКП"
+        self.proposal.docx_file_link = "/ТКП/2026/333300RU DD Миграция ТКП/offer.docx"
+        self.proposal.save(
+            update_fields=[
+                "proposal_workspace_disk_path",
+                "proposal_workspace_target_path",
+                "docx_file_link",
+            ]
+        )
+        ProjectWorkspace.objects.filter(project=self.project).update(
+            disk_path=f"/2026/{self.project_folder}"
+        )
+        SourceDataWorkspace.objects.filter(project=self.project).update(
+            disk_path=f"/2026/{self.project_folder}/05 Исходные данные"
+        )
+        Performer.objects.filter(pk=self.performer.pk).update(
+            contract_project_disk_folder=f"/2026/{self.project_folder}/09 Договоры/000 Иванов ИИ"
+        )
+        out = StringIO()
+
+        call_command(
+            "migrate_cloud_storage_structure",
+            "--old-root",
+            "/",
+            "--new-root",
+            "/",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        self.assertIn("MOVE /2026 -> /02 Проекты/2026", output)
+        self.assertIn("MOVE /ТКП -> /01 ТКП", output)
+        self.assertIn(
+            "proposals_app.ProposalRegistration"
+            f"#{self.proposal.pk}.proposal_workspace_disk_path: "
+            "/ТКП/2026/333300RU DD Миграция ТКП -> "
+            "/01 ТКП/2026/333300RU DD Миграция ТКП",
+            output,
+        )
+        self.assertIn(
+            "checklists_app.ProjectWorkspace"
+            f"#{self.project.yadisk_workspace.pk}.disk_path: "
+            f"/2026/{self.project_folder} -> "
+            f"/02 Проекты/2026/{self.project_folder}",
+            output,
+        )
+
     @patch("nextcloud_app.api.NextcloudApiClient.move_resource")
     def test_migrate_cloud_storage_structure_apply_moves_folders_and_updates_database(self, mocked_move):
         call_command(

--- a/nextcloud_app/workspace.py
+++ b/nextcloud_app/workspace.py
@@ -6,6 +6,11 @@ import time
 from django.db import transaction
 
 from checklists_app.models import ProjectWorkspace
+from core.cloud_paths import (
+    PROJECTS_SECTION_FOLDER,
+    PROPOSALS_SECTION_FOLDER,
+    cloud_year_folder,
+)
 from core.cloud_storage import get_nextcloud_root_path, get_primary_cloud_storage_label
 from users_app.models import Employee
 from yandexdisk_app.workspace import (
@@ -16,6 +21,7 @@ from yandexdisk_app.workspace import (
     _build_numbered_section_folder_name,
     _build_folder_tree,
     _build_project_folder_name,
+    _build_project_workspace_path,
     _sanitize,
     _sanitize_relative_path,
 )
@@ -115,7 +121,8 @@ def create_proposal_workspace(
     owner_user_id = client.username
 
     proposal_path = build_proposal_workspace_path(proposal, base_root=base_root)
-    tkp_root_path = client.ensure_folder(owner_user_id, _join_path("/" if base_root == "/" else base_root.rstrip("/"), _sanitize("ТКП")))
+    base = "/" if base_root == "/" else base_root.rstrip("/")
+    tkp_root_path = client.ensure_folder(owner_user_id, _join_path(base, _sanitize(PROPOSALS_SECTION_FOLDER)))
     year_path = client.ensure_folder(owner_user_id, _join_path(tkp_root_path, _sanitize(str(proposal.year))))
     proposal_path = client.ensure_folder(owner_user_id, proposal_path)
 
@@ -173,7 +180,7 @@ def create_basic_project_workspace_stream(
         else [_sanitize(name) for name in REGISTRATION_STANDARD_FOLDERS]
     )
 
-    total = 3 + len(folder_paths)
+    total = 4 + len(folder_paths)
     current = 0
     owner_user_id = client.username
 
@@ -183,9 +190,15 @@ def create_basic_project_workspace_stream(
             yield WorkspaceResult(False, "Не удалось определить Nextcloud-пользователя руководителя проекта.")
             return
 
-        year_str = str(project.year) if project.year else "Без года"
+        projects_root_path = yield from _ensure_folder_with_heartbeat(
+            client, owner_user_id, _join_path(base, _sanitize(PROJECTS_SECTION_FOLDER)), current, total,
+        )
+        current += 1
+        yield {"current": current, "total": total}
+
+        year_str = cloud_year_folder(project.year)
         year_path = yield from _ensure_folder_with_heartbeat(
-            client, owner_user_id, _join_path(base, _sanitize(year_str)), current, total,
+            client, owner_user_id, _join_path(projects_root_path, _sanitize(year_str)), current, total,
         )
         current += 1
         yield {"current": current, "total": total}
@@ -450,14 +463,13 @@ def _resolve_nextcloud_source_data_base(user, project):
         return None, WorkspaceResult(False, "Не задан корневой каталог Nextcloud в разделе «Подключения».")
 
     base = "/" if base_root == "/" else base_root.rstrip("/")
-    year_str = str(project.year) if project.year else "Без года"
-    project_folder = _build_project_folder_name(project)
+    project_path = _build_project_workspace_path(base, project)
 
     target_obj = SourceDataTargetFolder.objects.filter(user=user).first()
     target_folder = _sanitize_relative_path(
         target_obj.folder_name if target_obj else DEFAULT_SOURCE_DATA_FOLDER
     )
-    return _join_path(_join_path(_join_path(base, _sanitize(year_str)), project_folder), target_folder), None
+    return _join_path(project_path, target_folder), None
 
 
 def _join_path(base: str, child: str) -> str:
@@ -486,6 +498,6 @@ def build_proposal_workspace_path(proposal, *, base_root: str | None = None) -> 
         return ""
 
     base = "/" if root_path == "/" else root_path.rstrip("/")
-    tkp_root_path = _join_path(base, _sanitize("ТКП"))
+    tkp_root_path = _join_path(base, _sanitize(PROPOSALS_SECTION_FOLDER))
     year_path = _join_path(tkp_root_path, _sanitize(str(proposal.year)))
     return _join_path(year_path, _build_proposal_workspace_folder_name(proposal))

--- a/policy_app/tests.py
+++ b/policy_app/tests.py
@@ -543,6 +543,54 @@ class TypicalSectionViewsTests(TestCase):
             [first_specialty.pk, second_specialty.pk],
         )
 
+    def test_section_csv_upload_rolls_back_row_when_specialty_insert_fails(self):
+        owner = GroupMember.objects.create(
+            short_name="IMC",
+            country_name="Россия",
+            country_code="643",
+            country_alpha2="RU",
+            position=1,
+        )
+        department = OrgUnit.objects.create(
+            company=owner,
+            level=1,
+            department_name="Налоговый департамент",
+            short_name="TAX-DEPT",
+            unit_type="expertise",
+            position=1,
+        )
+        expertise = ExpertiseDirection.objects.create(
+            name="Налоги",
+            short_name="TAX",
+            position=1,
+        )
+        specialty = ExpertSpecialty.objects.create(
+            expertise_direction=department,
+            expertise_dir=expertise,
+            specialty="Налоговый due diligence",
+            position=1,
+        )
+        csv_file = SimpleUploadedFile(
+            "sections.csv",
+            (
+                "Продукт;Код;Краткое имя EN;Краткое имя RU;"
+                "Наименование раздела (услуги) EN;Наименование раздела (услуги) RU;"
+                "Тип учета;Исполнитель;Экспертиза;Подразделение;ТКП\n"
+                "SEC;SEC-6;tax-dd;нал-dd;Tax DD;Налоговый ДД;Услуги;"
+                "Налоговый due diligence, Налоговый due diligence;TAX;Налоговый департамент;Да\n"
+            ).encode("utf-8"),
+            content_type="text/csv",
+        )
+
+        response = self.client.post(reverse("section_csv_upload"), {"csv_file": csv_file})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["created"], 0)
+        self.assertEqual(len(response.json()["warnings"]), 1)
+        self.assertIn("ошибка сохранения", response.json()["warnings"][0])
+        self.assertFalse(TypicalSection.objects.filter(code="SEC-6").exists())
+        self.assertFalse(TypicalSectionSpecialty.objects.filter(specialty=specialty).exists())
+
 
 class SectionStructureViewsTests(TestCase):
     def setUp(self):

--- a/policy_app/views.py
+++ b/policy_app/views.py
@@ -4,6 +4,7 @@ import json
 from collections import defaultdict
 
 from django.contrib.auth.decorators import login_required, user_passes_test
+from django.db import transaction
 from django.db.models import IntegerField, Max, Q, Value
 from django.db.models.functions import Coalesce
 from django.http import HttpResponse, JsonResponse
@@ -846,26 +847,27 @@ def section_csv_upload(request):
 
         position = _next_position(TypicalSection, {"product": product})
         try:
-            section = TypicalSection.objects.create(
-                product=product,
-                code=code,
-                short_name=short_name,
-                short_name_ru=short_name_ru,
-                name_en=name_en,
-                name_ru=name_ru,
-                accounting_type=accounting_type,
-                expertise_dir=expertise_dir,
-                expertise_direction=expertise_direction,
-                exclude_from_tkp_autofill=_csv_truthy(tkp_raw),
-                position=position,
-            )
-            missing_specialties = []
-            for rank, specialty_name in enumerate(_split_csv_list_value(executor_raw, specialties_by_name), start=1):
-                specialty = specialties_by_name.get(_csv_lookup_key(specialty_name))
-                if not specialty:
-                    missing_specialties.append(specialty_name)
-                    continue
-                TypicalSectionSpecialty.objects.create(section=section, specialty=specialty, rank=rank)
+            with transaction.atomic():
+                section = TypicalSection.objects.create(
+                    product=product,
+                    code=code,
+                    short_name=short_name,
+                    short_name_ru=short_name_ru,
+                    name_en=name_en,
+                    name_ru=name_ru,
+                    accounting_type=accounting_type,
+                    expertise_dir=expertise_dir,
+                    expertise_direction=expertise_direction,
+                    exclude_from_tkp_autofill=_csv_truthy(tkp_raw),
+                    position=position,
+                )
+                missing_specialties = []
+                for rank, specialty_name in enumerate(_split_csv_list_value(executor_raw, specialties_by_name), start=1):
+                    specialty = specialties_by_name.get(_csv_lookup_key(specialty_name))
+                    if not specialty:
+                        missing_specialties.append(specialty_name)
+                        continue
+                    TypicalSectionSpecialty.objects.create(section=section, specialty=specialty, rank=rank)
             if missing_specialties:
                 warnings.append(f"Строка {i}: исполнители не найдены: {', '.join(missing_specialties)}.")
             created += 1

--- a/projects_app/forms.py
+++ b/projects_app/forms.py
@@ -83,7 +83,7 @@ def _employee_queryset():
     )
 
 
-def _employee_choices(queryset, current_value=""):
+def _employee_choices(queryset, current_value="", *, include_missing_current=True):
     choices = [("", "— Не выбрано —")]
     current_value = (current_value or "").strip()
     current_in_choices = False
@@ -96,7 +96,7 @@ def _employee_choices(queryset, current_value=""):
         if full_name == current_value:
             current_in_choices = True
 
-    if current_value and not current_in_choices:
+    if include_missing_current and current_value and not current_in_choices:
         choices.insert(1, (current_value, current_value))
 
     return choices
@@ -106,8 +106,39 @@ def _project_manager_choices(current_value=""):
     return _employee_choices(_project_manager_queryset(), current_value)
 
 
-def _all_employee_choices(current_value=""):
-    return _employee_choices(_employee_queryset(), current_value)
+def _typical_section_specialty_ids(typical_section_id):
+    if not typical_section_id:
+        return []
+    try:
+        typical_section_pk = int(typical_section_id)
+    except (TypeError, ValueError):
+        return []
+    return list(
+        TypicalSection.objects
+        .filter(pk=typical_section_pk)
+        .values_list("specialties__pk", flat=True)
+        .exclude(specialties__pk__isnull=True)
+        .distinct()
+    )
+
+
+def _all_employee_choices(current_value="", typical_section_id=None):
+    queryset = _employee_queryset()
+    include_missing_current = True
+
+    if typical_section_id:
+        specialty_ids = _typical_section_specialty_ids(typical_section_id)
+        if specialty_ids:
+            queryset = queryset.filter(expert_profile__specialties__pk__in=specialty_ids).distinct()
+        else:
+            queryset = queryset.none()
+        include_missing_current = False
+
+    return _employee_choices(
+        queryset,
+        current_value,
+        include_missing_current=include_missing_current,
+    )
 
 
 def _next_project_number():
@@ -563,7 +594,14 @@ class PerformerForm(forms.ModelForm):
                     data[fn] = str(v).replace("\u00a0", "").replace(" ", "").replace(",", ".")
             self.data = data
         current_executor = self.data.get("executor") or (self.instance.executor if self.instance else "")
-        self.fields["executor"].choices = _all_employee_choices(current_executor)
+        current_typical_section_id = (
+            self.data.get("typical_section")
+            or (self.instance.typical_section_id if self.instance else None)
+        )
+        self.fields["executor"].choices = _all_employee_choices(
+            current_executor,
+            typical_section_id=current_typical_section_id,
+        )
 
         today = timezone.now().date()
         currency_qs = OKVCurrency.objects.filter(

--- a/projects_app/templates/projects_app/performer_form.html
+++ b/projects_app/templates/projects_app/performer_form.html
@@ -131,6 +131,7 @@
 <script id="perf-reg-map" type="application/json">{{ reg_map_json|safe }}</script>
 <script id="perf-assets-map" type="application/json">{{ assets_map_json|safe }}</script>
 <script id="perf-sections-map" type="application/json">{{ sections_map_json|safe }}</script>
+<script id="perf-executor-options" type="application/json">{{ executor_options_json|safe }}</script>
 <script id="perf-executor-grade-map" type="application/json">{{ executor_grade_json|safe }}</script>
 <script id="perf-living-wage-map" type="application/json">{{ living_wage_json|safe }}</script>
 <script id="perf-tariff-map" type="application/json">{{ tariff_json|safe }}</script>
@@ -145,10 +146,16 @@
   const nameEl  = formEl.querySelector('#perf-name');
   const assetSel= formEl.querySelector('select[name="asset_name"]');
   const sectSel = formEl.querySelector('select[name="typical_section"]');
+  var execSel = formEl.querySelector('select[name="executor"]');
+  var gradeNameDisplay = formEl.querySelector('#perf-grade-name-display');
+  var gradeNameHidden  = formEl.querySelector('#perf-grade-name');
+  var gradeStarsEl     = formEl.querySelector('#perf-grade-stars');
+  var gradeHidden      = formEl.querySelector('#perf-grade-value');
 
   const regMap   = JSON.parse(document.getElementById('perf-reg-map').textContent || '{}');
   const assetsMap= JSON.parse(document.getElementById('perf-assets-map').textContent || '{}');
   const sectMap  = JSON.parse(document.getElementById('perf-sections-map').textContent || '{}');
+  const executorOptions = JSON.parse(document.getElementById('perf-executor-options').textContent || '[]');
   const execGradeMap = JSON.parse(document.getElementById('perf-executor-grade-map').textContent || '{}');
   const lwMap    = JSON.parse(document.getElementById('perf-living-wage-map').textContent || '{}');
   const tariffMap= JSON.parse(document.getElementById('perf-tariff-map').textContent || '{}');
@@ -189,6 +196,53 @@
       sectSel.appendChild(o);
     });
     if (current) sectSel.value = current;
+    refillExecutors();
+  }
+
+  function getSelectedSectionInfo() {
+    var sectionId = sectSel ? sectSel.value : '';
+    if (!sectionId) return null;
+    var regId = regSel ? regSel.value : '';
+    var sectList = sectMap[regId] || [];
+    for (var i = 0; i < sectList.length; i++) {
+      if (String(sectList[i].id) === String(sectionId)) return sectList[i];
+    }
+    return {specialty_ids: []};
+  }
+
+  function filteredExecutorOptions() {
+    var sectionInfo = getSelectedSectionInfo();
+    if (!sectionInfo) return executorOptions;
+    var specialtyIds = (sectionInfo.specialty_ids || []).map(String).filter(Boolean);
+    if (!specialtyIds.length) return [];
+    var specialtySet = new Set(specialtyIds);
+    return executorOptions.filter(function(opt) {
+      return (opt.specialty_ids || []).map(String).some(function(id) {
+        return specialtySet.has(id);
+      });
+    });
+  }
+
+  function refillExecutors() {
+    if (!execSel) return;
+    var current = execSel.value;
+    var list = filteredExecutorOptions();
+    execSel.innerHTML = '';
+    var opt0 = document.createElement('option');
+    opt0.value = '';
+    opt0.textContent = '— Не выбрано —';
+    execSel.appendChild(opt0);
+    list.forEach(function(opt) {
+      var o = document.createElement('option');
+      o.value = opt.value;
+      o.textContent = opt.label || opt.value;
+      execSel.appendChild(o);
+    });
+    var currentAllowed = current && list.some(function(opt) {
+      return opt.value === current;
+    });
+    execSel.value = currentAllowed ? current : '';
+    if (!currentAllowed) applyExecutorGrade('');
   }
 
   function applyReg(regId) {
@@ -198,14 +252,6 @@
     refillAssets(regId);
     refillSections(regId);
   }
-
-  if (regSel?.value) applyReg(regSel.value);
-
-  var execSel = formEl.querySelector('select[name="executor"]');
-  var gradeNameDisplay = formEl.querySelector('#perf-grade-name-display');
-  var gradeNameHidden  = formEl.querySelector('#perf-grade-name');
-  var gradeStarsEl     = formEl.querySelector('#perf-grade-stars');
-  var gradeHidden      = formEl.querySelector('#perf-grade-value');
 
   function renderStars(container, qual, levels) {
     container.innerHTML = '';
@@ -308,11 +354,16 @@
     actualCostsEl.addEventListener('change', calcAgreed);
   }
 
+  if (regSel?.value) applyReg(regSel.value);
+
   if (regSel) regSel.addEventListener('change', function() {
     applyReg(regSel.value);
     calcEstimated();
   });
-  if (sectSel) sectSel.addEventListener('change', calcEstimated);
+  if (sectSel) sectSel.addEventListener('change', function() {
+    refillExecutors();
+    calcEstimated();
+  });
 
   const prepEl = formEl.querySelector('[name="prepayment"]');
   const finalEl = formEl.querySelector('[name="final_payment"]');

--- a/projects_app/tests.py
+++ b/projects_app/tests.py
@@ -19,7 +19,9 @@ from policy_app.models import (
     LAWYER_GROUP,
     PROJECTS_HEAD_GROUP,
     Product,
+    TypicalSectionSpecialty,
 )
+from experts_app.models import ExpertProfile, ExpertProfileSpecialty, ExpertSpecialty
 from projects_app.models import (
     ContractProjectTargetFolder,
     LegalEntity,
@@ -30,7 +32,7 @@ from projects_app.models import (
     SourceDataTargetFolder,
     WorkVolume,
 )
-from projects_app.forms import ContractConditionsForm, LegalEntityForm, ProjectRegistrationForm, WorkVolumeForm
+from projects_app.forms import ContractConditionsForm, LegalEntityForm, PerformerForm, ProjectRegistrationForm, WorkVolumeForm
 from group_app.models import GroupMember, OrgUnit
 from users_app.models import Employee
 from unittest.mock import call, patch
@@ -318,6 +320,84 @@ class ProjectRegistrationFormTests(TestCase):
             self.assertIn("Проектов Иван Иванович", choices)
             self.assertIn("Директорова Дарья Дмитриевна", choices)
             self.assertNotIn("Экспертов Егор Егорович", choices)
+
+
+class PerformerFormExecutorFilteringTests(TestCase):
+    def setUp(self):
+        self.product = Product.objects.create(
+            short_name="DD",
+            name_en="Due Diligence",
+            name_ru="ДД",
+        )
+        self.project = ProjectRegistration.objects.create(
+            number=6101,
+            type=self.product,
+            name="Проект исполнителей",
+            year=2026,
+        )
+        self.section = self.product.sections.create(
+            code="TAX",
+            short_name="Tax",
+            short_name_ru="Налоги",
+            name_en="Tax",
+            name_ru="Налоги",
+            accounting_type="Раздел",
+        )
+        self.matching_specialty = ExpertSpecialty.objects.create(specialty="Налоги")
+        self.other_specialty = ExpertSpecialty.objects.create(specialty="Геология")
+        TypicalSectionSpecialty.objects.create(
+            section=self.section,
+            specialty=self.matching_specialty,
+            rank=1,
+        )
+        self.matching_name = "Иванов Иван Иванович"
+        self.other_name = "Петров Петр Петрович"
+        self.matching_employee = self._create_employee(
+            username="tax.executor",
+            first_name="Иван",
+            last_name="Иванов",
+            patronymic="Иванович",
+            specialty=self.matching_specialty,
+        )
+        self.other_employee = self._create_employee(
+            username="geo.executor",
+            first_name="Петр",
+            last_name="Петров",
+            patronymic="Петрович",
+            specialty=self.other_specialty,
+        )
+
+    def _create_employee(self, *, username, first_name, last_name, patronymic, specialty):
+        user = get_user_model().objects.create_user(
+            username=username,
+            password="secret",
+            first_name=first_name,
+            last_name=last_name,
+            is_staff=True,
+        )
+        employee = Employee.objects.create(user=user, patronymic=patronymic)
+        profile = ExpertProfile.objects.create(employee=employee)
+        ExpertProfileSpecialty.objects.create(profile=profile, specialty=specialty, rank=1)
+        return employee
+
+    def test_executor_choices_are_filtered_by_typical_section_specialties(self):
+        form = PerformerForm(data={
+            "registration": self.project.pk,
+            "typical_section": self.section.pk,
+        })
+
+        choices = [value for value, _label in form.fields["executor"].choices]
+
+        self.assertIn(self.matching_name, choices)
+        self.assertNotIn(self.other_name, choices)
+
+    def test_executor_choices_are_unfiltered_until_typical_section_is_selected(self):
+        form = PerformerForm()
+
+        choices = [value for value, _label in form.fields["executor"].choices]
+
+        self.assertIn(self.matching_name, choices)
+        self.assertIn(self.other_name, choices)
 
 
 class ProjectRegistrationFormViewTests(TestCase):
@@ -1132,7 +1212,7 @@ class NextcloudSourceDataWorkspaceFlowTests(TestCase):
         mocked_public_share,
     ):
         expected_project_folder = f"{self.project.short_uid} DD Исходные данные"
-        base_path = f"/Corporate Root/2026/{expected_project_folder}/05 Исходные данные/01 Запросы"
+        base_path = f"/Corporate Root/02 Проекты/2026/{expected_project_folder}/05 Исходные данные/01 Запросы"
         section_path = f"{base_path}/01 FIN Финансы"
         item_path = f"{section_path}/REQ-01 ОСВ"
         mocked_ensure_folder.side_effect = [section_path, item_path]
@@ -1266,7 +1346,7 @@ class NextcloudContractProjectFlowTests(TestCase):
     @patch("nextcloud_app.api.NextcloudApiClient.ensure_user_share")
     @patch("nextcloud_app.api.NextcloudApiClient.ensure_public_link_share", return_value="https://cloud.example.com/s/public-doc")
     @patch("nextcloud_app.api.NextcloudApiClient.upload_file", return_value=True)
-    @patch("nextcloud_app.api.NextcloudApiClient.ensure_folder", return_value="/Corporate Root/2026/5002 DD Контрактный проект/09 Договоры/000 Иванов ИИ")
+    @patch("nextcloud_app.api.NextcloudApiClient.ensure_folder", return_value="/Corporate Root/02 Проекты/2026/5002 DD Контрактный проект/09 Договоры/000 Иванов ИИ")
     @patch("nextcloud_app.api.NextcloudApiClient.list_resources", return_value=[])
     def test_create_contract_project_uses_nextcloud_and_stores_public_link(
         self,
@@ -1292,7 +1372,7 @@ class NextcloudContractProjectFlowTests(TestCase):
 
         self.performer.refresh_from_db()
         expected_project_folder = f"{self.project.short_uid} DD Контрактный проект"
-        expected_base_path = f"/Corporate Root/2026/{expected_project_folder}/09 Договоры"
+        expected_base_path = f"/Corporate Root/02 Проекты/2026/{expected_project_folder}/09 Договоры"
         expected_folder_path = f"{expected_base_path}/000 Иванов ИИ"
         expected_upload_path = f"{expected_folder_path}/Договор 5002_Иванов ИИ.docx"
 

--- a/projects_app/views.py
+++ b/projects_app/views.py
@@ -48,6 +48,7 @@ from core.cloud_storage import (
     sanitize_folder_name,
     upload_file as cloud_upload_file,
 )
+from core.cloud_paths import PROJECTS_SECTION_FOLDER, join_cloud_path
 from policy_app.models import (
     DEPARTMENT_HEAD_GROUP,
     DIRECTION_DIRECTOR_GROUP,
@@ -626,6 +627,7 @@ def _ordered_registration_sections(registration):
         TypicalSection.objects
         .filter(product_id__in=product_ids)
         .select_related("product", "expertise_dir")
+        .prefetch_related("ranked_specialties", "ranked_specialties__specialty")
         .order_by("position", "id")
     )
     sections.sort(
@@ -1260,6 +1262,34 @@ def _build_executor_grade_map():
     return result
 
 
+def _build_executor_options_payload():
+    employees = (
+        Employee.objects
+        .select_related("user", "expert_profile")
+        .prefetch_related("expert_profile__specialties")
+        .order_by("user__last_name", "user__first_name", "patronymic", "position", "id")
+    )
+    result = []
+    for employee in employees:
+        full_name = _employee_full_name(employee)
+        if not full_name:
+            continue
+        try:
+            profile = employee.expert_profile
+        except ExpertProfile.DoesNotExist:
+            profile = None
+        result.append({
+            "value": full_name,
+            "label": full_name,
+            "specialty_ids": [
+                specialty.pk
+                for specialty in profile.specialties.all()
+                if specialty.pk
+            ] if profile else [],
+        })
+    return result
+
+
 def _build_living_wage_map():
     from classifiers_app.models import LivingWage
     today = timezone.now().date()
@@ -1364,11 +1394,17 @@ def _performer_form_ctx(form, action: str, performer=None):
                 "product_id": s.product_id,
                 "pricing_method": (s.expertise_dir.pricing_method or "") if s.expertise_dir_id else "",
                 "direction_id": s.expertise_direction_id,
+                "specialty_ids": [
+                    link.specialty_id
+                    for link in s.ranked_specialties.all()
+                    if link.specialty_id
+                ],
             }
             for s in ordered_sections
         ]
 
     executor_grade_map = _build_executor_grade_map()
+    executor_options = _build_executor_options_payload()
     living_wage_map = _build_living_wage_map()
     tariff_map = _build_tariff_map()
     tariff_hours_map = _build_tariff_hours_map()
@@ -1381,6 +1417,7 @@ def _performer_form_ctx(form, action: str, performer=None):
         "reg_map_json": json.dumps(reg_map, ensure_ascii=False),
         "assets_map_json": json.dumps(assets_map, ensure_ascii=False),
         "sections_map_json": json.dumps(sections_map, ensure_ascii=False),
+        "executor_options_json": json.dumps(executor_options, ensure_ascii=False),
         "executor_grade_json": json.dumps(executor_grade_map, ensure_ascii=False),
         "living_wage_json": json.dumps(living_wage_map, ensure_ascii=False),
         "tariff_json": json.dumps(tariff_map, ensure_ascii=False),
@@ -2401,7 +2438,13 @@ def create_contract_project(request):
                 year_str = sanitize_folder_name(str(project.year) if project.year else "Без года")
                 project_folder = build_project_folder_name(project)
                 target_folder = sanitize_folder_name(target_obj.folder_name)
-                base_path = f"{disk_root}/{year_str}/{project_folder}/{target_folder}"
+                base_path = join_cloud_path(
+                    disk_root,
+                    PROJECTS_SECTION_FOLDER,
+                    year_str,
+                    project_folder,
+                    target_folder,
+                )
 
                 existing = list_folder_resources(request.user, base_path, limit=1000)
                 next_number = 0

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -6177,7 +6177,7 @@ class ProposalDispatchDiskColumnTests(TestCase):
         response = self.client.get(reverse("proposals_partial"))
 
         self.assertEqual(response.status_code, 200)
-        expected_workspace_path = f"/Corporate Root/ТКП/2026/{self.proposal.short_uid} DD Тестовое ТКП"
+        expected_workspace_path = f"/Corporate Root/01 ТКП/2026/{self.proposal.short_uid} DD Тестовое ТКП"
         owner_url = (
             "https://cloud.example.com/apps/files/files?dir="
             f"{quote(expected_workspace_path, safe='/')}"

--- a/staticfiles/core/js/proposals-panels.js
+++ b/staticfiles/core/js/proposals-panels.js
@@ -4099,7 +4099,7 @@
           refreshBtn.setAttribute('aria-label', 'Обновить курс Банка России на текущую дату');
           refreshBtn.innerHTML = '<i class="bi bi-arrow-clockwise" aria-hidden="true"></i>';
           refreshBtn.addEventListener('click', async function () {
-            const refreshUrl = form.dataset.cbrRateRefreshUrl || '';
+            const refreshUrl = formRoot.dataset.cbrRateRefreshUrl || '';
             if (!refreshUrl || refreshBtn.disabled) return;
             document.documentElement.classList.add('proposal-progress-cursor');
             refreshBtn.classList.add('is-loading');

--- a/yandexdisk_app/service.py
+++ b/yandexdisk_app/service.py
@@ -136,6 +136,50 @@ def create_folder(user, path: str) -> bool:
         return False
 
 
+def ensure_folder_path(user, path: str) -> bool:
+    """Create every folder segment in an absolute Yandex.Disk path."""
+    clean = "/" + "/".join(part.strip() for part in str(path or "").replace("\\", "/").split("/") if part.strip())
+    if clean == "/":
+        return True
+
+    current = ""
+    for part in clean.strip("/").split("/"):
+        current = f"{current}/{part}" if current else f"/{part}"
+        if not create_folder(user, current):
+            return False
+    return True
+
+
+def move_resource(user, source_path: str, target_path: str, overwrite: bool = False) -> bool:
+    """Move a file or folder on Yandex.Disk, creating the target parent first."""
+    token = _get_token(user)
+    if not token:
+        return False
+
+    source = "/" + "/".join(part.strip() for part in str(source_path or "").replace("\\", "/").split("/") if part.strip())
+    target = "/" + "/".join(part.strip() for part in str(target_path or "").replace("\\", "/").split("/") if part.strip())
+    if source in {"", "/"} or target in {"", "/"}:
+        return False
+    if source == target:
+        return True
+
+    parent = target.rsplit("/", 1)[0] or "/"
+    if parent != "/" and not ensure_folder_path(user, parent):
+        return False
+
+    headers = {"Authorization": f"OAuth {token}"}
+    try:
+        resp = requests.post(
+            f"{YANDEX_DISK_API}/resources/move",
+            headers=headers,
+            params={"from": source, "path": target, "overwrite": str(overwrite).lower()},
+            timeout=30,
+        )
+        return resp.status_code in (201, 202)
+    except Exception:
+        return False
+
+
 def publish_resource(user, path: str) -> str:
     """Опубликовать ресурс и вернуть public_url (или пустую строку при ошибке)."""
     token = _get_token(user)

--- a/yandexdisk_app/tests.py
+++ b/yandexdisk_app/tests.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import call, patch
 from datetime import datetime, timezone as dt_timezone
 
 from django.contrib.auth import get_user_model
@@ -98,7 +98,7 @@ class WorkspacePublishingTests(TestCase):
 
     @patch("yandexdisk_app.workspace.publish_resource")
     @patch("yandexdisk_app.workspace.create_folder", return_value=True)
-    def test_basic_workspace_creation_does_not_publish_project_folder(self, _create_folder, publish_resource):
+    def test_basic_workspace_creation_does_not_publish_project_folder(self, create_folder, publish_resource):
         items = list(create_basic_project_workspace_stream(self.user, self.project))
 
         self.assertIsInstance(items[-1], WorkspaceResult)
@@ -107,6 +107,15 @@ class WorkspacePublishingTests(TestCase):
 
         workspace = ProjectWorkspace.objects.get(project=self.project)
         self.assertEqual(workspace.public_url, "")
+        expected_project_path = f"/Root/02 Проекты/2026/{self.project.short_uid} DD Проект Альфа"
+        self.assertEqual(workspace.disk_path, expected_project_path)
+        create_folder.assert_has_calls(
+            [
+                call(self.user, "/Root/02 Проекты"),
+                call(self.user, "/Root/02 Проекты/2026"),
+                call(self.user, expected_project_path),
+            ]
+        )
 
 
 class FolderSyncTests(TestCase):

--- a/yandexdisk_app/workspace.py
+++ b/yandexdisk_app/workspace.py
@@ -8,6 +8,7 @@ from typing import Optional
 from django.db import transaction
 
 from checklists_app.models import ChecklistItem, ChecklistItemFolder, ProjectWorkspace
+from core.cloud_paths import PROJECTS_SECTION_FOLDER, cloud_year_folder, join_cloud_path
 from projects_app.models import Performer, ProjectRegistration
 from yandexdisk_app.models import YandexDiskSelection
 from yandexdisk_app.service import create_folder, get_resource_info, publish_resource
@@ -72,6 +73,18 @@ def _build_project_folder_name(project: ProjectRegistration) -> str:
     return _resolve_workspace_folder_name(_build_project_label(project))
 
 
+def _build_projects_root_path(base: str) -> str:
+    return join_cloud_path(base, _sanitize(PROJECTS_SECTION_FOLDER))
+
+
+def _build_project_year_path(base: str, project: ProjectRegistration) -> str:
+    return join_cloud_path(_build_projects_root_path(base), _sanitize(cloud_year_folder(project.year)))
+
+
+def _build_project_workspace_path(base: str, project: ProjectRegistration) -> str:
+    return join_cloud_path(_build_project_year_path(base, project), _build_project_folder_name(project))
+
+
 def _build_section_folder_name(section) -> str:
     code = getattr(section, "code", "") or ""
     short_name = getattr(section, "short_name_ru", "") or getattr(section, "short_name", "")
@@ -100,13 +113,15 @@ def create_project_workspace(user, project: ProjectRegistration) -> WorkspaceRes
 
     base = selection.resource_path.rstrip("/")
 
-    year_str = str(project.year) if project.year else "Без года"
-    year_path = f"{base}/{_sanitize(year_str)}"
+    projects_root = _build_projects_root_path(base)
+    if not create_folder(user, projects_root):
+        return WorkspaceResult(False, f"Не удалось создать папку проектов: {projects_root}")
+
+    year_path = _build_project_year_path(base, project)
     if not create_folder(user, year_path):
         return WorkspaceResult(False, f"Не удалось создать папку года: {year_path}")
 
-    project_folder = _build_project_folder_name(project)
-    project_path = f"{year_path}/{project_folder}"
+    project_path = _build_project_workspace_path(base, project)
 
     info = get_resource_info(user, project_path)
     existing_ws = ProjectWorkspace.objects.filter(project=project).first()
@@ -269,19 +284,24 @@ def create_basic_project_workspace_stream(user, project: ProjectRegistration):
         else [_sanitize(n) for n in REGISTRATION_STANDARD_FOLDERS]
     )
 
-    total = 2 + len(folder_paths)  # year + project + sub-folders
+    total = 3 + len(folder_paths)  # section + year + project + sub-folders
     current = 0
 
-    year_str = str(project.year) if project.year else "Без года"
-    year_path = f"{base}/{_sanitize(year_str)}"
+    projects_root = _build_projects_root_path(base)
+    if not create_folder(user, projects_root):
+        yield WorkspaceResult(False, f"Не удалось создать папку проектов: {projects_root}")
+        return
+    current += 1
+    yield {"current": current, "total": total}
+
+    year_path = _build_project_year_path(base, project)
     if not create_folder(user, year_path):
         yield WorkspaceResult(False, f"Не удалось создать папку года: {year_path}")
         return
     current += 1
     yield {"current": current, "total": total}
 
-    project_folder = _build_project_folder_name(project)
-    project_path = f"{year_path}/{project_folder}"
+    project_path = _build_project_workspace_path(base, project)
 
     if not create_folder(user, project_path):
         yield WorkspaceResult(False, f"Не удалось создать папку проекта: {project_path}")
@@ -329,15 +349,14 @@ def _resolve_source_data_base(user, project: ProjectRegistration):
             False, "Не выбрана папка на Яндекс.Диске. Подключите Яндекс.Диск и выберите папку.")
 
     disk_root = selection.resource_path.rstrip("/")
-    year_str = str(project.year) if project.year else "Без года"
-    project_folder = _build_project_folder_name(project)
+    project_path = _build_project_workspace_path(disk_root, project)
 
     target_obj = SourceDataTargetFolder.objects.filter(user=user).first()
     target_folder = _sanitize_relative_path(
         target_obj.folder_name if target_obj else DEFAULT_SOURCE_DATA_FOLDER
     )
 
-    base_path = f"{disk_root}/{_sanitize(year_str)}/{project_folder}/{target_folder}"
+    base_path = join_cloud_path(project_path, target_folder)
     return base_path, None
 
 


### PR DESCRIPTION
## Summary
- Route new ТКП folders to `01 ТКП/<year>/...` and project workspaces, source data, and contract folders to `02 Проекты/<year>/...`.
- Add shared cloud path helpers plus Nextcloud WebDAV and Yandex.Disk move operations.
- Add `migrate_cloud_storage_structure` with dry-run/apply modes to move existing folders and update stored path fields.
- Update tests for Nextcloud, Yandex.Disk, projects, proposals, and migration behavior.
## Test plan
- `python3 manage.py test nextcloud_app yandexdisk_app projects_app proposals_app`
- `python3 manage.py test nextcloud_app.tests.CloudStorageStructureMigrationTests`