### PR TITLE
Update TKP summary tables for multi-product proposals

### DIFF
--- a/core/static/core/css/site.css
+++ b/core/static/core/css/site.css
@@ -5113,6 +5113,9 @@ body.typical-service-term-gantt-row-dragging .typical-service-term-gantt-editor 
 #proposals-pane .proposal-commercial-table .proposal-commercial-days-group,
 #proposals-pane .proposal-commercial-table .proposal-commercial-day-header {
   text-align: center;
+  white-space: nowrap;
+  overflow: visible;
+  text-overflow: clip;
 }
 
 #proposals-pane .proposal-commercial-table .proposal-commercial-rate-header,
@@ -5219,6 +5222,8 @@ body.typical-service-term-gantt-row-dragging .typical-service-term-gantt-editor 
 
 #proposals-pane .proposal-commercial-table .proposal-commercial-rate,
 #proposals-pane .proposal-commercial-table .proposal-commercial-day-count,
+#proposals-pane .proposal-commercial-table .proposal-commercial-stage-day-count,
+#proposals-pane .proposal-commercial-table .proposal-commercial-summary-total-day-count,
 #proposals-pane .proposal-commercial-table .proposal-commercial-total {
   width: 100%;
   min-width: 0;
@@ -5226,7 +5231,9 @@ body.typical-service-term-gantt-row-dragging .typical-service-term-gantt-editor 
   text-align: right;
 }
 
-#proposals-pane .proposal-commercial-table .proposal-commercial-day-count {
+#proposals-pane .proposal-commercial-table .proposal-commercial-day-count,
+#proposals-pane .proposal-commercial-table .proposal-commercial-stage-day-count,
+#proposals-pane .proposal-commercial-table .proposal-commercial-summary-total-day-count {
   width: calc(100% - 1px);
   box-sizing: border-box;
   margin-right: 1px;

--- a/core/static/core/js/proposals-panels.js
+++ b/core/static/core/js/proposals-panels.js
@@ -4397,6 +4397,83 @@
       });
     }
 
+    function getSummaryStageLabels() {
+      if (!isSummaryCommercialBlock) return [];
+      return getStageCommercialBlocks().map(function (block, index) {
+        const title = String(block.querySelector('.proposal-stage-block-title')?.textContent || '').trim();
+        const prefix = 'Коммерческое предложение:';
+        const label = title.startsWith(prefix) ? title.slice(prefix.length).trim() : '';
+        return label || ('Этап ' + (index + 1));
+      });
+    }
+
+    function shouldRenderSummaryStageDays() {
+      return isSummaryCommercialBlock && getSummaryStageLabels().length > 1;
+    }
+
+    function normalizeSummaryAssetDayCounts(values, assetCount) {
+      const normalized = Array.isArray(values)
+        ? values.slice(0, assetCount).map(function (value) { return String(value ?? '').trim(); })
+        : [];
+      while (normalized.length < assetCount) normalized.push('');
+      return normalized;
+    }
+
+    function normalizeSummaryStageDayCounts(values, stageCount, assetCount) {
+      const source = Array.isArray(values) ? values : [];
+      return Array.from({ length: stageCount }, function (_stage, stageIndex) {
+        return normalizeSummaryAssetDayCounts(source[stageIndex] || [], assetCount);
+      });
+    }
+
+    function sumDayCountValues(values) {
+      return (Array.isArray(values) ? values : []).reduce(function (sum, value) {
+        const parsed = parseFloat(rawMoney(value || ''));
+        return sum + (Number.isFinite(parsed) ? parsed : 0);
+      }, 0);
+    }
+
+    function formatSummaryTotalDayValue(value) {
+      if (!Number.isFinite(value) || value <= 0) return '';
+      return Number.isInteger(value) ? String(value) : fmtMoney(value.toFixed(2));
+    }
+
+    function readSummaryJsonArray(row, key) {
+      try {
+        const data = JSON.parse(row?.dataset?.[key] || '[]');
+        return Array.isArray(data) ? data : [];
+      } catch (error) {
+        return [];
+      }
+    }
+
+    function getSummaryDayColumnSpecs(assetRows) {
+      const stageLabels = getSummaryStageLabels();
+      const assetCount = Math.max(assetRows.length, 1);
+      const hasMultipleAssets = assetRows.length > 1;
+      const assetLabels = assetRows.length
+        ? getAssetLabels(assetRows)
+        : Array.from({ length: assetCount }, function (_item, index) { return 'Актив ' + (index + 1); });
+      const specs = [];
+      stageLabels.forEach(function (stageLabel, stageIndex) {
+        assetLabels.forEach(function (assetLabel, assetIndex) {
+          specs.push({
+            kind: 'stage',
+            stageIndex: stageIndex,
+            assetIndex: assetIndex,
+            label: hasMultipleAssets ? assetLabel : (stageLabel + ': кол-во дней'),
+            measureLabel: hasMultipleAssets ? assetLabel : (stageLabel + ': кол-во дней'),
+          });
+        });
+      });
+      specs.push({
+        kind: 'total-days',
+        label: 'Всего',
+        measureLabel: hasMultipleAssets ? 'Кол-во дней' : 'Всего',
+      });
+      return specs;
+    }
+
     let dayHeaderMeasureEl = null;
 
     function measureCommercialDayLabelWidth(label) {
@@ -4419,6 +4496,11 @@
     }
 
     function getCommercialDayColumnWidths(assetRows) {
+      if (shouldRenderSummaryStageDays()) {
+        return getSummaryDayColumnSpecs(assetRows).map(function (spec) {
+          return measureCommercialDayLabelWidth(spec.measureLabel || spec.label) + 36;
+        });
+      }
       const labels = getAssetLabels(assetRows);
       if (labels.length <= 1) return [];
       return labels.map(function (label) {
@@ -4447,7 +4529,11 @@
       for (let i = 0; i < 5; i += 1) cols.push({});
       cols.push({ width: '10.5rem' });
 
-      if (assetRows.length <= 1) {
+      if (shouldRenderSummaryStageDays()) {
+        dayWidths.forEach(function (widthPx) {
+          cols.push({ widthPx: widthPx });
+        });
+      } else if (assetRows.length <= 1) {
         cols.push({ width: '10.5rem' });
       } else {
         dayWidths.forEach(function (widthPx) {
@@ -4478,6 +4564,70 @@
     function renderHeader(assetRows) {
       const labels = getAssetLabels(assetRows);
       renderCommercialColGroup(assetRows);
+      if (shouldRenderSummaryStageDays()) {
+        const stageLabels = getSummaryStageLabels();
+        const assetCount = Math.max(assetRows.length, 1);
+        const hasMultipleAssets = assetRows.length > 1;
+        if (!hasMultipleAssets) {
+          thead.innerHTML = ''
+            + '<tr>'
+            + '<th class="proposal-assets-check-col"></th>'
+            + '<th>Специалист</th>'
+            + '<th>Специальность</th>'
+            + '<th>Профессиональный статус</th>'
+            + '<th>Услуги</th>'
+            + '<th class="proposal-commercial-rate-header">Ставка, евро / день</th>'
+            + stageLabels.map(function (stageLabel) {
+              return '<th class="proposal-commercial-days-group proposal-commercial-day-header proposal-commercial-days-header proposal-commercial-days-header-multi">'
+                + escapeHtml(stageLabel) + ': кол-во дней</th>';
+            }).join('')
+            + '<th class="proposal-commercial-day-header proposal-commercial-total-days-header">Всего</th>'
+            + '<th class="proposal-commercial-total-header">Итого, евро без НДС</th>'
+            + '</tr>';
+
+          const widths = getCommercialDayColumnWidths(assetRows);
+          Array.from(thead.querySelectorAll('.proposal-commercial-day-header')).forEach(function (header, index) {
+            applyCommercialDayColumnWidth(header, widths[index]);
+          });
+          return;
+        }
+        const assetLabels = assetRows.length
+          ? labels
+          : Array.from({ length: assetCount }, function (_item, index) { return 'Актив ' + (index + 1); });
+        thead.innerHTML = ''
+          + '<tr>'
+          + '<th class="proposal-assets-check-col" rowspan="2"></th>'
+          + '<th rowspan="2">Специалист</th>'
+          + '<th rowspan="2">Специальность</th>'
+          + '<th rowspan="2">Профессиональный статус</th>'
+          + '<th rowspan="2">Услуги</th>'
+          + '<th class="proposal-commercial-rate-header" rowspan="2">Ставка, евро / день</th>'
+          + stageLabels.map(function (stageLabel) {
+            return '<th class="proposal-commercial-days-group proposal-commercial-days-group-subheaders proposal-commercial-days-header proposal-commercial-days-header-multi" colspan="' + assetCount + '">'
+              + escapeHtml(stageLabel) + ': кол-во дней</th>';
+          }).join('')
+          + '<th class="proposal-commercial-days-group proposal-commercial-days-group-subheaders proposal-commercial-days-header proposal-commercial-days-header-multi" colspan="1">Кол-во дней</th>'
+          + '<th class="proposal-commercial-total-header" rowspan="2">Итого, евро без НДС</th>'
+          + '</tr>'
+          + '<tr>'
+          + stageLabels.map(function () {
+            return assetLabels.map(function (label) {
+              return '<th class="proposal-commercial-day-header">' + escapeHtml(label) + '</th>';
+            }).join('');
+          }).join('')
+          + '<th class="proposal-commercial-day-header proposal-commercial-total-days-header">Всего</th>'
+          + '</tr>';
+
+        const widths = getCommercialDayColumnWidths(assetRows);
+        Array.from(thead.querySelectorAll('.proposal-commercial-day-header')).forEach(function (header, index) {
+          applyCommercialDayColumnWidth(header, widths[index]);
+        });
+        Array.from(thead.querySelectorAll('.proposal-commercial-days-group')).forEach(function (header) {
+          const width = measureCommercialDayLabelWidth(header.textContent || '') + 36;
+          applyCommercialDayColumnWidth(header, width);
+        });
+        return;
+      }
       if (labels.length <= 1) {
         thead.innerHTML = ''
           + '<tr>'
@@ -4534,6 +4684,7 @@
     function recalcRowTotal(row) {
       if (!row) return;
       if (isFixedRow(row)) return;
+      if (isSummaryCommercialBlock) return;
       const rateInput = row.querySelector('.proposal-commercial-rate');
       const totalInput = row.querySelector('.proposal-commercial-total');
       if (!rateInput || !totalInput) return;
@@ -4552,10 +4703,26 @@
       totalInput.value = fmtMoney((rate * totalDays).toFixed(2));
     }
 
+    function recalcSummaryCommercialRowTotal(row) {
+      if (!isSummaryCommercialBlock || !row || isFixedRow(row)) return;
+      const rate = parseFloat(rawMoney(row.querySelector('.proposal-commercial-rate')?.value || ''));
+      const totalDays = sumDayCountValues(readSummaryJsonArray(row, 'summaryAssetDayCounts'));
+      const totalInput = row.querySelector('.proposal-commercial-total');
+      if (!totalInput) return;
+      totalInput.value = Number.isFinite(rate) && totalDays > 0
+        ? fmtMoney((rate * totalDays).toFixed(2))
+        : '';
+    }
+
     function recalcTravelRowTotal(row) {
       if (!row || !isTravelRow(row)) return;
       const totalInput = row.querySelector('.proposal-commercial-total');
       if (!totalInput) return;
+      if (shouldRenderSummaryStageDays()) {
+        const preservedRaw = rawMoney(row.dataset.preservedActualTotalRaw || '');
+        totalInput.value = preservedRaw ? fmtMoney(preservedRaw) : '';
+        return;
+      }
       if (getTravelExpensesMode(row) !== PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION) {
         const preservedRaw = rawMoney(row.dataset.preservedActualTotalRaw || '');
         totalInput.value = preservedRaw ? fmtMoney(preservedRaw) : '';
@@ -4588,6 +4755,47 @@
 
       const totalCell = row.querySelector('.proposal-commercial-total-cell');
       if (!totalCell) return;
+
+      if (shouldRenderSummaryStageDays()) {
+        const assetCount = Math.max(assetRows.length, 1);
+        const stageLabels = getSummaryStageLabels();
+        const normalizedAssetValues = normalizeSummaryAssetDayCounts(sourceValues, assetCount);
+        const normalizedStageValues = normalizeSummaryStageDayCounts(
+          options?.stageDayCounts,
+          stageLabels.length,
+          assetCount
+        );
+        row.dataset.summaryAssetDayCounts = JSON.stringify(normalizedAssetValues);
+        row.dataset.summaryStageDayCounts = JSON.stringify(normalizedStageValues);
+
+        const specs = getSummaryDayColumnSpecs(assetRows);
+        specs.forEach(function (spec, index) {
+          const dayCell = createProposalTableCell('proposal-commercial-day-cell');
+          applyCommercialDayColumnWidth(dayCell, dayColumnWidths[index]);
+          const input = document.createElement('input');
+          input.type = 'text';
+          input.className = 'form-control readonly-field '
+            + (spec.kind === 'total-days'
+              ? 'proposal-commercial-summary-total-day-count'
+              : 'proposal-commercial-stage-day-count');
+          input.readOnly = true;
+          input.tabIndex = -1;
+          if (spec.kind === 'total-days') {
+            const totalDays = sumDayCountValues(normalizedAssetValues);
+            input.value = formatSummaryTotalDayValue(totalDays);
+          } else {
+            input.value = normalizedStageValues[spec.stageIndex]?.[spec.assetIndex] || '';
+          }
+          input.style.width = '100%';
+          input.style.minWidth = '0';
+          input.style.maxWidth = '100%';
+          input.style.boxSizing = 'border-box';
+          dayCell.appendChild(input);
+          row.insertBefore(dayCell, totalCell);
+        });
+        recalcSummaryCommercialRowTotal(row);
+        return;
+      }
 
       if (!assetRows.length) {
         const placeholderCell = createProposalTableCell('proposal-commercial-day-placeholder-cell');
@@ -4664,7 +4872,12 @@
           professional_status: '',
           service_name: PROPOSAL_TRAVEL_EXPENSES_LABEL,
           rate_eur_per_day: '',
-          asset_day_counts: getDayInputs(row).map(function (input) { return (input.value || '').trim(); }),
+          asset_day_counts: isSummaryCommercialBlock
+            ? readSummaryJsonArray(row, 'summaryAssetDayCounts')
+            : getDayInputs(row).map(function (input) { return (input.value || '').trim(); }),
+          stage_asset_day_counts: isSummaryCommercialBlock
+            ? readSummaryJsonArray(row, 'summaryStageDayCounts')
+            : undefined,
           total_eur_without_vat: rawMoney(row.querySelector('.proposal-commercial-total')?.value || ''),
         };
       }
@@ -4674,7 +4887,12 @@
         professional_status: (row.querySelector('.proposal-commercial-status')?.value || '').trim(),
         service_name: (row.querySelector('.proposal-commercial-service')?.value || '').trim(),
         rate_eur_per_day: rawMoney(row.querySelector('.proposal-commercial-rate')?.value || ''),
-        asset_day_counts: getDayInputs(row).map(function (input) { return (input.value || '').trim(); }),
+        asset_day_counts: isSummaryCommercialBlock
+          ? readSummaryJsonArray(row, 'summaryAssetDayCounts')
+          : getDayInputs(row).map(function (input) { return (input.value || '').trim(); }),
+        stage_asset_day_counts: isSummaryCommercialBlock
+          ? readSummaryJsonArray(row, 'summaryStageDayCounts')
+          : undefined,
         total_eur_without_vat: rawMoney(row.querySelector('.proposal-commercial-total')?.value || ''),
       };
     }
@@ -4683,19 +4901,39 @@
       const dataRows = getDataRows();
       const assetCount = Math.max(getAssetRows().length, 1);
       const dayCounts = Array.from({ length: assetCount }, function () { return 0; });
+      const stageCount = getSummaryStageLabels().length;
+      const stageDayCounts = Array.from({ length: stageCount }, function () {
+        return Array.from({ length: assetCount }, function () { return 0; });
+      });
       let total = 0;
 
       dataRows.forEach(function (row) {
-        getDayInputs(row).forEach(function (input, index) {
-          const value = parseInt((input.value || '').trim(), 10);
-          if (Number.isFinite(value)) dayCounts[index] += value;
-        });
+        if (isSummaryCommercialBlock) {
+          normalizeSummaryAssetDayCounts(readSummaryJsonArray(row, 'summaryAssetDayCounts'), assetCount).forEach(function (value, index) {
+            const parsed = parseInt(String(value || '').trim(), 10);
+            if (Number.isFinite(parsed)) dayCounts[index] += parsed;
+          });
+          normalizeSummaryStageDayCounts(readSummaryJsonArray(row, 'summaryStageDayCounts'), stageCount, assetCount).forEach(function (stageValues, stageIndex) {
+            stageValues.forEach(function (value, assetIndex) {
+              const parsed = parseInt(String(value || '').trim(), 10);
+              if (Number.isFinite(parsed)) stageDayCounts[stageIndex][assetIndex] += parsed;
+            });
+          });
+        } else {
+          getDayInputs(row).forEach(function (input, index) {
+            const value = parseInt((input.value || '').trim(), 10);
+            if (Number.isFinite(value)) dayCounts[index] += value;
+          });
+        }
         const rowTotal = parseFloat(rawMoney(row.querySelector('.proposal-commercial-total')?.value || ''));
         if (Number.isFinite(rowTotal)) total += rowTotal;
       });
 
       return {
         asset_day_counts: dayCounts.map(function (value) { return value > 0 ? String(value) : ''; }),
+        stage_asset_day_counts: stageDayCounts.map(function (stageValues) {
+          return stageValues.map(function (value) { return value > 0 ? String(value) : ''; });
+        }),
         total_eur_without_vat: total > 0 ? fmtMoney(total.toFixed(2)) : '',
       };
     }
@@ -4703,6 +4941,10 @@
     function computeTravelRowTotalValue() {
       const travelRow = tbody.querySelector('tr[data-travel-expenses-row="1"]');
       if (!travelRow) return 0;
+      if (shouldRenderSummaryStageDays()) {
+        const value = parseFloat(rawMoney(travelRow.querySelector('.proposal-commercial-total')?.value || ''));
+        return Number.isFinite(value) ? value : 0;
+      }
       return getDayInputs(travelRow).reduce(function (sum, input) {
         const value = parseFloat(rawMoney(input.value || ''));
         return sum + (Number.isFinite(value) ? value : 0);
@@ -4780,7 +5022,10 @@
       const summaryRow = tbody.querySelector('tr[data-summary-row="1"]');
       if (!summaryRow) return;
       const summary = computeSummaryValues();
-      syncDayCells(summaryRow, getAssetRows(), summary.asset_day_counts, { readOnly: true });
+      syncDayCells(summaryRow, getAssetRows(), summary.asset_day_counts, {
+        readOnly: true,
+        stageDayCounts: summary.stage_asset_day_counts,
+      });
       const totalInput = summaryRow.querySelector('.proposal-commercial-total');
       if (totalInput) totalInput.value = summary.total_eur_without_vat;
     }
@@ -4896,7 +5141,10 @@
       }
       if (rate) rate.value = data.rate_eur_per_day ? fmtMoney(data.rate_eur_per_day) : '';
       if (total) total.value = data.total_eur_without_vat ? fmtMoney(data.total_eur_without_vat) : '';
-      syncDayCells(row, getAssetRows(), data.asset_day_counts || [], { readOnly: isSummaryCommercialBlock });
+      syncDayCells(row, getAssetRows(), data.asset_day_counts || [], {
+        readOnly: isSummaryCommercialBlock,
+        stageDayCounts: data.stage_asset_day_counts || [],
+      });
       recalcRowTotal(row);
     }
 
@@ -5048,7 +5296,10 @@
       totalTd.appendChild(totalInput);
       row.appendChild(totalTd);
 
-      syncDayCells(row, getAssetRows(), data.asset_day_counts || [], { readOnly: isSummaryCommercialBlock });
+      syncDayCells(row, getAssetRows(), data.asset_day_counts || [], {
+        readOnly: isSummaryCommercialBlock,
+        stageDayCounts: data.stage_asset_day_counts || [],
+      });
 
       [statusInput].forEach(function (input) {
         if (isSummaryCommercialBlock) return;
@@ -5140,7 +5391,10 @@
       totalTd.appendChild(totalInput);
       row.appendChild(totalTd);
 
-      syncDayCells(row, getAssetRows(), data.asset_day_counts || [], { readOnly: isSummaryCommercialBlock });
+      syncDayCells(row, getAssetRows(), data.asset_day_counts || [], {
+        readOnly: isSummaryCommercialBlock,
+        stageDayCounts: data.stage_asset_day_counts || [],
+      });
 
       if (!isSummaryCommercialBlock) {
         rateSelect.addEventListener('change', function () {
@@ -5554,6 +5808,7 @@
         return servicesStore ? servicesStore.getRows() : getRows().map(serializeRow).filter(Boolean);
       },
       replaceRows: function (rowsData, meta) {
+        renderHeader(getAssetRows());
         if (servicesStore) {
           servicesStore.commitCommercialRows(rowsData || [], { ...(meta || {}), source: 'commercial-view' });
           return;
@@ -7418,16 +7673,21 @@
 
       function buildSummaryCommercialRows() {
         const assetCount = Math.max(getAssetRows().length, 1);
+        const commercialBlocks = getCommercialBlocks();
+        const stageCount = commercialBlocks.length;
         const groupedRows = [];
         const groupedByKey = new Map();
         const preferredOrder = getSummaryCommercialRowOrder();
         const travelDayTotals = Array.from({ length: assetCount }, function () { return 0; });
+        const travelStageDayTotals = Array.from({ length: stageCount }, function () {
+          return Array.from({ length: assetCount }, function () { return 0; });
+        });
         let travelTotal = 0;
         let hasTravelCalculation = false;
         let hasTravelActual = false;
         let hasTravelData = false;
 
-        getCommercialBlocks().forEach(function (block) {
+        commercialBlocks.forEach(function (block, stageIndex) {
           const api = attachProposalCommercialTable(block, assetsApi);
           const rows = Array.isArray(api?.getSerializedRows?.()) ? api.getSerializedRows() : [];
           const totalsState = parseCommercialTotalsPayload(block);
@@ -7445,6 +7705,9 @@
                   const numericValue = parseFloat(rawMoney(value || ''));
                   if (Number.isFinite(numericValue)) {
                     travelDayTotals[index] += numericValue;
+                    if (travelStageDayTotals[stageIndex]) {
+                      travelStageDayTotals[stageIndex][index] += numericValue;
+                    }
                     hasTravelData = true;
                   }
                 });
@@ -7466,6 +7729,9 @@
                 service_name: '',
                 rate_eur_per_day: String(row?.rate_eur_per_day || '').trim(),
                 asset_day_counts: Array.from({ length: assetCount }, function () { return 0; }),
+                stage_asset_day_counts: Array.from({ length: stageCount }, function () {
+                  return Array.from({ length: assetCount }, function () { return 0; });
+                }),
                 total_eur_without_vat: 0,
               };
               groupedByKey.set(key, bucket);
@@ -7475,6 +7741,9 @@
               const numericValue = parseInt(String(value || '').trim(), 10);
               if (Number.isFinite(numericValue)) {
                 bucket.asset_day_counts[index] += numericValue;
+                if (bucket.stage_asset_day_counts[stageIndex]) {
+                  bucket.stage_asset_day_counts[stageIndex][index] += numericValue;
+                }
               }
             });
             const totalValue = parseFloat(rawMoney(row?.total_eur_without_vat || ''));
@@ -7485,6 +7754,13 @@
         });
 
         const rows = groupedRows.map(function (bucket, index) {
+          const rateValue = parseFloat(rawMoney(bucket.rate_eur_per_day || ''));
+          const totalDays = bucket.asset_day_counts.reduce(function (sum, value) {
+            return sum + (Number.isFinite(value) ? value : 0);
+          }, 0);
+          const calculatedTotal = Number.isFinite(rateValue) && totalDays > 0
+            ? rateValue * totalDays
+            : bucket.total_eur_without_vat;
           return {
             specialist: bucket.specialist,
             job_title: bucket.job_title,
@@ -7492,7 +7768,10 @@
             service_name: '',
             rate_eur_per_day: bucket.rate_eur_per_day,
             asset_day_counts: bucket.asset_day_counts.map(function (value) { return value > 0 ? String(value) : ''; }),
-            total_eur_without_vat: bucket.total_eur_without_vat > 0 ? bucket.total_eur_without_vat.toFixed(2) : '',
+            stage_asset_day_counts: bucket.stage_asset_day_counts.map(function (stageValues) {
+              return stageValues.map(function (value) { return value > 0 ? String(value) : ''; });
+            }),
+            total_eur_without_vat: calculatedTotal > 0 ? calculatedTotal.toFixed(2) : '',
             __summaryOrderIndex: index,
           };
         });
@@ -7514,6 +7793,7 @@
             service_name: row.service_name,
             rate_eur_per_day: row.rate_eur_per_day,
             asset_day_counts: row.asset_day_counts,
+            stage_asset_day_counts: row.stage_asset_day_counts,
             total_eur_without_vat: row.total_eur_without_vat,
           };
         });
@@ -7533,6 +7813,13 @@
             asset_day_counts: travelMode === PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION
               ? travelDayTotals.map(function (value) { return value > 0 ? fmtMoney(value.toFixed(2)) : ''; })
               : Array.from({ length: assetCount }, function () { return ''; }),
+            stage_asset_day_counts: travelMode === PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION
+              ? travelStageDayTotals.map(function (stageValues) {
+                return stageValues.map(function (value) { return value > 0 ? fmtMoney(value.toFixed(2)) : ''; });
+              })
+              : Array.from({ length: stageCount }, function () {
+                return Array.from({ length: assetCount }, function () { return ''; });
+              }),
             total_eur_without_vat: travelTotal > 0 ? travelTotal.toFixed(2) : '',
           });
         }

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -945,6 +945,204 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertEqual(len(data_row), 5)
         self.assertEqual(data_row[3]["text"], "2")
 
+    def test_resolve_budget_table_uses_multistage_summary_for_single_asset(self):
+        second_product = Product.objects.create(
+            short_name="TDD",
+            name_en="Technical Due Diligence",
+            name_ru="ТДД",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Оптимизация",
+            position=2,
+        )
+        proposal = ProposalRegistration.objects.create(
+            number=4445,
+            group_member=self.group_member,
+            type=second_product,
+            name="Мультиэтапное ТКП",
+            year=2026,
+            status=ProposalRegistration.ProposalStatus.PRELIMINARY,
+            customer='ООО "Приморское"',
+            commercial_totals_json={
+                "exchange_rate": "100",
+                "discount_percent": "0",
+                "contract_total": "100000",
+            },
+            stage_payloads_json=[
+                {
+                    "rank": 1,
+                    "product_id": self.product.pk,
+                    "commercial_totals_json": {"travel_expenses_mode": "actual"},
+                    "commercial_offer_payload": [
+                        {
+                            "specialist": "Иванов И.И.",
+                            "job_title": "Геолог",
+                            "professional_status": "Партнер",
+                            "service_name": "Этап 1",
+                            "rate_eur_per_day": "100",
+                            "asset_day_counts": ["1"],
+                            "total_eur_without_vat": "100",
+                        }
+                    ],
+                },
+                {
+                    "rank": 2,
+                    "product_id": second_product.pk,
+                    "commercial_totals_json": {"travel_expenses_mode": "actual"},
+                    "commercial_offer_payload": [
+                        {
+                            "specialist": "Иванов И.И.",
+                            "job_title": "Геолог",
+                            "professional_status": "Партнер",
+                            "service_name": "Этап 2",
+                            "rate_eur_per_day": "100",
+                            "asset_day_counts": ["2"],
+                            "total_eur_without_vat": "200",
+                        }
+                    ],
+                },
+            ],
+        )
+        ProposalRegistrationProduct.objects.bulk_create(
+            [
+                ProposalRegistrationProduct(proposal=proposal, product=self.product, rank=1),
+                ProposalRegistrationProduct(proposal=proposal, product=second_product, rank=2),
+            ]
+        )
+        ProposalAsset.objects.create(proposal=proposal, short_name="Актив 1", position=1)
+        ProposalCommercialOffer.objects.create(
+            proposal=proposal,
+            specialist="Иванов И.И.",
+            job_title="Геолог",
+            professional_status="Партнер",
+            service_name="",
+            rate_eur_per_day="100",
+            asset_day_counts=["3"],
+            total_eur_without_vat="999",
+            position=1,
+        )
+
+        _, _, tables = resolve_variables(
+            proposal,
+            [ProposalVariable(key="[[budget_table]]", is_computed=True)],
+        )
+
+        table_spec = tables["[[budget_table]]"]
+        header_texts = [cell["text"] for cell in table_spec["rows"][0]]
+        self.assertEqual(
+            header_texts,
+            [
+                "Специалист",
+                "Должность/направление",
+                "Ставка,\n€/дн",
+                "Этап 1 DD: кол-во дней",
+                "Этап 2 TDD: кол-во дней",
+                "Всего",
+                "Итого,\n€ без НДС",
+            ],
+        )
+        data_row = table_spec["rows"][1]
+        self.assertEqual(data_row[3]["text"], "1")
+        self.assertEqual(data_row[4]["text"], "2")
+        self.assertEqual(data_row[5]["text"], "3")
+        self.assertEqual(data_row[6]["text"], "300,00")
+
+    def test_resolve_budget_table_uses_multistage_summary_for_multiple_assets(self):
+        second_product = Product.objects.create(
+            short_name="TDD",
+            name_en="Technical Due Diligence",
+            name_ru="ТДД",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Оптимизация",
+            position=2,
+        )
+        proposal = ProposalRegistration.objects.create(
+            number=4446,
+            group_member=self.group_member,
+            type=second_product,
+            name="Мультиэтапное ТКП",
+            year=2026,
+            status=ProposalRegistration.ProposalStatus.PRELIMINARY,
+            customer='ООО "Приморское"',
+            commercial_totals_json={
+                "exchange_rate": "100",
+                "discount_percent": "0",
+                "contract_total": "100000",
+            },
+            stage_payloads_json=[
+                {
+                    "rank": 1,
+                    "product_id": self.product.pk,
+                    "commercial_totals_json": {"travel_expenses_mode": "actual"},
+                    "commercial_offer_payload": [
+                        {
+                            "specialist": "Иванов И.И.",
+                            "job_title": "Геолог",
+                            "professional_status": "Партнер",
+                            "service_name": "Этап 1",
+                            "rate_eur_per_day": "100",
+                            "asset_day_counts": ["1", "2"],
+                            "total_eur_without_vat": "300",
+                        }
+                    ],
+                },
+                {
+                    "rank": 2,
+                    "product_id": second_product.pk,
+                    "commercial_totals_json": {"travel_expenses_mode": "actual"},
+                    "commercial_offer_payload": [
+                        {
+                            "specialist": "Иванов И.И.",
+                            "job_title": "Геолог",
+                            "professional_status": "Партнер",
+                            "service_name": "Этап 2",
+                            "rate_eur_per_day": "100",
+                            "asset_day_counts": ["3", "4"],
+                            "total_eur_without_vat": "700",
+                        }
+                    ],
+                },
+            ],
+        )
+        ProposalRegistrationProduct.objects.bulk_create(
+            [
+                ProposalRegistrationProduct(proposal=proposal, product=self.product, rank=1),
+                ProposalRegistrationProduct(proposal=proposal, product=second_product, rank=2),
+            ]
+        )
+        ProposalAsset.objects.create(proposal=proposal, short_name="Актив 1", position=1)
+        ProposalAsset.objects.create(proposal=proposal, short_name="Актив 2", position=2)
+        ProposalCommercialOffer.objects.create(
+            proposal=proposal,
+            specialist="Иванов И.И.",
+            job_title="Геолог",
+            professional_status="Партнер",
+            service_name="",
+            rate_eur_per_day="100",
+            asset_day_counts=["4", "6"],
+            total_eur_without_vat="999",
+            position=1,
+        )
+
+        _, _, tables = resolve_variables(
+            proposal,
+            [ProposalVariable(key="[[budget_table]]", is_computed=True)],
+        )
+
+        table_spec = tables["[[budget_table]]"]
+        first_header = table_spec["rows"][0]
+        second_header = table_spec["rows"][1]
+        self.assertEqual(first_header[3]["text"], "Этап 1 DD: кол-во дней")
+        self.assertEqual(first_header[3]["colspan"], 2)
+        self.assertEqual(first_header[4]["text"], "Этап 2 TDD: кол-во дней")
+        self.assertEqual(first_header[4]["colspan"], 2)
+        self.assertEqual(first_header[5]["text"], "Кол-во дней")
+        self.assertEqual([cell["text"] for cell in second_header], ["Актив 1", "Актив 2", "Актив 1", "Актив 2", "Всего"])
+        data_row = table_spec["rows"][2]
+        self.assertEqual([cell["text"] for cell in data_row[3:8]], ["1", "2", "3", "4", "10"])
+        self.assertEqual(data_row[8]["text"], "1\u00a0000,00")
+
     def test_process_template_inserts_budget_table(self):
         template_doc = Document()
         template_doc.add_paragraph("[[budget_table]]")

--- a/proposals_app/variable_resolver.py
+++ b/proposals_app/variable_resolver.py
@@ -418,6 +418,17 @@ def _proposal_multi_asset_column_widths_pct(asset_count: int) -> list[float]:
     return [float(width) for width in widths]
 
 
+def _proposal_multistage_column_widths_pct(day_column_count: int) -> list[float]:
+    if day_column_count <= 0:
+        return []
+    fixed_columns = [Decimal("15.5"), Decimal("40"), Decimal("7")]
+    trailing_columns = [Decimal("10")]
+    fixed_total = sum(fixed_columns + trailing_columns, Decimal("0"))
+    day_width = (Decimal("100.0") - fixed_total) / Decimal(str(day_column_count))
+    widths = fixed_columns + [day_width] * day_column_count + trailing_columns
+    return [float(width) for width in widths]
+
+
 def _normalize_proposal_travel_expenses_mode(value) -> str:
     mode = str(value or "").strip()
     if mode in {PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL, PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION}:
@@ -431,7 +442,370 @@ def _round_to_hundred_thousand(value: Decimal | None) -> Decimal | None:
     return (value // Decimal("100000")) * Decimal("100000")
 
 
+def _proposal_day_decimal(value) -> Decimal | None:
+    if value in (None, ""):
+        return None
+    return _parse_decimal(str(value).strip().replace(",", "."))
+
+
+def _format_day_count(value) -> str:
+    parsed = _proposal_day_decimal(value)
+    if parsed is None or parsed == Decimal("0"):
+        return ""
+    return _format_decimal(parsed, precision=2, strip_trailing_zeros=True)
+
+
+def _proposal_multistage_budget_table(proposal) -> dict | None:
+    stage_payloads = [item for item in (getattr(proposal, "stage_payloads_json", None) or []) if isinstance(item, dict)]
+    products = list(proposal.ordered_products()) if hasattr(proposal, "ordered_products") else []
+    if len(stage_payloads) <= 1 and len(products) <= 1:
+        return None
+    if not stage_payloads:
+        return None
+
+    offers = list(proposal.commercial_offers.order_by("position", "id"))
+    saved_travel_offer = next(
+        (
+            item
+            for item in offers
+            if _is_proposal_travel_expenses_name(getattr(item, "service_name", ""))
+        ),
+        None,
+    )
+    saved_regular_offers = [
+        item
+        for item in offers
+        if not _is_proposal_travel_expenses_name(getattr(item, "service_name", ""))
+    ]
+    asset_labels = [
+        str(getattr(asset, "short_name", "") or "").strip()
+        for asset in proposal.assets.order_by("position", "id")
+    ]
+    max_asset_count = max(
+        [
+            len(item.get("asset_day_counts") or [])
+            for stage in stage_payloads
+            for item in (stage.get("commercial_offer_payload") or [])
+            if isinstance(item, dict)
+        ],
+        default=0,
+    )
+    asset_count = max(len(asset_labels), max_asset_count, 1)
+    show_asset_columns = asset_count > 1
+    while len(asset_labels) < asset_count:
+        asset_labels.append(f"Актив {len(asset_labels) + 1}")
+    asset_labels = [label or f"Актив {index + 1}" for index, label in enumerate(asset_labels)]
+
+    stage_count = len(stage_payloads)
+    day_column_count = stage_count * (asset_count if show_asset_columns else 1) + 1
+
+    def product_for_stage(index: int, payload: dict):
+        if index < len(products):
+            return products[index]
+        product_id = str(payload.get("product_id") or "").strip()
+        return next((product for product in products if str(getattr(product, "pk", "") or "") == product_id), None)
+
+    stage_labels = []
+    for index, payload in enumerate(stage_payloads, start=1):
+        product = product_for_stage(index - 1, payload)
+        short_name = str(getattr(product, "short_name", "") or "").strip()
+        stage_labels.append(f"Этап {index} {short_name}".strip())
+
+    def header_cell(text, **extra):
+        return {
+            "text": text,
+            "bold": True,
+            "align": extra.pop("align", "center"),
+            "header": True,
+            "vertical_align": "center",
+            "no_wrap": True,
+            **extra,
+        }
+
+    if show_asset_columns:
+        rows: list[list[dict[str, object]]] = [
+            [
+                header_cell("Специалист", align="left", rowspan=2),
+                header_cell("Должность/направление", align="left", rowspan=2),
+                header_cell("Ставка,\n€/дн", align="right", rowspan=2),
+                *[
+                    header_cell(f"{label}: кол-во дней", colspan=asset_count)
+                    for label in stage_labels
+                ],
+                header_cell("Кол-во дней", colspan=1),
+                header_cell("Итого,\n€ без НДС", align="right", rowspan=2),
+            ],
+            [
+                *[
+                    header_cell(asset_label)
+                    for _stage_label in stage_labels
+                    for asset_label in asset_labels
+                ],
+                header_cell("Всего"),
+            ],
+        ]
+    else:
+        rows = [
+            [
+                header_cell("Специалист", align="left"),
+                header_cell("Должность/направление", align="left"),
+                header_cell("Ставка,\n€/дн", align="right"),
+                *[header_cell(f"{label}: кол-во дней") for label in stage_labels],
+                header_cell("Всего"),
+                header_cell("Итого,\n€ без НДС", align="right"),
+            ]
+        ]
+
+    grouped_rows: dict[tuple[str, str], dict[str, object]] = {}
+    grouped_order: list[tuple[str, str]] = []
+    stage_day_totals = [[Decimal("0") for _ in range(asset_count)] for _ in range(stage_count)]
+    travel_stage_day_totals = [[Decimal("0") for _ in range(asset_count)] for _ in range(stage_count)]
+    travel_total = Decimal("0")
+    has_travel_calculation = False
+    has_travel_actual = False
+    has_travel_data = False
+
+    def normalized_day_values(raw_values) -> list[Decimal]:
+        values = []
+        for raw_value in list(raw_values or [])[:asset_count]:
+            values.append(_proposal_day_decimal(raw_value) or Decimal("0"))
+        while len(values) < asset_count:
+            values.append(Decimal("0"))
+        return values
+
+    for stage_index, stage in enumerate(stage_payloads):
+        totals_state = stage.get("commercial_totals_json") or {}
+        travel_mode = (
+            _normalize_proposal_travel_expenses_mode(totals_state.get("travel_expenses_mode"))
+            or PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL
+        )
+        for item in stage.get("commercial_offer_payload") or []:
+            if not isinstance(item, dict):
+                continue
+            day_values = normalized_day_values(item.get("asset_day_counts") or [])
+            if _is_proposal_travel_expenses_name(item.get("service_name") or ""):
+                item_total = _proposal_day_decimal(item.get("total_eur_without_vat")) or Decimal("0")
+                travel_total += item_total
+                if item_total or any(value for value in day_values):
+                    has_travel_data = True
+                if travel_mode == PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION:
+                    has_travel_calculation = True
+                    for asset_index, value in enumerate(day_values):
+                        travel_stage_day_totals[stage_index][asset_index] += value
+                else:
+                    has_travel_actual = True
+                continue
+
+            key = (
+                str(item.get("specialist") or "").strip(),
+                str(item.get("job_title") or "").strip(),
+            )
+            if key not in grouped_rows:
+                grouped_rows[key] = {
+                    "specialist": key[0],
+                    "job_title": key[1],
+                    "professional_status": str(item.get("professional_status") or "").strip(),
+                    "rate_eur_per_day": item.get("rate_eur_per_day"),
+                    "stage_asset_day_counts": [[Decimal("0") for _ in range(asset_count)] for _ in range(stage_count)],
+                    "fallback_total": Decimal("0"),
+                }
+                grouped_order.append(key)
+            bucket = grouped_rows[key]
+            for asset_index, value in enumerate(day_values):
+                bucket["stage_asset_day_counts"][stage_index][asset_index] += value
+                stage_day_totals[stage_index][asset_index] += value
+            bucket["fallback_total"] += _proposal_day_decimal(item.get("total_eur_without_vat")) or Decimal("0")
+
+    if saved_travel_offer is not None:
+        has_travel_data = True
+        saved_travel_total = _proposal_day_decimal(getattr(saved_travel_offer, "total_eur_without_vat", None))
+        if saved_travel_total is not None:
+            travel_total = saved_travel_total
+
+    summary_total = Decimal("0")
+    if saved_regular_offers:
+        source_rows = []
+        for item in saved_regular_offers:
+            key = (
+                str(getattr(item, "specialist", "") or "").strip(),
+                str(getattr(item, "job_title", "") or "").strip(),
+            )
+            bucket = grouped_rows.get(key)
+            source_rows.append(
+                {
+                    "specialist": key[0],
+                    "job_title": key[1],
+                    "professional_status": str(getattr(item, "professional_status", "") or "").strip(),
+                    "rate_eur_per_day": getattr(item, "rate_eur_per_day", None),
+                    "stage_asset_day_counts": (
+                        bucket["stage_asset_day_counts"]
+                        if bucket is not None
+                        else [[Decimal("0") for _ in range(asset_count)] for _ in range(stage_count)]
+                    ),
+                    "asset_day_counts": normalized_day_values(getattr(item, "asset_day_counts", []) or []),
+                    "fallback_total": _proposal_day_decimal(getattr(item, "total_eur_without_vat", None)) or Decimal("0"),
+                }
+            )
+    else:
+        source_rows = []
+        for key in grouped_order:
+            bucket = grouped_rows[key]
+            stage_counts = bucket["stage_asset_day_counts"]
+            source_rows.append(
+                {
+                    "specialist": str(bucket["specialist"] or "").strip(),
+                    "job_title": str(bucket["job_title"] or "").strip(),
+                    "professional_status": str(bucket["professional_status"] or "").strip(),
+                    "rate_eur_per_day": bucket["rate_eur_per_day"],
+                    "stage_asset_day_counts": stage_counts,
+                    "asset_day_counts": [
+                        sum(stage_counts[stage_index][asset_index] for stage_index in range(stage_count))
+                        for asset_index in range(asset_count)
+                    ],
+                    "fallback_total": bucket["fallback_total"],
+                }
+            )
+
+    for source in source_rows:
+        stage_counts = source["stage_asset_day_counts"]
+        asset_totals = [
+            source["asset_day_counts"][asset_index] if asset_index < len(source["asset_day_counts"]) else Decimal("0")
+            for asset_index in range(asset_count)
+        ]
+        total_days = sum(asset_totals, Decimal("0"))
+        rate = _proposal_day_decimal(source["rate_eur_per_day"])
+        row_total = (rate * total_days) if rate is not None and total_days else source["fallback_total"]
+        summary_total += row_total
+        direction = ", ".join(
+            value
+            for value in [
+                str(source["job_title"] or "").strip(),
+                str(source["professional_status"] or "").strip(),
+            ]
+            if value
+        )
+        rows.append(
+            [
+                {"text": str(source["specialist"] or "").strip()},
+                {"text": direction, "no_wrap": True},
+                {"text": _format_money(rate), "align": "right"},
+                *[
+                    {"text": _format_day_count(stage_counts[stage_index][asset_index]), "align": "right"}
+                    for stage_index in range(stage_count)
+                    for asset_index in (range(asset_count) if show_asset_columns else [0])
+                ],
+                {"text": _format_day_count(total_days), "align": "right"},
+                {"text": _format_money(row_total), "align": "right"},
+            ]
+        )
+
+    displayed_stage_day_totals = [[Decimal("0") for _ in range(asset_count)] for _ in range(stage_count)]
+    for source in source_rows:
+        stage_counts = source["stage_asset_day_counts"]
+        for stage_index in range(stage_count):
+            for asset_index in range(asset_count):
+                displayed_stage_day_totals[stage_index][asset_index] += stage_counts[stage_index][asset_index]
+
+    totals_state = getattr(proposal, "commercial_totals_json", {}) or {}
+    travel_expenses_mode = (
+        PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION
+        if has_travel_calculation and not has_travel_actual
+        else PROPOSAL_TRAVEL_EXPENSES_MODE_ACTUAL
+    )
+    if not has_travel_data:
+        travel_expenses_mode = _normalize_proposal_travel_expenses_mode(totals_state.get("travel_expenses_mode")) or travel_expenses_mode
+
+    def flatten_stage_values(matrix, *, include_values=True) -> list[str]:
+        if not include_values:
+            return ["" for _ in range(stage_count * (asset_count if show_asset_columns else 1))]
+        return [
+            _format_day_count(matrix[stage_index][asset_index])
+            for stage_index in range(stage_count)
+            for asset_index in (range(asset_count) if show_asset_columns else [0])
+        ]
+
+    def append_fixed_row(label, *, rate="", day_values=None, total="", total_days=None):
+        current_day_values = list(day_values or [])
+        while len(current_day_values) < stage_count * (asset_count if show_asset_columns else 1):
+            current_day_values.append("")
+        total_days_text = (
+            _format_day_count(total_days)
+            if total_days is not None
+            else _format_day_count(sum((_proposal_day_decimal(value) or Decimal("0")) for value in current_day_values))
+        )
+        rows.append(
+            [
+                {"text": label, "colspan": 2, "bold": True},
+                {"text": str(rate or ""), "align": "right"},
+                *[
+                    {"text": str(value or ""), "align": "right"}
+                    for value in current_day_values
+                ],
+                {"text": total_days_text, "align": "right"},
+                {"text": str(total or ""), "align": "right"},
+            ]
+        )
+
+    summary_total_days = sum(
+        sum(source["asset_day_counts"], Decimal("0"))
+        for source in source_rows
+    )
+    append_fixed_row(
+        PROPOSAL_SUMMARY_TOTAL_LABEL,
+        day_values=flatten_stage_values(displayed_stage_day_totals),
+        total=_format_money(summary_total),
+        total_days=summary_total_days,
+    )
+    if has_travel_data:
+        append_fixed_row(
+            PROPOSAL_TRAVEL_EXPENSES_LABEL,
+            rate="расчёт" if travel_expenses_mode == PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION else "по факту",
+            day_values=flatten_stage_values(
+                travel_stage_day_totals,
+                include_values=travel_expenses_mode == PROPOSAL_TRAVEL_EXPENSES_MODE_CALCULATION,
+            ),
+            total=_format_money(travel_total),
+        )
+    summary_with_travel_total = summary_total + travel_total
+    exchange_rate = _parse_decimal(totals_state.get("exchange_rate"))
+    discount_percent = _parse_decimal(totals_state.get("discount_percent"))
+    rub_total = (summary_with_travel_total * exchange_rate) if exchange_rate is not None else None
+    discounted_total = (
+        rub_total - (rub_total * (discount_percent / Decimal("100")))
+        if rub_total is not None and discount_percent is not None
+        else rub_total
+    )
+    contract_total = _parse_decimal(totals_state.get("contract_total"))
+    contract_total_auto = _parse_decimal(totals_state.get("contract_total_auto"))
+    if contract_total in (None, Decimal("0")):
+        contract_total = contract_total_auto or _round_to_hundred_thousand(discounted_total)
+
+    append_fixed_row(PROPOSAL_SUMMARY_WITH_TRAVEL_TOTAL_LABEL, total=_format_money(summary_with_travel_total))
+    append_fixed_row(
+        PROPOSAL_RUB_TOTAL_LABEL,
+        rate=_format_decimal(exchange_rate, precision=4, strip_trailing_zeros=True),
+        total=_format_money(rub_total),
+    )
+    append_fixed_row(
+        PROPOSAL_RUB_DISCOUNTED_LABEL,
+        rate=_format_percent(discount_percent, strip_trailing_zeros=True),
+        total=_format_money(discounted_total),
+    )
+    append_fixed_row(PROPOSAL_CONTRACT_TOTAL_LABEL, total=_format_money(contract_total))
+
+    return {
+        "rows": rows,
+        "font_size_pt": 7,
+        "style": "Table Grid",
+        "column_widths_pct": _proposal_multistage_column_widths_pct(day_column_count),
+    }
+
+
 def _proposal_budget_table(proposal) -> dict:
+    multistage_table = _proposal_multistage_budget_table(proposal)
+    if multistage_table is not None:
+        return multistage_table
+
     offers = list(proposal.commercial_offers.order_by("position", "id"))
     travel_offer = next(
         (


### PR DESCRIPTION
## Summary
- Added stage/product day breakdown to the TKP commercial offer summary table.
- Aligned DOCX budget table generation with the multi-product summary table structure.
- Fixed summary totals to calculate from rate multiplied by total days and added regression tests.
## Test plan
- python3 -m py_compile proposals_app/variable_resolver.py proposals_app/tests.py
- python3 manage.py test proposals_app.tests.ProposalDocumentGenerationTests.test_resolve_budget_table_uses_multistage_summary_for_single_asset proposals_app.tests.ProposalDocumentGenerationTests.test_resolve_budget_table_uses_multistage_summary_for_multiple_assets proposals_app.tests.ProposalRegistrationFormTests.test_resolve_variables_uses_summary_payload_after_multistage_save