### PR TITLE
Update cloud storage folder structure

### DIFF
--- a/contracts_app/templates/contracts_app/contract_conclusion_section.html
+++ b/contracts_app/templates/contracts_app/contract_conclusion_section.html
@@ -165,9 +165,7 @@
       <div id="contract-request-actions"
            class="d-flex align-items-stretch gap-2 products-actions-row"
            data-request-url="{% url 'contract_request' %}"
-           data-create-contract-url="{% url 'create_contract_project' %}"
-           data-contract-target-url="{% url 'contract_project_target_folder_load' %}"
-           data-contract-target-save-url="{% url 'contract_project_target_folder_save' %}">
+           data-create-contract-url="{% url 'create_contract_project' %}">
         <div class="btn-group">
           <button type="button"
                   id="create-contract-btn"
@@ -212,14 +210,13 @@
               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
             </div>
             <div class="modal-body">
-              <label for="create-contract-target-select" class="form-label">
-                Выбор целевой папки:
-              </label>
-              <select id="create-contract-target-select" class="form-select"></select>
+              <p class="mb-0 text-muted">
+                Папки проектов договоров создаются автоматически в структуре
+                «02 Договоры / год проекта / проект / 02 Исполнители / исполнитель».
+              </p>
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-dismiss="modal">Отмена</button>
-              <button type="button" id="create-contract-target-save-btn" class="btn btn-primary btn-sm">Сохранить</button>
+              <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-dismiss="modal">Закрыть</button>
             </div>
           </div>
         </div>
@@ -233,7 +230,10 @@
               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
             </div>
             <div class="modal-body">
-              <p class="mb-3">На {{ primary_cloud_storage_label }} в целевой папке будут созданы папки исполнителей с проектами договоров.</p>
+              <p class="mb-3">
+                На {{ primary_cloud_storage_label }} будут созданы папки договоров в структуре
+                «02 Договоры / год проекта / проект / 02 Исполнители / исполнитель».
+              </p>
               <div id="create-contract-progress" class="d-none">
                 <div class="ws-progress-track">
                   <div class="ws-progress-fill" style="width:0%"></div>

--- a/contracts_app/tests.py
+++ b/contracts_app/tests.py
@@ -108,7 +108,7 @@ class ContractsCloudLabelTests(TestCase):
         self.assertContains(response, "Отправить проект договора")
         self.assertContains(
             response,
-            "На Nextcloud в целевой папке будут созданы папки исполнителей с проектами договоров.",
+            "На Nextcloud будут созданы папки договоров в структуре",
             html=False,
         )
         self.assertContains(response, 'id="contract-project-filter-toggle"', html=False)

--- a/core/cloud_paths.py
+++ b/core/cloud_paths.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 
 PROPOSALS_SECTION_FOLDER = "01 ТКП"
-PROJECTS_SECTION_FOLDER = "02 Проекты"
+CONTRACTS_SECTION_FOLDER = "02 Договоры"
+PROJECTS_SECTION_FOLDER = "03 Проекты"
+CONTRACTS_PERFORMERS_FOLDER = "02 Исполнители"
 LEGACY_PROPOSALS_SECTION_FOLDER = "ТКП"
+LEGACY_PROJECTS_SECTION_FOLDER = "02 Проекты"
 
 
 def normalize_cloud_path(path: str) -> str:

--- a/nextcloud_app/management/commands/migrate_cloud_storage_structure.py
+++ b/nextcloud_app/management/commands/migrate_cloud_storage_structure.py
@@ -14,6 +14,9 @@ from checklists_app.models import (
     SourceDataWorkspace,
 )
 from core.cloud_paths import (
+    CONTRACTS_PERFORMERS_FOLDER,
+    CONTRACTS_SECTION_FOLDER,
+    LEGACY_PROJECTS_SECTION_FOLDER,
     LEGACY_PROPOSALS_SECTION_FOLDER,
     PROJECTS_SECTION_FOLDER,
     PROPOSALS_SECTION_FOLDER,
@@ -56,7 +59,7 @@ PATH_FIELDS = (
 
 
 class Command(BaseCommand):
-    help = "Migrates cloud folder paths to the 01 ТКП / 02 Проекты structure."
+    help = "Migrates cloud folder paths to the 01 ТКП / 02 Договоры / 03 Проекты structure."
 
     def add_arguments(self, parser):
         parser.add_argument("--old-root", required=True, help="Current/legacy root path, for example /Projects.")
@@ -135,13 +138,24 @@ class Command(BaseCommand):
             if transformed != normalized:
                 return transformed
 
+        if field == "contract_project_disk_folder":
+            transformed = self._transform_contract_project_path(normalized, old_root, new_root)
+            if transformed != normalized:
+                return transformed
+
         legacy_tkp = join_cloud_path(old_root, LEGACY_PROPOSALS_SECTION_FOLDER)
         target_tkp = join_cloud_path(new_root, PROPOSALS_SECTION_FOLDER)
         transformed = replace_cloud_path_prefix(normalized, legacy_tkp, target_tkp)
         if transformed != normalized:
             return transformed
 
-        for section in (PROPOSALS_SECTION_FOLDER, PROJECTS_SECTION_FOLDER):
+        legacy_projects = join_cloud_path(old_root, LEGACY_PROJECTS_SECTION_FOLDER)
+        target_projects = join_cloud_path(new_root, PROJECTS_SECTION_FOLDER)
+        transformed = replace_cloud_path_prefix(normalized, legacy_projects, target_projects)
+        if transformed != normalized:
+            return transformed
+
+        for section in (PROPOSALS_SECTION_FOLDER, PROJECTS_SECTION_FOLDER, CONTRACTS_SECTION_FOLDER):
             transformed = replace_cloud_path_prefix(
                 normalized,
                 join_cloud_path(old_root, section),
@@ -159,6 +173,31 @@ class Command(BaseCommand):
             return join_cloud_path(new_root, PROJECTS_SECTION_FOLDER, relative)
         return normalized
 
+    def _transform_contract_project_path(self, normalized: str, old_root: str, new_root: str) -> str:
+        relative = self._relative_to_root(normalized, old_root)
+        if relative is None:
+            return normalized
+
+        parts = [part for part in relative.split("/") if part]
+        if parts and parts[0] in {LEGACY_PROJECTS_SECTION_FOLDER, PROJECTS_SECTION_FOLDER, CONTRACTS_SECTION_FOLDER}:
+            parts = parts[1:]
+
+        if len(parts) < 4:
+            return normalized
+
+        year, project_folder, _legacy_target_folder = parts[:3]
+        if not self._is_project_year_segment(year):
+            return normalized
+
+        return join_cloud_path(
+            new_root,
+            CONTRACTS_SECTION_FOLDER,
+            year,
+            project_folder,
+            CONTRACTS_PERFORMERS_FOLDER,
+            *parts[3:],
+        )
+
     def _collect_move_operations(
         self,
         changes: list[PathChange],
@@ -167,11 +206,16 @@ class Command(BaseCommand):
     ) -> list[MoveOperation]:
         operations: dict[tuple[str, str], MoveOperation] = {}
         for change in changes:
-            operation = self._move_operation_for_path(change.old_path, old_root, new_root)
-            if operation is None:
+            if not self._is_physical_path_field(change.field):
+                continue
+            operation = MoveOperation(
+                normalize_cloud_path(change.old_path),
+                normalize_cloud_path(change.new_path),
+            )
+            if operation.source_path == operation.target_path:
                 continue
             operations[(operation.source_path, operation.target_path)] = operation
-        return sorted(operations.values(), key=lambda item: item.source_path)
+        return self._prune_nested_move_operations(operations.values())
 
     def _move_operation_for_path(self, path: str, old_root: str, new_root: str) -> MoveOperation | None:
         normalized = normalize_cloud_path(path)
@@ -179,10 +223,14 @@ class Command(BaseCommand):
         if normalized == legacy_tkp or normalized.startswith(f"{legacy_tkp}/"):
             return MoveOperation(legacy_tkp, join_cloud_path(new_root, PROPOSALS_SECTION_FOLDER))
 
-        for section in (PROPOSALS_SECTION_FOLDER, PROJECTS_SECTION_FOLDER):
+        for section in (PROPOSALS_SECTION_FOLDER, PROJECTS_SECTION_FOLDER, CONTRACTS_SECTION_FOLDER):
             section_root = join_cloud_path(old_root, section)
             if normalized == section_root or normalized.startswith(f"{section_root}/"):
                 return MoveOperation(section_root, join_cloud_path(new_root, section))
+
+        legacy_projects = join_cloud_path(old_root, LEGACY_PROJECTS_SECTION_FOLDER)
+        if normalized == legacy_projects or normalized.startswith(f"{legacy_projects}/"):
+            return MoveOperation(legacy_projects, join_cloud_path(new_root, PROJECTS_SECTION_FOLDER))
 
         relative = self._relative_to_root(normalized, old_root)
         if relative is None:
@@ -250,6 +298,34 @@ class Command(BaseCommand):
     @staticmethod
     def _is_project_year_segment(value: str) -> bool:
         return value == "Без года" or value.isdigit()
+
+    @staticmethod
+    def _is_physical_path_field(field: str) -> bool:
+        return field != "proposal_workspace_target_path"
+
+    def _prune_nested_move_operations(self, operations) -> list[MoveOperation]:
+        selected: list[MoveOperation] = []
+        for operation in sorted(
+            operations,
+            key=lambda item: (self._path_depth(item.source_path), item.source_path),
+        ):
+            if any(self._operation_covers(parent, operation) for parent in selected):
+                continue
+            selected.append(operation)
+        return selected
+
+    @staticmethod
+    def _operation_covers(parent: MoveOperation, child: MoveOperation) -> bool:
+        if parent.source_path == child.source_path:
+            return True
+        if not child.source_path.startswith(f"{parent.source_path.rstrip('/')}/"):
+            return False
+        suffix = child.source_path[len(parent.source_path.rstrip("/")):]
+        return child.target_path == f"{parent.target_path.rstrip('/')}{suffix}"
+
+    @staticmethod
+    def _path_depth(path: str) -> int:
+        return len(normalize_cloud_path(path).strip("/").split("/"))
 
     @staticmethod
     def _relative_to_root(path: str, root: str) -> str | None:

--- a/nextcloud_app/tests.py
+++ b/nextcloud_app/tests.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.test import Client, TestCase, override_settings
 
+from contacts_app.models import PersonRecord
 from core.models import CloudStorageSettings
 from group_app.models import GroupMember
 from policy_app.models import Product
@@ -454,7 +455,18 @@ class NextcloudWorkspaceTests(TestCase):
             is_staff=True,
             is_active=True,
         )
-        Employee.objects.create(user=self.manager, patronymic="Иванович", role="Руководитель проектов")
+        self.manager_person = PersonRecord.objects.create(
+            last_name="Иванов",
+            first_name="Иван",
+            middle_name="Иванович",
+            position=1,
+        )
+        self.manager_employee = Employee.objects.create(
+            user=self.manager,
+            person_record=self.manager_person,
+            patronymic="Иванович",
+            role="Руководитель проектов",
+        )
         NextcloudUserLink.objects.create(
             user=self.manager,
             nextcloud_user_id=f"ncstaff-{self.manager.pk}",
@@ -481,11 +493,12 @@ class NextcloudWorkspaceTests(TestCase):
             name="Проект Nextcloud",
             year=2026,
             project_manager="Иванов Иван Иванович",
+            project_manager_prs_id=self.manager_person.formatted_id,
         )
 
     def test_create_basic_project_workspace_creates_folders_and_grants_editor_access(self):
         project_folder = _build_project_folder_name(self.project)
-        project_path = f"/Corporate Root/02 Проекты/2026/{project_folder}"
+        project_path = f"/Corporate Root/03 Проекты/2026/{project_folder}"
         client = Mock()
         client.is_configured = True
         client.username = "cloud-admin"
@@ -503,8 +516,8 @@ class NextcloudWorkspaceTests(TestCase):
         self.assertEqual(
             client.ensure_folder.call_args_list,
             [
-                call("cloud-admin", "/Corporate Root/02 Проекты"),
-                call("cloud-admin", "/Corporate Root/02 Проекты/2026"),
+                call("cloud-admin", "/Corporate Root/03 Проекты"),
+                call("cloud-admin", "/Corporate Root/03 Проекты/2026"),
                 call("cloud-admin", project_path),
                 call("cloud-admin", f"{project_path}/01 Документы"),
                 call("cloud-admin", f"{project_path}/01 Документы/02 Письма"),
@@ -526,7 +539,7 @@ class NextcloudWorkspaceTests(TestCase):
         settings_obj.save()
 
         project_folder = _build_project_folder_name(self.project)
-        project_path = f"/02 Проекты/2026/{project_folder}"
+        project_path = f"/03 Проекты/2026/{project_folder}"
         client = Mock()
         client.is_configured = True
         client.username = "cloud-admin"
@@ -545,12 +558,86 @@ class NextcloudWorkspaceTests(TestCase):
         self.assertEqual(
             client.ensure_folder.call_args_list,
             [
-                call("cloud-admin", "/02 Проекты"),
-                call("cloud-admin", "/02 Проекты/2026"),
+                call("cloud-admin", "/03 Проекты"),
+                call("cloud-admin", "/03 Проекты/2026"),
                 call("cloud-admin", project_path),
                 call("cloud-admin", f"{project_path}/01 Документы"),
                 call("cloud-admin", f"{project_path}/01 Документы/02 Письма"),
             ],
+        )
+
+    def test_create_basic_project_workspace_resolves_short_manager_label(self):
+        self.project.project_manager = "Иванов И.И."
+        self.project.project_manager_prs_id = ""
+        self.project.save(update_fields=["project_manager", "project_manager_prs_id"])
+        project_folder = _build_project_folder_name(self.project)
+        project_path = f"/Corporate Root/03 Проекты/2026/{project_folder}"
+        client = Mock()
+        client.is_configured = True
+        client.username = "cloud-admin"
+        client.ensure_folder.side_effect = lambda _owner, path: "/" + "/".join(
+            part for part in str(path).replace("\\", "/").split("/") if part
+        )
+        client.enable_user.return_value = None
+        client.set_user_email.return_value = None
+        client.set_user_display_name.return_value = None
+        client.ensure_user_share.return_value = Mock()
+        client.build_files_url.return_value = f"https://cloud.example.com/apps/files/files?dir={project_path}"
+
+        items = list(create_basic_project_workspace_stream(self.creator, self.project, client=client))
+
+        self.assertTrue(items[-1].ok)
+        client.ensure_user_share.assert_called_once_with(
+            "cloud-admin",
+            project_path,
+            f"ncstaff-{self.manager.pk}",
+            permissions=15,
+        )
+
+    def test_create_basic_project_workspace_uses_manager_prs_id_not_duplicate_name(self):
+        duplicate_user = User.objects.create_user(
+            username="duplicate-admin@example.com",
+            email="duplicate-admin@example.com",
+            password="Secret123!",
+            first_name="Иван",
+            last_name="Иванов",
+            is_staff=True,
+            is_active=True,
+        )
+        Employee.objects.create(
+            user=duplicate_user,
+            person_record=self.manager_person,
+            patronymic="Иванович",
+            role="Администратор",
+        )
+        NextcloudUserLink.objects.create(
+            user=duplicate_user,
+            nextcloud_user_id=f"ncstaff-{duplicate_user.pk}",
+            nextcloud_username=f"ncstaff-{duplicate_user.pk}",
+            nextcloud_email="duplicate-admin@example.com",
+        )
+        project_folder = _build_project_folder_name(self.project)
+        project_path = f"/Corporate Root/03 Проекты/2026/{project_folder}"
+        client = Mock()
+        client.is_configured = True
+        client.username = "cloud-admin"
+        client.ensure_folder.side_effect = lambda _owner, path: "/" + "/".join(
+            part for part in str(path).replace("\\", "/").split("/") if part
+        )
+        client.enable_user.return_value = None
+        client.set_user_email.return_value = None
+        client.set_user_display_name.return_value = None
+        client.ensure_user_share.return_value = Mock()
+        client.build_files_url.return_value = f"https://cloud.example.com/apps/files/files?dir={project_path}"
+
+        items = list(create_basic_project_workspace_stream(self.creator, self.project, client=client))
+
+        self.assertTrue(items[-1].ok)
+        client.ensure_user_share.assert_called_once_with(
+            "cloud-admin",
+            project_path,
+            f"ncstaff-{self.manager.pk}",
+            permissions=15,
         )
 
     def test_create_basic_project_workspace_returns_workspace_error_when_manager_sync_api_fails(self):
@@ -580,11 +667,11 @@ class NextcloudWorkspaceTests(TestCase):
             return "/" + "/".join(part for part in str(path).replace("\\", "/").split("/") if part)
         client.ensure_folder.side_effect = [
             NextcloudApiError("429 rate limit"),
-            "/Corporate Root/02 Проекты",
-            "/Corporate Root/02 Проекты/2026",
-            "/Corporate Root/02 Проекты/2026/Проект 6001 DD Проект Nextcloud",
-            "/Corporate Root/02 Проекты/2026/Проект 6001 DD Проект Nextcloud/01 Документы",
-            "/Corporate Root/02 Проекты/2026/Проект 6001 DD Проект Nextcloud/01 Документы/02 Письма",
+            "/Corporate Root/03 Проекты",
+            "/Corporate Root/03 Проекты/2026",
+            "/Corporate Root/03 Проекты/2026/Проект 6001 DD Проект Nextcloud",
+            "/Corporate Root/03 Проекты/2026/Проект 6001 DD Проект Nextcloud/01 Документы",
+            "/Corporate Root/03 Проекты/2026/Проект 6001 DD Проект Nextcloud/01 Документы/02 Письма",
         ]
         client.ensure_user_share.return_value = Mock()
         client.build_files_url.return_value = "https://cloud.example.com/apps/files/files?dir=/test"
@@ -784,8 +871,21 @@ class CloudStorageStructureMigrationTests(TestCase):
 
         output = out.getvalue()
         self.assertIn("DRY-RUN", output)
-        self.assertIn("MOVE /Corporate Root/ТКП -> /Corporate Root/01 ТКП", output)
-        self.assertIn("MOVE /Corporate Root/2026 -> /Corporate Root/02 Проекты/2026", output)
+        self.assertIn(
+            "MOVE /Corporate Root/ТКП/2026/333300RU DD Миграция ТКП -> "
+            "/Corporate Root/01 ТКП/2026/333300RU DD Миграция ТКП",
+            output,
+        )
+        self.assertIn(
+            f"MOVE /Corporate Root/2026/{self.project_folder} -> "
+            f"/Corporate Root/03 Проекты/2026/{self.project_folder}",
+            output,
+        )
+        self.assertIn(
+            f"MOVE /Corporate Root/2026/{self.project_folder}/09 Договоры/000 Иванов ИИ -> "
+            f"/Corporate Root/02 Договоры/2026/{self.project_folder}/02 Исполнители/000 Иванов ИИ",
+            output,
+        )
         self.proposal.refresh_from_db()
         self.assertEqual(
             self.proposal.proposal_workspace_disk_path,
@@ -824,8 +924,21 @@ class CloudStorageStructureMigrationTests(TestCase):
         )
 
         output = out.getvalue()
-        self.assertIn("MOVE /2026 -> /02 Проекты/2026", output)
-        self.assertIn("MOVE /ТКП -> /01 ТКП", output)
+        self.assertIn(
+            "MOVE /ТКП/2026/333300RU DD Миграция ТКП -> "
+            "/01 ТКП/2026/333300RU DD Миграция ТКП",
+            output,
+        )
+        self.assertIn(
+            f"MOVE /2026/{self.project_folder} -> "
+            f"/03 Проекты/2026/{self.project_folder}",
+            output,
+        )
+        self.assertIn(
+            f"MOVE /2026/{self.project_folder}/09 Договоры/000 Иванов ИИ -> "
+            f"/02 Договоры/2026/{self.project_folder}/02 Исполнители/000 Иванов ИИ",
+            output,
+        )
         self.assertIn(
             "proposals_app.ProposalRegistration"
             f"#{self.proposal.pk}.proposal_workspace_disk_path: "
@@ -837,7 +950,7 @@ class CloudStorageStructureMigrationTests(TestCase):
             "checklists_app.ProjectWorkspace"
             f"#{self.project.yadisk_workspace.pk}.disk_path: "
             f"/2026/{self.project_folder} -> "
-            f"/02 Проекты/2026/{self.project_folder}",
+            f"/03 Проекты/2026/{self.project_folder}",
             output,
         )
 
@@ -855,11 +968,28 @@ class CloudStorageStructureMigrationTests(TestCase):
 
         mocked_move.assert_has_calls(
             [
-                call("cloud-admin", "/Corporate Root/2026", "/Corporate Root/02 Проекты/2026", overwrite=False),
-                call("cloud-admin", "/Corporate Root/ТКП", "/Corporate Root/01 ТКП", overwrite=False),
+                call(
+                    "cloud-admin",
+                    f"/Corporate Root/2026/{self.project_folder}",
+                    f"/Corporate Root/03 Проекты/2026/{self.project_folder}",
+                    overwrite=False,
+                ),
+                call(
+                    "cloud-admin",
+                    "/Corporate Root/ТКП/2026/333300RU DD Миграция ТКП",
+                    "/Corporate Root/01 ТКП/2026/333300RU DD Миграция ТКП",
+                    overwrite=False,
+                ),
+                call(
+                    "cloud-admin",
+                    f"/Corporate Root/2026/{self.project_folder}/09 Договоры/000 Иванов ИИ",
+                    f"/Corporate Root/02 Договоры/2026/{self.project_folder}/02 Исполнители/000 Иванов ИИ",
+                    overwrite=False,
+                ),
             ],
             any_order=True,
         )
+        self.assertEqual(mocked_move.call_count, 3)
         self.proposal.refresh_from_db()
         self.assertEqual(
             self.proposal.proposal_workspace_disk_path,
@@ -872,12 +1002,12 @@ class CloudStorageStructureMigrationTests(TestCase):
         workspace = ProjectWorkspace.objects.get(project=self.project)
         self.assertEqual(
             workspace.disk_path,
-            f"/Corporate Root/02 Проекты/2026/{self.project_folder}",
+            f"/Corporate Root/03 Проекты/2026/{self.project_folder}",
         )
         self.performer.refresh_from_db()
         self.assertEqual(
             self.performer.contract_project_disk_folder,
-            f"/Corporate Root/02 Проекты/2026/{self.project_folder}/09 Договоры/000 Иванов ИИ",
+            f"/Corporate Root/02 Договоры/2026/{self.project_folder}/02 Исполнители/000 Иванов ИИ",
         )
 
 

--- a/nextcloud_app/workspace.py
+++ b/nextcloud_app/workspace.py
@@ -12,6 +12,7 @@ from core.cloud_paths import (
     cloud_year_folder,
 )
 from core.cloud_storage import get_nextcloud_root_path, get_primary_cloud_storage_label
+from policy_app.models import DIRECTION_DIRECTOR_GROUP, PROJECTS_HEAD_GROUP
 from users_app.models import Employee
 from yandexdisk_app.workspace import (
     DEFAULT_SOURCE_DATA_FOLDER,
@@ -41,6 +42,7 @@ _LINK_RETRY_WAIT_BASE = 30.0
 _LINK_RETRY_WAIT_MAX = 35.0
 
 _HEARTBEAT_INTERVAL = 2.0
+_PROJECT_MANAGER_ROLES = (PROJECTS_HEAD_GROUP, DIRECTION_DIRECTOR_GROUP)
 
 
 def _heartbeat_sleep(seconds, progress, total):
@@ -416,20 +418,29 @@ def _resolve_project_manager_nextcloud_link(
     *,
     client: NextcloudApiClient,
 ) -> NextcloudUserLink | None:
-    manager_name = (project.project_manager or "").strip()
-    if not manager_name:
+    manager_prs_id = _normalize_person_lookup(getattr(project, "project_manager_prs_id", "") or "")
+    manager_name = _normalize_person_lookup(getattr(project, "project_manager", "") or "")
+    if not manager_prs_id and not manager_name:
         return None
 
     match = None
-    for employee in (
+    employees = (
         Employee.objects
-        .select_related("user")
-        .filter(user__is_active=True, user__is_staff=True)
+        .select_related("user", "person_record")
+        .filter(user__is_active=True, user__is_staff=True, role__in=_PROJECT_MANAGER_ROLES)
         .order_by("user__last_name", "user__first_name", "patronymic", "id")
-    ):
-        if _employee_full_name(employee) == manager_name:
-            match = employee
-            break
+    )
+    if manager_prs_id:
+        for employee in employees:
+            if manager_prs_id == _normalize_person_lookup(_employee_prs_id(employee)):
+                match = employee
+                break
+
+    if match is None and manager_name:
+        for employee in employees:
+            if manager_name in _employee_lookup_values(employee):
+                match = employee
+                break
     if match is None:
         return None
 
@@ -453,6 +464,35 @@ def _employee_full_name(employee: Employee) -> str:
         (employee.patronymic or "").strip(),
     ]
     return " ".join(part for part in parts if part).strip()
+
+
+def _employee_short_name(employee: Employee, *, dots: bool = True) -> str:
+    last_name = (employee.user.last_name or "").strip()
+    initials = []
+    for value in ((employee.user.first_name or "").strip(), (employee.patronymic or "").strip()):
+        if value:
+            initials.append(f"{value[0]}." if dots else value[0])
+    return " ".join(part for part in (last_name, "".join(initials)) if part).strip()
+
+
+def _employee_prs_id(employee: Employee) -> str:
+    return (getattr(employee, "formatted_prs_id", "") or "").strip()
+
+
+def _employee_lookup_values(employee: Employee) -> set[str]:
+    values = {
+        _employee_prs_id(employee),
+        _employee_full_name(employee),
+        _employee_short_name(employee),
+        _employee_short_name(employee, dots=False),
+        (employee.user.email or "").strip(),
+        (employee.user.username or "").strip(),
+    }
+    return {_normalize_person_lookup(value) for value in values if value}
+
+
+def _normalize_person_lookup(value: str) -> str:
+    return " ".join(str(value or "").replace("\xa0", " ").split()).casefold()
 
 
 def _resolve_nextcloud_source_data_base(user, project):

--- a/projects_app/forms.py
+++ b/projects_app/forms.py
@@ -66,10 +66,14 @@ def _employee_full_name(employee):
     return " ".join(part for part in parts if part).strip()
 
 
+def _employee_prs_id(employee):
+    return (getattr(employee, "formatted_prs_id", "") or "").strip()
+
+
 def _project_manager_queryset():
     return (
         Employee.objects
-        .select_related("user")
+        .select_related("user", "person_record")
         .filter(role__in=PROJECT_MANAGER_ROLES)
         .order_by("user__last_name", "user__first_name", "patronymic", "position", "id")
     )
@@ -83,7 +87,7 @@ def _employee_queryset():
     )
 
 
-def _employee_choices(queryset, current_value="", *, include_missing_current=True):
+def _employee_choices(queryset, current_value="", *, include_missing_current=True, use_prs_value=False, show_prs_label=False):
     choices = [("", "— Не выбрано —")]
     current_value = (current_value or "").strip()
     current_in_choices = False
@@ -92,8 +96,11 @@ def _employee_choices(queryset, current_value="", *, include_missing_current=Tru
         full_name = _employee_full_name(employee)
         if not full_name:
             continue
-        choices.append((full_name, full_name))
-        if full_name == current_value:
+        prs_id = _employee_prs_id(employee)
+        value = (prs_id if use_prs_value else "") or full_name
+        label = f"{full_name} ({prs_id})" if show_prs_label and prs_id else full_name
+        choices.append((value, label))
+        if current_value in {value, full_name, prs_id}:
             current_in_choices = True
 
     if include_missing_current and current_value and not current_in_choices:
@@ -103,7 +110,28 @@ def _employee_choices(queryset, current_value="", *, include_missing_current=Tru
 
 
 def _project_manager_choices(current_value=""):
-    return _employee_choices(_project_manager_queryset(), current_value)
+    return _employee_choices(
+        _project_manager_queryset(),
+        current_value,
+        use_prs_value=True,
+        show_prs_label=True,
+    )
+
+
+def _resolve_project_manager_choice(value):
+    raw = (value or "").strip()
+    if not raw:
+        return "", ""
+
+    employees = list(_project_manager_queryset())
+    normalized = " ".join(raw.replace("\xa0", " ").split()).casefold()
+    for employee in employees:
+        if _employee_prs_id(employee).casefold() == normalized:
+            return _employee_full_name(employee), _employee_prs_id(employee)
+    for employee in employees:
+        if _employee_full_name(employee).casefold() == normalized:
+            return _employee_full_name(employee), _employee_prs_id(employee)
+    return raw, ""
 
 
 def _typical_section_specialty_ids(typical_section_id):
@@ -227,11 +255,22 @@ class ProjectRegistrationForm(BootstrapMixin, forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         current_group_member = self.data.get("group_member") or (self.instance.group_member_id if self.instance else "")
-        current_manager = self.data.get("project_manager") or (self.instance.project_manager if self.instance else "")
+        if self.data:
+            current_manager = self.data.get("project_manager") or ""
+        else:
+            instance_manager = self.instance.project_manager if self.instance else ""
+            _manager_name, resolved_manager_prs_id = _resolve_project_manager_choice(instance_manager)
+            current_manager = (
+                (self.instance.project_manager_prs_id if self.instance else "")
+                or resolved_manager_prs_id
+                or instance_manager
+            )
         self.fields["group_member"].queryset = _group_choices(current_group_member)
         self.fields["group_member"].label_from_instance = lambda obj: obj.group_display_label
         self.fields["group_member"].empty_label = "— Не выбрано —"
         self.fields["project_manager"].choices = _project_manager_choices(current_manager)
+        if not self.data:
+            self.fields["project_manager"].initial = current_manager
 
         today = timezone.now().date()
         country_qs = OKSMCountry.objects.filter(
@@ -273,7 +312,17 @@ class ProjectRegistrationForm(BootstrapMixin, forms.ModelForm):
         return member
 
     def clean_project_manager(self):
-        return (self.cleaned_data.get("project_manager") or "").strip()
+        manager_name, manager_prs_id = _resolve_project_manager_choice(self.cleaned_data.get("project_manager"))
+        self._cleaned_project_manager_prs_id = manager_prs_id
+        return manager_name
+
+    def save(self, commit=True):
+        instance = super().save(commit=False)
+        instance.project_manager_prs_id = getattr(self, "_cleaned_project_manager_prs_id", "") or ""
+        if commit:
+            instance.save()
+            self.save_m2m()
+        return instance
 
     def clean(self):
         cleaned_data = super().clean()
@@ -486,7 +535,12 @@ class WorkVolumeForm(BootstrapMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        current_manager = self.data.get("manager") or (self.instance.manager if self.instance else "")
+        if self.data:
+            current_manager = self.data.get("manager") or ""
+        else:
+            instance_manager = self.instance.manager if self.instance else ""
+            _manager_name, resolved_manager_prs_id = _resolve_project_manager_choice(instance_manager)
+            current_manager = resolved_manager_prs_id or instance_manager
         self.fields["manager"].choices = _project_manager_choices(current_manager)
 
         today = timezone.now().date()
@@ -498,11 +552,20 @@ class WorkVolumeForm(BootstrapMixin, forms.ModelForm):
         self.fields["country"].queryset = country_qs
         self.fields["country"].label_from_instance = lambda obj: obj.short_name
         if not self.data and not current_manager and getattr(self.instance, "project_id", None):
-            self.fields["manager"].initial = self.instance.project.project_manager or ""
+            _project_manager_name, project_manager_prs_id = _resolve_project_manager_choice(
+                self.instance.project.project_manager or ""
+            )
+            self.fields["manager"].initial = project_manager_prs_id or self.instance.project.project_manager or ""
+        elif not self.data and current_manager:
+            self.fields["manager"].initial = current_manager
         if not self.data and getattr(self.instance, "project_id", None):
             self.fields["type"].initial = getattr(self.instance.project, "type_short_display", "") or ""
             self.fields["name"].initial = self.instance.project.name or ""
         self._bootstrapify()
+
+    def clean_manager(self):
+        manager_name, _manager_prs_id = _resolve_project_manager_choice(self.cleaned_data.get("manager"))
+        return manager_name
 
     def save(self, commit=True):
         instance = super().save(commit=False)

--- a/projects_app/migrations/0054_projectregistration_project_manager_prs_id.py
+++ b/projects_app/migrations/0054_projectregistration_project_manager_prs_id.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("projects_app", "0053_remove_project_registration_identity_unique"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="projectregistration",
+            name="project_manager_prs_id",
+            field=models.CharField(blank=True, default="", max_length=32, verbose_name="ID-PRS руководителя проекта"),
+        ),
+    ]

--- a/projects_app/models.py
+++ b/projects_app/models.py
@@ -129,6 +129,7 @@ class ProjectRegistration(models.Model):
     registration_number = models.CharField("Регистрационный номер", max_length=100, blank=True)
     registration_date = models.DateField("Дата регистрации", null=True, blank=True)
     project_manager = models.CharField("Руководитель проекта", max_length=255, blank=True)
+    project_manager_prs_id = models.CharField("ID-PRS руководителя проекта", max_length=32, blank=True, default="")
     contract_subject = models.TextField("Предмет договора", blank=True)
 
     class Meta:

--- a/projects_app/tests.py
+++ b/projects_app/tests.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 
 from checklists_app.models import ChecklistItem, SourceDataItemFolder, SourceDataSectionFolder, SourceDataWorkspace
 from classifiers_app.models import BusinessEntityIdentifierRecord, BusinessEntityRecord, LegalEntityRecord, OKSMCountry
+from contacts_app.models import PersonRecord
 from core.models import CloudStorageSettings
 from contracts_app.models import ContractTemplate
 from nextcloud_app.models import NextcloudUserLink
@@ -23,7 +24,6 @@ from policy_app.models import (
 )
 from experts_app.models import ExpertProfile, ExpertProfileSpecialty, ExpertSpecialty
 from projects_app.models import (
-    ContractProjectTargetFolder,
     LegalEntity,
     Performer,
     ProjectRegistration,
@@ -313,13 +313,66 @@ class ProjectRegistrationFormTests(TestCase):
             role=EXPERT_GROUP,
         )
 
-        registration_choices = [value for value, _label in ProjectRegistrationForm().fields["project_manager"].choices]
-        work_choices = [value for value, _label in WorkVolumeForm().fields["manager"].choices]
+        registration_choices = [label for _value, label in ProjectRegistrationForm().fields["project_manager"].choices]
+        work_choices = [label for _value, label in WorkVolumeForm().fields["manager"].choices]
 
         for choices in (registration_choices, work_choices):
-            self.assertIn("Проектов Иван Иванович", choices)
-            self.assertIn("Директорова Дарья Дмитриевна", choices)
-            self.assertNotIn("Экспертов Егор Егорович", choices)
+            self.assertTrue(any(label.startswith("Проектов Иван Иванович") for label in choices))
+            self.assertTrue(any(label.startswith("Директорова Дарья Дмитриевна") for label in choices))
+            self.assertFalse(any(label.startswith("Экспертов Егор Егорович") for label in choices))
+
+    def test_project_manager_form_saves_selected_prs_id(self):
+        person = PersonRecord.objects.create(
+            last_name="Иванов",
+            first_name="Иван",
+            middle_name="Иванович",
+            position=1,
+        )
+        user = get_user_model().objects.create_user(
+            username="project-manager-prs",
+            first_name="Иван",
+            last_name="Иванов",
+            is_staff=True,
+        )
+        Employee.objects.create(
+            user=user,
+            person_record=person,
+            patronymic="Иванович",
+            role=PROJECTS_HEAD_GROUP,
+        )
+        group_member = GroupMember.objects.create(
+            short_name="IMCM",
+            country_name="Россия",
+            country_alpha2="RU",
+        )
+        product = Product.objects.create(short_name="PRS-DD", name_en="Due Diligence PRS", name_ru="ДД PRS")
+
+        choices = dict(ProjectRegistrationForm().fields["project_manager"].choices)
+        self.assertEqual(choices[person.formatted_id], f"Иванов Иван Иванович ({person.formatted_id})")
+
+        form = ProjectRegistrationForm(
+            data={
+                "number": "6201",
+                "group_member": str(group_member.pk),
+                "agreement_type": ProjectRegistration.AgreementType.MAIN,
+                "name": "Проект с руководителем",
+                "status": "Не начат",
+                "deadline": "2026-05-01",
+                "year": "2026",
+                "country": "",
+                "customer": "",
+                "identifier": "",
+                "registration_number": "",
+                "registration_date": "",
+                "project_manager": person.formatted_id,
+                "type_id": str(product.pk),
+            }
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        obj = form.save(commit=False)
+        self.assertEqual(obj.project_manager, "Иванов Иван Иванович")
+        self.assertEqual(obj.project_manager_prs_id, person.formatted_id)
 
 
 class PerformerFormExecutorFilteringTests(TestCase):
@@ -1212,7 +1265,7 @@ class NextcloudSourceDataWorkspaceFlowTests(TestCase):
         mocked_public_share,
     ):
         expected_project_folder = f"{self.project.short_uid} DD Исходные данные"
-        base_path = f"/Corporate Root/02 Проекты/2026/{expected_project_folder}/05 Исходные данные/01 Запросы"
+        base_path = f"/Corporate Root/03 Проекты/2026/{expected_project_folder}/05 Исходные данные/01 Запросы"
         section_path = f"{base_path}/01 FIN Финансы"
         item_path = f"{section_path}/REQ-01 ОСВ"
         mocked_ensure_folder.side_effect = [section_path, item_path]
@@ -1313,7 +1366,6 @@ class NextcloudContractProjectFlowTests(TestCase):
             employee=self.employee,
             executor="Иванов Иван Иванович",
         )
-        ContractProjectTargetFolder.objects.create(user=self.user, folder_name="09 Договоры")
         self.template = ContractTemplate.objects.create(
             product=self.product,
             contract_type="gph",
@@ -1346,7 +1398,7 @@ class NextcloudContractProjectFlowTests(TestCase):
     @patch("nextcloud_app.api.NextcloudApiClient.ensure_user_share")
     @patch("nextcloud_app.api.NextcloudApiClient.ensure_public_link_share", return_value="https://cloud.example.com/s/public-doc")
     @patch("nextcloud_app.api.NextcloudApiClient.upload_file", return_value=True)
-    @patch("nextcloud_app.api.NextcloudApiClient.ensure_folder", return_value="/Corporate Root/02 Проекты/2026/5002 DD Контрактный проект/09 Договоры/000 Иванов ИИ")
+    @patch("nextcloud_app.api.NextcloudApiClient.ensure_folder", return_value="/Corporate Root/02 Договоры/2026/5002 DD Контрактный проект/02 Исполнители/000 Иванов ИИ")
     @patch("nextcloud_app.api.NextcloudApiClient.list_resources", return_value=[])
     def test_create_contract_project_uses_nextcloud_and_stores_public_link(
         self,
@@ -1372,12 +1424,21 @@ class NextcloudContractProjectFlowTests(TestCase):
 
         self.performer.refresh_from_db()
         expected_project_folder = f"{self.project.short_uid} DD Контрактный проект"
-        expected_base_path = f"/Corporate Root/02 Проекты/2026/{expected_project_folder}/09 Договоры"
+        expected_base_path = f"/Corporate Root/02 Договоры/2026/{expected_project_folder}/02 Исполнители"
         expected_folder_path = f"{expected_base_path}/000 Иванов ИИ"
         expected_upload_path = f"{expected_folder_path}/Договор 5002_Иванов ИИ.docx"
 
         mocked_list_resources.assert_called_once_with("cloud-admin", expected_base_path, limit=1000)
-        mocked_ensure_folder.assert_called_once_with("cloud-admin", expected_folder_path)
+        mocked_ensure_folder.assert_has_calls(
+            [
+                call("cloud-admin", "/Corporate Root"),
+                call("cloud-admin", "/Corporate Root/02 Договоры"),
+                call("cloud-admin", "/Corporate Root/02 Договоры/2026"),
+                call("cloud-admin", f"/Corporate Root/02 Договоры/2026/{expected_project_folder}"),
+                call("cloud-admin", expected_base_path),
+                call("cloud-admin", expected_folder_path),
+            ]
+        )
         mocked_upload_file.assert_called_once()
         self.assertEqual(mocked_upload_file.call_args.args[0], "cloud-admin")
         self.assertEqual(mocked_upload_file.call_args.args[1], expected_upload_path)

--- a/projects_app/views.py
+++ b/projects_app/views.py
@@ -48,7 +48,12 @@ from core.cloud_storage import (
     sanitize_folder_name,
     upload_file as cloud_upload_file,
 )
-from core.cloud_paths import PROJECTS_SECTION_FOLDER, join_cloud_path
+from core.cloud_paths import (
+    CONTRACTS_PERFORMERS_FOLDER,
+    CONTRACTS_SECTION_FOLDER,
+    join_cloud_path,
+    normalize_cloud_path,
+)
 from policy_app.models import (
     DEPARTMENT_HEAD_GROUP,
     DIRECTION_DIRECTOR_GROUP,
@@ -540,7 +545,7 @@ def work_deps(request):
         "type": reg.type_short_display,
         "type_short": reg.type_short_display,
         "name": reg.name or "",
-        "project_manager": reg.project_manager or "",
+        "project_manager": reg.project_manager_prs_id or reg.project_manager or "",
         "country_id": reg.country_id or "",
     })
 
@@ -2244,7 +2249,6 @@ def create_contract_project(request):
     progress updates.
     """
     import re
-    from .models import ContractProjectTargetFolder
     from contracts_app.models import ContractTemplate, ContractVariable
     from contracts_app.variable_resolver import resolve_variables
     from contracts_app.docx_processor import process_template
@@ -2277,10 +2281,6 @@ def create_contract_project(request):
         return JsonResponse({"ok": False, "error": str(exc)}, status=400)
     if not disk_root:
         return JsonResponse({"ok": False, "error": "Не выбрана папка в основном облачном хранилище."}, status=400)
-
-    target_obj = ContractProjectTargetFolder.objects.filter(user=request.user).first()
-    if not target_obj or not target_obj.folder_name:
-        return JsonResponse({"ok": False, "error": "Не выбрана целевая папка в настройках."}, status=400)
 
     all_templates = list(
         ContractTemplate.objects
@@ -2325,6 +2325,17 @@ def create_contract_project(request):
         executor_name = _executor_short(perf.executor)
         ext = os.path.splitext(original_name or "")[1] or ".docx"
         return sanitize_folder_name(f"Договор {project_prefix}_{executor_name}{ext}")
+
+    def _ensure_cloud_folder_path(path):
+        normalized = normalize_cloud_path(path)
+        if normalized == "/":
+            return True
+        current = ""
+        for part in normalized.strip("/").split("/"):
+            current = f"{current}/{part}" if current else f"/{part}"
+            if not cloud_create_folder(request.user, current):
+                return False
+        return True
 
     def _find_template(perf):
         """Find the best matching ContractTemplate for a Performer row."""
@@ -2437,14 +2448,19 @@ def create_contract_project(request):
                 project = perf.registration
                 year_str = sanitize_folder_name(str(project.year) if project.year else "Без года")
                 project_folder = build_project_folder_name(project)
-                target_folder = sanitize_folder_name(target_obj.folder_name)
                 base_path = join_cloud_path(
                     disk_root,
-                    PROJECTS_SECTION_FOLDER,
+                    CONTRACTS_SECTION_FOLDER,
                     year_str,
                     project_folder,
-                    target_folder,
+                    CONTRACTS_PERFORMERS_FOLDER,
                 )
+
+                if not _ensure_cloud_folder_path(base_path):
+                    errors.append(base_path)
+                    current += 1
+                    yield _padded(json.dumps({"current": current, "total": total}) + "\n")
+                    continue
 
                 existing = list_folder_resources(request.user, base_path, limit=1000)
                 next_number = 0

--- a/yandexdisk_app/tests.py
+++ b/yandexdisk_app/tests.py
@@ -107,12 +107,12 @@ class WorkspacePublishingTests(TestCase):
 
         workspace = ProjectWorkspace.objects.get(project=self.project)
         self.assertEqual(workspace.public_url, "")
-        expected_project_path = f"/Root/02 Проекты/2026/{self.project.short_uid} DD Проект Альфа"
+        expected_project_path = f"/Root/03 Проекты/2026/{self.project.short_uid} DD Проект Альфа"
         self.assertEqual(workspace.disk_path, expected_project_path)
         create_folder.assert_has_calls(
             [
-                call(self.user, "/Root/02 Проекты"),
-                call(self.user, "/Root/02 Проекты/2026"),
+                call(self.user, "/Root/03 Проекты"),
+                call(self.user, "/Root/03 Проекты/2026"),
                 call(self.user, expected_project_path),
             ]
         )


### PR DESCRIPTION
## Summary
- Update cloud storage roots to `01 ТКП`, `02 Договоры`, and `03 Проекты`.
- Store project manager `ID-PRS` and grant Nextcloud editor access by `ID-PRS` for project workspaces.
- Move contract draft generation to `02 Договоры/<year>/<project>/02 Исполнители/<executor>` and update migration/tests.
## Test plan
- Ran targeted Django tests for Nextcloud/Yandex workspaces, contract draft creation, contract links, and cloud structure migration.
- Verified `makemigrations --check --dry-run`.