### PR TITLE
Update contract deadline and CI/CD validation changes

### DIFF
--- a/contracts_app/migrations/0028_update_deadline_ru_description.py
+++ b/contracts_app/migrations/0028_update_deadline_ru_description.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+
+def update_deadline_ru_description(apps, schema_editor):
+    ContractVariable = apps.get_model("contracts_app", "ContractVariable")
+    ContractVariable.objects.filter(key="{{deadline_ru}}").update(
+        description="Позднейший дедлайн разделов исполнителя из графика проекта в формате «дд месяц гггг г.»"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("contracts_app", "0027_contractreturncomment"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_deadline_ru_description, migrations.RunPython.noop),
+    ]

--- a/contracts_app/tests.py
+++ b/contracts_app/tests.py
@@ -2025,6 +2025,79 @@ class ContractVariableResolverTests(TestCase):
         self.assertEqual(replacements["{{day}}"], "07")
         self.assertEqual(replacements["{{month}}"], "мая")
 
+    def test_deadline_ru_uses_latest_gantt_deadline_for_performer_batch(self):
+        product = Product.objects.create(
+            short_name="DD",
+            name_en="Due Diligence",
+            name_ru="ДД",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+        )
+        project = ProjectRegistration.objects.create(
+            number=7005,
+            type=product,
+            name="Проект с дедлайнами графика",
+            deadline=date(2030, 1, 1),
+            year=2026,
+        )
+        performer_a = Performer.objects.create(
+            registration=project,
+            executor="Иванов Иван Иванович",
+            asset_name="Карьер",
+        )
+        performer_b = Performer.objects.create(
+            registration=project,
+            executor="Иванов Иван Иванович",
+            asset_name="Фабрика",
+        )
+        unrelated_performer = Performer.objects.create(
+            registration=project,
+            executor="Петров Петр Петрович",
+            asset_name="Фабрика",
+        )
+        project.gantt_data = {
+            "data": [
+                {
+                    "id": f"managed-performer-{performer_a.pk}",
+                    "managed_source": "performer",
+                    "performer_id": performer_a.pk,
+                    "asset_name": "Карьер",
+                    "deadline": "2026-05-12",
+                },
+                {
+                    "id": f"managed-performer-{performer_b.pk}",
+                    "managed_source": "performer",
+                    "performer_id": performer_b.pk,
+                    "asset_name": "Фабрика",
+                    "deadline": "2026-05-20",
+                },
+                {
+                    "id": f"managed-performer-{unrelated_performer.pk}",
+                    "managed_source": "performer",
+                    "performer_id": unrelated_performer.pk,
+                    "asset_name": "Фабрика",
+                    "deadline": "2026-06-30",
+                },
+            ],
+            "links": [],
+            "meta": {},
+        }
+        project.save(update_fields=["gantt_data"])
+        project.refresh_from_db()
+        performer_a.registration = project
+        performer_b.registration = project
+        variables = [ContractVariable(key="{{deadline_ru}}", is_computed=True)]
+
+        replacements, lists = resolve_variables(
+            performer_a,
+            variables,
+            all_performers=[performer_a, performer_b],
+        )
+
+        self.assertEqual(lists, {})
+        self.assertEqual(replacements["{{deadline_ru}}"], "20 мая 2026 г.")
+
     def test_contacts_short_name_falls_back_to_performer_employee_person_record(self):
         user = get_user_model().objects.create_user(
             username="resolver-performer-person",

--- a/contracts_app/variable_resolver.py
+++ b/contracts_app/variable_resolver.py
@@ -585,11 +585,68 @@ def _computed_finplat_sum_kop_text(ep, _p, all_performers) -> str:
     return number_to_words_ru(int(_kopecks(_calc_finplat(ep, all_performers))))
 
 
-def _computed_deadline_ru(_ep, p, _all_performers) -> str:
+def _parse_gantt_date(value):
+    from datetime import date, datetime
+
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    raw = str(value).strip()
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).date()
+    except ValueError:
+        pass
+    for fmt in ("%Y-%m-%d", "%d.%m.%Y"):
+        try:
+            return datetime.strptime(raw, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _latest_gantt_deadline_for_performers(performer, all_performers):
+    registration = getattr(performer, "registration", None)
+    if not registration:
+        return None
+
+    performer_ids = {
+        str(item.pk)
+        for item in (all_performers or [performer])
+        if getattr(item, "pk", None) and getattr(item, "registration_id", None) == performer.registration_id
+    }
+    if not performer_ids and getattr(performer, "pk", None):
+        performer_ids = {str(performer.pk)}
+
+    payload = getattr(registration, "gantt_data", None)
+    if not performer_ids or not isinstance(payload, dict):
+        return None
+
+    dates = []
+    for task in payload.get("data") or []:
+        if (
+            not isinstance(task, dict)
+            or not task.get("performer_id")
+            or str(task.get("performer_id")) not in performer_ids
+        ):
+            continue
+        deadline = _parse_gantt_date(task.get("deadline"))
+        if deadline:
+            dates.append(deadline)
+    return max(dates) if dates else None
+
+
+def _computed_deadline_ru(_ep, p, all_performers) -> str:
     from core.dates import format_date_ru
-    if not p.registration or not p.registration.deadline:
+
+    deadline = _latest_gantt_deadline_for_performers(p, all_performers)
+    if not deadline:
         return ""
-    return format_date_ru(p.registration.deadline, "j E Y") + " г."
+    return format_date_ru(deadline, "j E Y") + " г."
 
 
 def _performer_contract_date(performer):

--- a/nextcloud_app/tests.py
+++ b/nextcloud_app/tests.py
@@ -18,7 +18,11 @@ from nextcloud_app.api import NextcloudApiError
 from nextcloud_app.api import NextcloudApiClient
 from nextcloud_app.models import NextcloudUserLink
 from nextcloud_app.provisioning import ensure_nextcloud_account
-from nextcloud_app.workspace import create_basic_project_workspace_stream, create_proposal_workspace
+from nextcloud_app.workspace import (
+    create_basic_project_workspace_stream,
+    create_proposal_workspace,
+    grant_project_workspace_editor_access_for_performers,
+)
 
 User = get_user_model()
 
@@ -532,6 +536,93 @@ class NextcloudWorkspaceTests(TestCase):
         workspace = ProjectWorkspace.objects.get(project=self.project)
         self.assertEqual(workspace.disk_path, project_path)
         self.assertEqual(workspace.public_url, f"https://cloud.example.com/apps/files/files?dir={project_path}")
+
+    def test_create_basic_project_workspace_grants_access_to_confirmed_performer(self):
+        performer_user = User.objects.create_user(
+            username="performer@example.com",
+            email="performer@example.com",
+            password="Secret123!",
+            first_name="Петр",
+            last_name="Петров",
+            is_staff=True,
+            is_active=True,
+        )
+        performer_employee = Employee.objects.create(user=performer_user, patronymic="Петрович")
+        Performer.objects.create(
+            registration=self.project,
+            employee=performer_employee,
+            executor="Петров Петр Петрович",
+            participation_response=Performer.ParticipationResponse.CONFIRMED,
+        )
+        NextcloudUserLink.objects.create(
+            user=performer_user,
+            nextcloud_user_id=f"ncstaff-{performer_user.pk}",
+            nextcloud_username=f"ncstaff-{performer_user.pk}",
+            nextcloud_email="performer@example.com",
+        )
+        project_folder = _build_project_folder_name(self.project)
+        project_path = f"/Corporate Root/03 Проекты/2026/{project_folder}"
+        client = Mock()
+        client.is_configured = True
+        client.username = "cloud-admin"
+        client.ensure_folder.side_effect = lambda _owner, path: "/" + "/".join(
+            part for part in str(path).replace("\\", "/").split("/") if part
+        )
+        client.ensure_user_share.return_value = Mock()
+        client.build_files_url.return_value = f"https://cloud.example.com/apps/files/files?dir={project_path}"
+
+        items = list(create_basic_project_workspace_stream(self.creator, self.project, client=client))
+
+        self.assertTrue(items[-1].ok)
+        client.ensure_user_share.assert_has_calls(
+            [
+                call("cloud-admin", project_path, f"ncstaff-{self.manager.pk}", permissions=15),
+                call("cloud-admin", project_path, f"ncstaff-{performer_user.pk}", permissions=15),
+            ]
+        )
+
+    def test_grant_project_workspace_editor_access_for_confirmed_performer(self):
+        performer_user = User.objects.create_user(
+            username="workspace-performer@example.com",
+            email="workspace-performer@example.com",
+            password="Secret123!",
+            first_name="Сергей",
+            last_name="Сергеев",
+            is_staff=True,
+            is_active=True,
+        )
+        performer_employee = Employee.objects.create(user=performer_user, patronymic="Сергеевич")
+        performer = Performer.objects.create(
+            registration=self.project,
+            employee=performer_employee,
+            executor="Сергеев Сергей Сергеевич",
+            participation_response=Performer.ParticipationResponse.CONFIRMED,
+        )
+        NextcloudUserLink.objects.create(
+            user=performer_user,
+            nextcloud_user_id=f"ncstaff-{performer_user.pk}",
+            nextcloud_username=f"ncstaff-{performer_user.pk}",
+            nextcloud_email="workspace-performer@example.com",
+        )
+        ProjectWorkspace.objects.create(
+            project=self.project,
+            disk_path="/Corporate Root/03 Проекты/2026/Проект 6001 DD Проект Nextcloud",
+            created_by=self.creator,
+        )
+        client = Mock()
+        client.is_configured = True
+        client.username = "cloud-admin"
+        client.ensure_user_share.return_value = Mock()
+
+        granted = grant_project_workspace_editor_access_for_performers([performer.pk], client=client)
+
+        self.assertEqual(granted, 1)
+        client.ensure_user_share.assert_called_once_with(
+            "cloud-admin",
+            "/Corporate Root/03 Проекты/2026/Проект 6001 DD Проект Nextcloud",
+            f"ncstaff-{performer_user.pk}",
+            permissions=15,
+        )
 
     def test_create_basic_project_workspace_accepts_slash_as_root_path(self):
         settings_obj = CloudStorageSettings.get_solo()

--- a/nextcloud_app/workspace.py
+++ b/nextcloud_app/workspace.py
@@ -182,7 +182,8 @@ def create_basic_project_workspace_stream(
         else [_sanitize(name) for name in REGISTRATION_STANDARD_FOLDERS]
     )
 
-    total = 4 + len(folder_paths)
+    confirmed_performer_users = _confirmed_project_performer_users(project)
+    total = 4 + len(folder_paths) + len(confirmed_performer_users)
     current = 0
     owner_user_id = client.username
 
@@ -191,7 +192,6 @@ def create_basic_project_workspace_stream(
         if manager_link is None:
             yield WorkspaceResult(False, "Не удалось определить Nextcloud-пользователя руководителя проекта.")
             return
-
         projects_root_path = yield from _ensure_folder_with_heartbeat(
             client, owner_user_id, _join_path(base, _sanitize(PROJECTS_SECTION_FOLDER)), current, total,
         )
@@ -227,6 +227,19 @@ def create_basic_project_workspace_stream(
         )
         current += 1
         yield {"current": current, "total": total}
+
+        for performer_user in confirmed_performer_users:
+            performer_link = _ensure_nextcloud_link_for_user(performer_user, client=client)
+            if not performer_link or not performer_link.nextcloud_user_id:
+                raise NextcloudApiError("Не удалось определить Nextcloud-пользователя исполнителя проекта.")
+            client.ensure_user_share(
+                owner_user_id,
+                project_path,
+                performer_link.nextcloud_user_id,
+                permissions=NextcloudApiClient.EDITOR_PERMISSIONS,
+            )
+            current += 1
+            yield {"current": current, "total": total}
     except NextcloudApiError as exc:
         yield WorkspaceResult(False, str(exc))
         return
@@ -444,17 +457,104 @@ def _resolve_project_manager_nextcloud_link(
     if match is None:
         return None
 
-    existing_link = NextcloudUserLink.objects.filter(user=match.user).first()
+    return _ensure_nextcloud_link_for_user(match.user, client=client, display_name=_employee_full_name(match))
+
+
+def grant_project_workspace_editor_access_for_performers(
+    performer_ids,
+    *,
+    client: NextcloudApiClient | None = None,
+) -> int:
+    from projects_app.models import Performer
+
+    normalized_ids = sorted({int(value) for value in performer_ids or [] if str(value).strip()})
+    if not normalized_ids:
+        return 0
+
+    client = client or NextcloudApiClient()
+    if not client.is_configured:
+        raise NextcloudApiError("Nextcloud не настроен для предоставления доступа к рабочему пространству проекта.")
+
+    performers = (
+        Performer.objects
+        .select_related("employee", "employee__user", "registration")
+        .filter(
+            pk__in=normalized_ids,
+            participation_response=Performer.ParticipationResponse.CONFIRMED,
+            employee__user__isnull=False,
+        )
+        .order_by("registration_id", "employee__user_id", "id")
+    )
+    workspace_by_project_id = {
+        workspace.project_id: workspace
+        for workspace in ProjectWorkspace.objects.filter(
+            project_id__in={performer.registration_id for performer in performers}
+        )
+    }
+
+    granted = 0
+    seen = set()
+    for performer in performers:
+        workspace = workspace_by_project_id.get(performer.registration_id)
+        if not workspace or not workspace.disk_path:
+            continue
+        share_key = (workspace.project_id, performer.employee.user_id)
+        if share_key in seen:
+            continue
+        seen.add(share_key)
+        link = _ensure_nextcloud_link_for_user(performer.employee.user, client=client)
+        if not link or not link.nextcloud_user_id:
+            raise NextcloudApiError("Не удалось определить Nextcloud-пользователя исполнителя проекта.")
+        client.ensure_user_share(
+            client.username,
+            workspace.disk_path,
+            link.nextcloud_user_id,
+            permissions=NextcloudApiClient.EDITOR_PERMISSIONS,
+        )
+        granted += 1
+    return granted
+
+
+def _confirmed_project_performer_users(project):
+    from projects_app.models import Performer
+
+    users = []
+    seen_user_ids = set()
+    performers = (
+        Performer.objects
+        .select_related("employee", "employee__user")
+        .filter(
+            registration=project,
+            participation_response=Performer.ParticipationResponse.CONFIRMED,
+            employee__user__isnull=False,
+        )
+        .order_by("employee__user_id", "id")
+    )
+    for performer in performers:
+        user = performer.employee.user
+        if user.pk in seen_user_ids:
+            continue
+        seen_user_ids.add(user.pk)
+        users.append(user)
+    return users
+
+
+def _ensure_nextcloud_link_for_user(user, *, client: NextcloudApiClient, display_name: str | None = None):
+    existing_link = NextcloudUserLink.objects.filter(user=user).first()
     if existing_link and existing_link.nextcloud_user_id:
         client.enable_user(existing_link.nextcloud_user_id)
-        client.set_user_email(existing_link.nextcloud_user_id, (match.user.email or "").strip())
-        client.set_user_display_name(existing_link.nextcloud_user_id, _employee_full_name(match))
+        client.set_user_email(existing_link.nextcloud_user_id, (user.email or "").strip())
+        client.set_user_display_name(existing_link.nextcloud_user_id, display_name or _user_display_name(user))
         return existing_link
 
-    link = ensure_nextcloud_account(match.user, client=client)
+    link = ensure_nextcloud_account(user, client=client)
     if link and link.nextcloud_user_id:
         return link
     return None
+
+
+def _user_display_name(user) -> str:
+    return " ".join(part for part in [user.first_name, user.last_name] if part).strip() or user.get_username()
 
 
 def _employee_full_name(employee: Employee) -> str:

--- a/notifications_app/services.py
+++ b/notifications_app/services.py
@@ -532,6 +532,21 @@ def check_direction_notifications_completion(performer_ids):
             notification.save(update_fields=["is_processed", "action_at", "updated_at"])
 
 
+def _grant_nextcloud_workspace_access_for_confirmed_performers(performer_ids):
+    from core.cloud_storage import is_nextcloud_primary
+
+    if not is_nextcloud_primary():
+        return 0
+
+    from nextcloud_app.api import NextcloudApiError
+    from nextcloud_app.workspace import grant_project_workspace_editor_access_for_performers
+
+    try:
+        return grant_project_workspace_editor_access_for_performers(performer_ids)
+    except NextcloudApiError as exc:
+        raise ValueError(f"Не удалось предоставить доступ к рабочему пространству проекта в Nextcloud: {exc}") from exc
+
+
 @transaction.atomic
 def process_participation_notification(notification, actor, action_choice):
     if notification.notification_type != Notification.NotificationType.PROJECT_PARTICIPATION_CONFIRMATION:
@@ -567,6 +582,7 @@ def process_participation_notification(notification, actor, action_choice):
 
             prefill_contract_adjustment_fields(self_performer_ids, confirmed_at=now)
             ensure_confirmed_assignments_for_performers(self_performer_ids)
+            _grant_nextcloud_workspace_access_for_confirmed_performers(self_performer_ids)
         all_confirmed = not Performer.objects.filter(
             pk__in=all_performer_ids,
         ).exclude(
@@ -590,6 +606,7 @@ def process_participation_notification(notification, actor, action_choice):
 
             prefill_contract_adjustment_fields(all_performer_ids, confirmed_at=now)
             ensure_confirmed_assignments_for_performers(all_performer_ids)
+            _grant_nextcloud_workspace_access_for_confirmed_performers(all_performer_ids)
         is_fully_processed = True
 
     if not notification.is_read:

--- a/notifications_app/tests.py
+++ b/notifications_app/tests.py
@@ -1,14 +1,17 @@
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.test import SimpleTestCase, TestCase, override_settings
 
+from checklists_app.models import ProjectWorkspace
 from classifiers_app.models import OKSMCountry
 from contacts_app.models import CitizenshipRecord, PersonRecord
+from core.models import CloudStorageSettings
 from core.email_backend import DomainSMTPEmailBackend
 from group_app.models import GroupMember
+from nextcloud_app.models import NextcloudUserLink
 from notifications_app.email_delivery import (
     EmailDeliveryError,
     build_plain_text_body,
@@ -201,4 +204,53 @@ class ParticipationNotificationContractPrefillTests(TestCase):
         self.assertTrue(self.performer.contract_number.startswith("IMCM/7001-ИИ/"))
         self.assertEqual(self.performer.contract_date, self.notification.action_at.date())
         self.assertEqual(self.performer.contract_signing_note, "Разрабатывается проект договора")
+        mocked_assignments.assert_called_once_with([self.performer.pk])
+
+    @override_settings(
+        NEXTCLOUD_PROVISIONING_BASE_URL="https://cloud.example.com",
+        NEXTCLOUD_PROVISIONING_USERNAME="cloud-admin",
+        NEXTCLOUD_PROVISIONING_TOKEN="token",
+        NEXTCLOUD_OIDC_PROVIDER_ID=1,
+    )
+    @patch("nextcloud_app.workspace.NextcloudApiClient")
+    @patch("worktime_app.services.ensure_confirmed_assignments_for_performers")
+    def test_confirming_participation_grants_nextcloud_workspace_editor_access(
+        self,
+        mocked_assignments,
+        mocked_client_cls,
+    ):
+        settings_obj = CloudStorageSettings.get_solo()
+        settings_obj.primary_storage = CloudStorageSettings.PrimaryStorage.NEXTCLOUD
+        settings_obj.nextcloud_root_path = "/Corporate Root"
+        settings_obj.save()
+        ProjectWorkspace.objects.create(
+            project=self.project,
+            disk_path="/Corporate Root/03 Проекты/2026/Проект 7001 Договорный проект",
+            created_by=self.actor,
+        )
+        NextcloudUserLink.objects.create(
+            user=self.expert_user,
+            nextcloud_user_id=f"ncstaff-{self.expert_user.pk}",
+            nextcloud_username=f"ncstaff-{self.expert_user.pk}",
+            nextcloud_email=self.expert_user.email,
+        )
+        client = Mock()
+        client.is_configured = True
+        client.username = "cloud-admin"
+        client.ensure_user_share.return_value = Mock()
+        mocked_client_cls.EDITOR_PERMISSIONS = 15
+        mocked_client_cls.return_value = client
+
+        process_participation_notification(
+            self.notification,
+            self.expert_user,
+            Notification.ActionChoice.CONFIRMED,
+        )
+
+        client.ensure_user_share.assert_called_once_with(
+            "cloud-admin",
+            "/Corporate Root/03 Проекты/2026/Проект 7001 Договорный проект",
+            f"ncstaff-{self.expert_user.pk}",
+            permissions=15,
+        )
         mocked_assignments.assert_called_once_with([self.performer.pk])


### PR DESCRIPTION
## Summary
- Changed `{{deadline_ru}}` to use the latest performer deadline from the project schedule instead of the project registry deadline.
- Added coverage for batched performer schedule deadlines and updated the displayed variable description.
- Includes the latest notification and Nextcloud workspace/test changes currently outside `main`.
## Test plan
- CI/CD pipeline on this pull request.