### PR TITLE
Fix DOCX summary totals for single-asset multistage proposals

### DIFF
--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -1017,8 +1017,8 @@ class ProposalDocumentGenerationTests(TestCase):
             professional_status="Партнер",
             service_name="",
             rate_eur_per_day="100",
-            asset_day_counts=["3"],
-            total_eur_without_vat="999",
+            asset_day_counts=[""],
+            total_eur_without_vat="0",
             position=1,
         )
 

--- a/proposals_app/variable_resolver.py
+++ b/proposals_app/variable_resolver.py
@@ -666,12 +666,21 @@ def _proposal_multistage_budget_table(proposal) -> dict | None:
                 }
             )
 
-    for source in source_rows:
-        stage_counts = source["stage_asset_day_counts"]
-        asset_totals = [
-            source["asset_day_counts"][asset_index] if asset_index < len(source["asset_day_counts"]) else Decimal("0")
+    def effective_asset_totals(source: dict[str, object]) -> list[Decimal]:
+        saved_totals = list(source.get("asset_day_counts") or [])
+        while len(saved_totals) < asset_count:
+            saved_totals.append(Decimal("0"))
+        if any(value for value in saved_totals):
+            return saved_totals[:asset_count]
+        stage_counts = source.get("stage_asset_day_counts") or []
+        return [
+            sum(stage_counts[stage_index][asset_index] for stage_index in range(stage_count))
             for asset_index in range(asset_count)
         ]
+
+    for source in source_rows:
+        stage_counts = source["stage_asset_day_counts"]
+        asset_totals = effective_asset_totals(source)
         total_days = sum(asset_totals, Decimal("0"))
         rate = _proposal_day_decimal(source["rate_eur_per_day"])
         row_total = (rate * total_days) if rate is not None and total_days else source["fallback_total"]
@@ -746,10 +755,7 @@ def _proposal_multistage_budget_table(proposal) -> dict | None:
             ]
         )
 
-    summary_total_days = sum(
-        sum(source["asset_day_counts"], Decimal("0"))
-        for source in source_rows
-    )
+    summary_total_days = sum(sum(effective_asset_totals(source), Decimal("0")) for source in source_rows)
     append_fixed_row(
         PROPOSAL_SUMMARY_TOTAL_LABEL,
         day_values=flatten_stage_values(displayed_stage_day_totals),


### PR DESCRIPTION
## Summary
- Fixed DOCX budget table generation for multi-product TKP with a single asset.
- The "Всего" day column now falls back to summing stage day columns when saved summary day counts are empty.
- "Итого, € без НДС" now uses the corrected total days value.
- Added regression coverage for the single-asset multistage DOCX summary case.
## Test plan
- python3 -m py_compile proposals_app/variable_resolver.py proposals_app/tests.py
- python3 manage.py test proposals_app.tests.ProposalDocumentGenerationTests.test_resolve_budget_table_uses_multistage_summary_for_single_asset proposals_app.tests.ProposalDocumentGenerationTests.test_resolve_budget_table_uses_multistage_summary_for_multiple_assets
- python3 manage.py test proposals_app.tests.ProposalDocumentGenerationTests.test_resolve_budget_table_returns_table_stests.ProposalDocumentGenerationTests.test_resolve_budget_table_omits_asset_column_for_single_asset proposals_app.tests.ProposalDocumentGenerationTests.test_resolve_budget_table_uses_multistage_summary_for_single_asset proposals_app.tests.ProposalDocumentGenerationTests.test_resolve_budget_table_uses_multistage_summary_for_multiple_assets proposals_app.tests.ProposalDocumentGenerationTests.test_process_template_inserts_budget_table proposals_app.tests.ProposalDocumentGenerationTests.test_process_template_inserts_single_asset_budget_table_with_pct_widths proposals_app.tests.ProposalRegistrationFormTests.test_resolve_variables_uses_summary_payload_after_multistage_save