### PR TITLE
Fix contract document generation and PDF signing flow

### DIFF
--- a/contracts_app/tests.py
+++ b/contracts_app/tests.py
@@ -197,6 +197,31 @@ class ContractsCloudLabelTests(TestCase):
         self.assertIn("https://cloud.example.com/s/contract-pdf", signing_section)
         self.assertIn("Договор 7001_Иванов ИИ.pdf", signing_section)
 
+    def test_contract_docx_source_is_available_to_onlyoffice_without_session(self):
+        from projects_app.views import _build_contract_docx_source_token
+
+        self.client.logout()
+        token = _build_contract_docx_source_token(self.performer)
+
+        with patch(
+            "projects_app.views.cloud_download_file",
+            return_value=(
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                b"docx-bytes",
+            ),
+        ):
+            response = self.client.get(
+                reverse("contract_onlyoffice_docx_source", args=[self.performer.pk]),
+                {"token": token},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"docx-bytes")
+        self.assertEqual(
+            response["Content-Type"],
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+
     @override_settings(ONLYOFFICE_DOCUMENT_SERVER_URL="https://docs.example.com")
     def test_sign_contract_documents_generates_pdf_and_public_link(self):
         with (

--- a/group_app/tests.py
+++ b/group_app/tests.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
@@ -129,5 +130,19 @@ class GroupMemberSealTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("attachment;", response["Content-Disposition"])
+        self.assertIn("seal.png", response["Content-Disposition"])
+        self.assertEqual(b"".join(response.streaming_content), b"seal-data")
+
+    def test_member_seal_download_uses_storage_open_without_filesystem_path(self):
+        self.member.seal_file = "group/seals/1/seal.png"
+        self.member.save(update_fields=["seal_file"])
+        file_obj = MagicMock()
+        file_obj.read.side_effect = [b"seal-data", b""]
+        file_obj.close = MagicMock()
+        with patch.object(self.member.seal_file.storage, "open", return_value=file_obj) as mocked_open:
+            response = self.client.get(reverse("gm_seal_download", args=[self.member.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        mocked_open.assert_called_once_with(self.member.seal_file.name, "rb")
         self.assertIn("seal.png", response["Content-Disposition"])
         self.assertEqual(b"".join(response.streaming_content), b"seal-data")

--- a/group_app/views.py
+++ b/group_app/views.py
@@ -182,13 +182,14 @@ def member_seal_download(request, pk: int):
     member = get_object_or_404(GroupMember, pk=pk)
     if not member.seal_file:
         raise Http404("Файл не найден")
-    file_path = member.seal_file.path
-    if not os.path.isfile(file_path):
-        raise Http404("Файл не найден на диске")
     from urllib.parse import quote
 
-    basename = os.path.basename(file_path)
-    response = FileResponse(open(file_path, "rb"), content_type="application/octet-stream")
+    basename = os.path.basename(member.seal_file.name)
+    try:
+        file_handle = member.seal_file.open("rb")
+    except Exception as exc:
+        raise Http404("Файл не найден") from exc
+    response = FileResponse(file_handle, content_type="application/octet-stream")
     response["Content-Disposition"] = f"attachment; filename*=UTF-8''{quote(basename)}"
     return response
 

--- a/projects_app/tests.py
+++ b/projects_app/tests.py
@@ -1569,12 +1569,18 @@ class NextcloudContractProjectFlowTests(TestCase):
         self.performer.contract_project_disk_folder = existing_folder_path
         self.performer.contract_project_folder_link = "https://cloud.example.com/s/existing-folder"
         self.performer.contract_project_folder_file_id = "folder-file-id"
+        self.performer.contract_pdf_file = "old-contract.pdf"
+        self.performer.contract_pdf_link = "https://cloud.example.com/s/old-pdf"
+        self.performer.contract_pdf_file_id = "old-pdf-id"
         self.performer.save(update_fields=[
             "contract_batch_id",
             "contract_project_created",
             "contract_project_disk_folder",
             "contract_project_folder_link",
             "contract_project_folder_file_id",
+            "contract_pdf_file",
+            "contract_pdf_link",
+            "contract_pdf_file_id",
         ])
         mocked_ensure_nextcloud_account.side_effect = lambda user, client=None: (
             self.executor_link if user.pk == self.recipient_user.pk else self.lawyer_link
@@ -1600,6 +1606,9 @@ class NextcloudContractProjectFlowTests(TestCase):
         self.performer.refresh_from_db()
         self.assertEqual(self.performer.contract_batch_id, existing_batch_id)
         self.assertEqual(self.performer.contract_project_disk_folder, existing_folder_path)
+        self.assertEqual(self.performer.contract_pdf_file, "")
+        self.assertEqual(self.performer.contract_pdf_link, "")
+        self.assertEqual(self.performer.contract_pdf_file_id, "")
 
     @patch("nextcloud_app.provisioning.ensure_nextcloud_account")
     @patch("contracts_app.variable_resolver.resolve_variables", return_value=({}, {}))

--- a/projects_app/views.py
+++ b/projects_app/views.py
@@ -3075,7 +3075,12 @@ def create_contract_project(request):
                         if not cloud_upload_file(request.user, upload_path, file_data):
                             errors.append(f"Загрузка файла: {upload_name} → {folder_name}")
                         else:
-                            file_update_kwargs = {"contract_file": upload_name}
+                            file_update_kwargs = {
+                                "contract_file": upload_name,
+                                "contract_pdf_file": "",
+                                "contract_pdf_link": "",
+                                "contract_pdf_file_id": "",
+                            }
                             file_id = _resolve_contract_project_nextcloud_file_id(upload_path)
                             if file_id:
                                 file_update_kwargs["contract_project_file_id"] = file_id

--- a/settings/base.py
+++ b/settings/base.py
@@ -219,6 +219,7 @@ ENFORCE_LOGIN_EXEMPT = (
     "/checklists/shared/",
     "/media/",
     "/proposals/docx-source/",
+    "/projects/performers/contract-docx-source/",
     "/o/authorize/",
     "/o/token/",
     "/o/revoke_token/",


### PR DESCRIPTION
## Summary
- Fixed contract PDF generation so ONLYOFFICE can access the signed DOCX source without being redirected to login.
- Updated contract/project document generation logic and related tests.
- Updated group document handling logic and related tests.
## Test plan
- Targeted Django tests for contract PDF generation/source access passed locally.
- CI/CD should run full test suite on this PR.