### PR TITLE
Update TKP DOCX summary and stage term variables

### DIFF
--- a/contracts_app/docx_processor.py
+++ b/contracts_app/docx_processor.py
@@ -371,6 +371,56 @@ def _apply_paragraph_style(p_pr, style_id: str | None) -> None:
     p_style.set(qn("w:val"), style_id)
 
 
+def _resolve_character_style_id(paragraph, style_ref: str | None) -> str:
+    style_ref = str(style_ref or "").strip()
+    if not style_ref:
+        return ""
+    style_names = [style_ref]
+    if style_ref in {"Strong", "Сильное выделение"}:
+        style_names = ["Сильное выделение", "Strong"]
+    document = getattr(getattr(paragraph, "part", None), "document", None)
+    styles = getattr(document, "styles", None)
+    if styles is None:
+        return style_ref
+    try:
+        for style_name in style_names:
+            for style in styles:
+                if getattr(style, "name", "") == style_name:
+                    return getattr(style, "style_id", "") or style_ref
+        for style in styles:
+            if getattr(style, "style_id", "") == style_ref:
+                return style_ref
+    except Exception:
+        return style_ref
+    return style_ref
+
+
+def _resolve_rich_item_character_styles(paragraph, rich_items: list[dict[str, object]]) -> list[dict[str, object]]:
+    resolved_items: list[dict[str, object]] = []
+    for item in rich_items:
+        if not isinstance(item, dict):
+            resolved_items.append(item)
+            continue
+        resolved_item = dict(item)
+        runs = resolved_item.get("runs")
+        if isinstance(runs, list):
+            resolved_runs = []
+            for run in runs:
+                if not isinstance(run, dict):
+                    resolved_runs.append(run)
+                    continue
+                resolved_run = dict(run)
+                if resolved_run.get("character_style_id"):
+                    resolved_run["character_style_id"] = _resolve_character_style_id(
+                        paragraph,
+                        str(resolved_run.get("character_style_id") or ""),
+                    )
+                resolved_runs.append(resolved_run)
+            resolved_item["runs"] = resolved_runs
+        resolved_items.append(resolved_item)
+    return resolved_items
+
+
 def _apply_paragraph_left_indent(p_pr, left_indent_cm) -> None:
     if left_indent_cm in (None, ""):
         return
@@ -631,7 +681,7 @@ def _replace_list_in_paragraph(
         _insert_rich_paragraphs(
             anchor,
             parent,
-            rich_items,
+            _resolve_rich_item_character_styles(paragraph, rich_items),
             bullet_num_id=bullet_num_id,
             multilevel_num_id=multilevel_num_id,
             bullet_style_id=bullet_style_id,

--- a/core/static/core/js/proposals-panels.js
+++ b/core/static/core/js/proposals-panels.js
@@ -7848,14 +7848,37 @@
         summaryApi.replaceRows(summaryPayload.rows, { reason: 'summary-sync' });
       }
 
+      let summaryCommercialSyncQueued = false;
+
+      function scheduleSummaryCommercialBlockSync() {
+        if (summaryCommercialSyncQueued) return;
+        summaryCommercialSyncQueued = true;
+        window.setTimeout(function () {
+          summaryCommercialSyncQueued = false;
+          syncSummaryCommercialBlock();
+        }, 0);
+      }
+
       function bindSummaryCommercialSync() {
         getCommercialBlocks().forEach(function (block) {
           if (block.dataset.summarySyncBound === '1') return;
           block.dataset.summarySyncBound = '1';
           block.addEventListener('proposal-commercial-changed', function () {
-            syncSummaryCommercialBlock();
+            scheduleSummaryCommercialBlockSync();
           });
         });
+        if (form.dataset.summaryAssetSyncBound !== '1') {
+          form.dataset.summaryAssetSyncBound = '1';
+          form.addEventListener('proposal-assets-changed', function () {
+            scheduleSummaryCommercialBlockSync();
+          });
+        }
+        if (form.dataset.summaryProductSyncBound !== '1') {
+          form.dataset.summaryProductSyncBound = '1';
+          form.addEventListener('proposal-stage-products-changed', function () {
+            scheduleSummaryCommercialBlockSync();
+          });
+        }
       }
 
       function syncStageTerms() {

--- a/proposals_app/migrations/0051_seed_final_report_term_month_variable.py
+++ b/proposals_app/migrations/0051_seed_final_report_term_month_variable.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+from django.db.models import Max
+
+
+def seed_final_report_term_month_variable(apps, schema_editor):
+    ProposalVariable = apps.get_model("proposals_app", "ProposalVariable")
+    variable = ProposalVariable.objects.filter(key="{{final_report_term_month}}").first()
+    defaults = {
+        "description": "Срок оказания услуг от получения исходных данных до сдачи Итогового отчёта в месяцах",
+        "is_computed": True,
+        "source_section": "",
+        "source_table": "",
+        "source_column": "",
+    }
+    if variable:
+        for field, value in defaults.items():
+            setattr(variable, field, value)
+        variable.save(update_fields=list(defaults))
+        return
+
+    max_position = ProposalVariable.objects.aggregate(m=Max("position"))["m"] or 0
+    ProposalVariable.objects.create(
+        key="{{final_report_term_month}}",
+        position=max_position + 1,
+        **defaults,
+    )
+
+
+def remove_final_report_term_month_variable(apps, schema_editor):
+    return
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("proposals_app", "0050_seed_product_name_list_variable"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            seed_final_report_term_month_variable,
+            remove_final_report_term_month_variable,
+        ),
+    ]

--- a/proposals_app/migrations/0052_seed_stage_terms_variable.py
+++ b/proposals_app/migrations/0052_seed_stage_terms_variable.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+from django.db.models import Max
+
+
+def seed_stage_terms_variable(apps, schema_editor):
+    ProposalVariable = apps.get_model("proposals_app", "ProposalVariable")
+    variable = ProposalVariable.objects.filter(key="[[stage_terms]]").first()
+    defaults = {
+        "description": "Сроки сдачи Предварительного и Итогового отчета по этапу",
+        "is_computed": True,
+        "source_section": "",
+        "source_table": "",
+        "source_column": "",
+    }
+    if variable:
+        for field, value in defaults.items():
+            setattr(variable, field, value)
+        variable.save(update_fields=list(defaults))
+        return
+
+    max_position = ProposalVariable.objects.aggregate(m=Max("position"))["m"] or 0
+    ProposalVariable.objects.create(
+        key="[[stage_terms]]",
+        position=max_position + 1,
+        **defaults,
+    )
+
+
+def remove_stage_terms_variable(apps, schema_editor):
+    return
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("proposals_app", "0051_seed_final_report_term_month_variable"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            seed_stage_terms_variable,
+            remove_stage_terms_variable,
+        ),
+    ]

--- a/proposals_app/templates/proposals_app/proposal_form_page.html
+++ b/proposals_app/templates/proposals_app/proposal_form_page.html
@@ -367,7 +367,9 @@
               </thead>
               <tbody id="proposal-stage-terms-tbody">
                 {% for stage in form.stage_rows %}
-                  <tr class="proposal-stage-terms-row" data-proposal-stage-key="{{ stage.rank }}">
+                  <tr class="proposal-stage-terms-row"
+                      data-proposal-stage-key="{{ stage.rank }}"
+                      data-product-id="{{ stage.product_id|default:'' }}">
                     <td class="proposal-terms-stage-col">
                       <input type="text" class="form-control readonly-field proposal-stage-label-input" value="Этап {{ stage.rank }}" readonly tabindex="-1">
                     </td>

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -3668,7 +3668,7 @@ class ProposalRegistrationFormTests(TestCase):
         self.assertEqual(replacements["{{tkp_preliminary}}"], "(предварительное)")
         self.assertEqual(replacements["{{preliminary_payment_percentage_full}}"], "70%")
         self.assertEqual(replacements["{{preliminary_report_term_month}}"], "4,5 месяца")
-        self.assertEqual(replacements["{{final_report_term_month}}"], "1 мес.")
+        self.assertEqual(replacements["{{final_report_term_month}}"], "5,7 мес.")
         self.assertEqual(replacements["{{stages}}"], "1 этап")
         self.assertEqual(replacements["{{owner_country_full_name}}"], "Российская Федерация")
         self.assertEqual(replacements["{{year}}"], "2026")

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -19,6 +19,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from docx import Document
+from docx.enum.style import WD_STYLE_TYPE
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
 
@@ -634,6 +635,10 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertIn("Этап 2", full_text)
         self.assertIn("Месторождение Приморское", full_text)
         self.assertIn("Фабрика Приморская", full_text)
+        product_paragraph = next(paragraph for paragraph in generated_doc.paragraphs if paragraph.text == "Технический аудит.")
+        self.assertTrue(
+            "w:numPr" in product_paragraph._element.xml or "w:pStyle" in product_paragraph._element.xml
+        )
         scope_paragraph = next(paragraph for paragraph in generated_doc.paragraphs if paragraph.text == "Этап 1 и описание")
         self.assertTrue(any(run.bold for run in scope_paragraph.runs if "Этап 1" in run.text))
         red_paragraph = next(paragraph for paragraph in generated_doc.paragraphs if paragraph.text == "Красный текст")
@@ -754,6 +759,10 @@ class ProposalDocumentGenerationTests(TestCase):
             service_composition="Первый абзац\n\nВторой абзац",
         )
         template_doc = Document()
+        try:
+            strong_style = template_doc.styles.add_style("Сильное выделение", WD_STYLE_TYPE.CHARACTER)
+        except ValueError:
+            strong_style = next(style for style in template_doc.styles if style.name == "Сильное выделение")
         template_doc.add_paragraph("[[scope_of_work]]")
         buffer = BytesIO()
         template_doc.save(buffer)
@@ -772,7 +781,7 @@ class ProposalDocumentGenerationTests(TestCase):
 
         generated_doc = Document(BytesIO(generated_bytes))
         scope_header = next(paragraph for paragraph in generated_doc.paragraphs if paragraph.text == "Состав услуг:")
-        self.assertIn('w:rStyle w:val="Strong"', scope_header._element.xml)
+        self.assertIn(f'w:rStyle w:val="{strong_style.style_id}"', scope_header._element.xml)
         scope_paragraphs = [
             paragraph
             for paragraph in generated_doc.paragraphs
@@ -1021,6 +1030,17 @@ class ProposalDocumentGenerationTests(TestCase):
             total_eur_without_vat="0",
             position=1,
         )
+        ProposalCommercialOffer.objects.create(
+            proposal=proposal,
+            specialist="Иванов И.И.",
+            job_title="Геолог",
+            professional_status="Партнер",
+            service_name="",
+            rate_eur_per_day="100",
+            asset_day_counts=[""],
+            total_eur_without_vat="555",
+            position=2,
+        )
 
         _, _, tables = resolve_variables(
             proposal,
@@ -1046,6 +1066,9 @@ class ProposalDocumentGenerationTests(TestCase):
         self.assertEqual(data_row[4]["text"], "2")
         self.assertEqual(data_row[5]["text"], "3")
         self.assertEqual(data_row[6]["text"], "300,00")
+        manual_total_row = table_spec["rows"][2]
+        self.assertEqual(manual_total_row[5]["text"], "")
+        self.assertEqual(manual_total_row[6]["text"], "555,00")
 
     def test_resolve_budget_table_uses_multistage_summary_for_multiple_assets(self):
         second_product = Product.objects.create(
@@ -1120,8 +1143,8 @@ class ProposalDocumentGenerationTests(TestCase):
             professional_status="Партнер",
             service_name="",
             rate_eur_per_day="100",
-            asset_day_counts=["4", "6"],
-            total_eur_without_vat="999",
+            asset_day_counts=["", ""],
+            total_eur_without_vat="0",
             position=1,
         )
 
@@ -1142,6 +1165,69 @@ class ProposalDocumentGenerationTests(TestCase):
         data_row = table_spec["rows"][2]
         self.assertEqual([cell["text"] for cell in data_row[3:8]], ["1", "2", "3", "4", "10"])
         self.assertEqual(data_row[8]["text"], "1\u00a0000,00")
+
+    def test_resolve_service_cost_uses_commercial_contract_total_when_saved_value_is_empty(self):
+        proposal = ProposalRegistration.objects.create(
+            number=4447,
+            group_member=self.group_member,
+            type=self.product,
+            name="Стоимость из коммерческих итогов",
+            year=2026,
+            status=ProposalRegistration.ProposalStatus.PRELIMINARY,
+            customer='ООО "Приморское"',
+            service_cost=None,
+            commercial_totals_json={
+                "contract_total": "1234567.89",
+                "contract_total_auto": "1200000",
+            },
+        )
+
+        replacements, _, _ = resolve_variables(
+            proposal,
+            [
+                ProposalVariable(
+                    key="{{total_price}}",
+                    source_section="proposals",
+                    source_table="registry",
+                    source_column="service_cost",
+                )
+            ],
+        )
+
+        self.assertEqual(replacements["{{total_price}}"], "1\u00a0234\u00a0567,89")
+
+    def test_resolve_total_price_is_available_as_service_cost_alias(self):
+        proposal = ProposalRegistration.objects.create(
+            number=4448,
+            group_member=self.group_member,
+            type=self.product,
+            name="Алиас стоимости",
+            year=2026,
+            status=ProposalRegistration.ProposalStatus.PRELIMINARY,
+            customer='ООО "Приморское"',
+            service_cost=None,
+            commercial_totals_json={"contract_total": "7654321"},
+        )
+
+        replacements, _, _ = resolve_variables(
+            proposal,
+            [
+                ProposalVariable(
+                    key="{{service_cost}}",
+                    source_section="proposals",
+                    source_table="registry",
+                    source_column="service_cost",
+                )
+            ],
+        )
+        self.assertEqual(replacements["{{service_cost}}"], "7\u00a0654\u00a0321,00")
+        self.assertEqual(replacements["{{total_price}}"], "7\u00a0654\u00a0321,00")
+
+        replacements, _, _ = resolve_variables(
+            proposal,
+            [ProposalVariable(key="{{total_price}}", is_computed=True)],
+        )
+        self.assertEqual(replacements["{{total_price}}"], "7\u00a0654\u00a0321,00")
 
     def test_process_template_inserts_budget_table(self):
         template_doc = Document()
@@ -3529,6 +3615,10 @@ class ProposalRegistrationFormTests(TestCase):
                 is_computed=True,
             ),
             ProposalVariable(
+                key="{{final_report_term_month}}",
+                is_computed=True,
+            ),
+            ProposalVariable(
                 key="{{stages}}",
                 is_computed=True,
             ),
@@ -3560,6 +3650,7 @@ class ProposalRegistrationFormTests(TestCase):
         self.assertEqual(replacements["{{purpose}}"], "Проверка актива")
         self.assertEqual(replacements["{{service_cost}}"], "1\u00a0250\u00a0000,50")
         self.assertEqual(replacements["{{evaluation_date}}"], "01.04.2026")
+        self.assertEqual(replacements["{{effective_date}}"], "01.04.2026")
         self.assertEqual(replacements["{{final_report_term_weeks}}"], "2,0")
         self.assertEqual(replacements["{{status}}"], "Предварительное")
         self.assertEqual(replacements["{{advance_percent}}"], "50%")
@@ -3577,6 +3668,7 @@ class ProposalRegistrationFormTests(TestCase):
         self.assertEqual(replacements["{{tkp_preliminary}}"], "(предварительное)")
         self.assertEqual(replacements["{{preliminary_payment_percentage_full}}"], "70%")
         self.assertEqual(replacements["{{preliminary_report_term_month}}"], "4,5 месяца")
+        self.assertEqual(replacements["{{final_report_term_month}}"], "1 мес.")
         self.assertEqual(replacements["{{stages}}"], "1 этап")
         self.assertEqual(replacements["{{owner_country_full_name}}"], "Российская Федерация")
         self.assertEqual(replacements["{{year}}"], "2026")
@@ -3585,12 +3677,12 @@ class ProposalRegistrationFormTests(TestCase):
         self.assertEqual(
             lists["[[scope_of_work]]"],
             [
-                {"runs": [{"text": "Состав услуг:", "character_style_id": "Strong"}]},
+                {"runs": [{"text": "Состав услуг:", "character_style_id": "Сильное выделение"}]},
                 {"html": "<p><strong>Этап 1</strong></p>"},
                 {"html": "<p><u>Этап 2</u></p>"},
             ],
         )
-        self.assertEqual(lists["[[product_name]]"], [{"runs": [{"text": "Технический аудит."}]}])
+        self.assertEqual(lists["[[product_name]]"], ["Технический аудит."])
         self.assertEqual(lists["[[actives_name]]"], [])
         self.assertEqual(tables, {})
 
@@ -3729,6 +3821,28 @@ class ProposalRegistrationFormTests(TestCase):
 
                 self.assertEqual(replacements["{{stages}}"], expected)
 
+    def test_resolve_final_report_term_month_uses_last_stage_final_report_date(self):
+        proposal = ProposalRegistration(
+            final_report_date=date(2026, 4, 1),
+            stage_payloads_json=[
+                {
+                    "rank": 1,
+                    "service_term_months": "1.0",
+                    "preliminary_report_date": "19.02.2026",
+                    "final_report_date": "01.04.2026",
+                },
+                {"rank": 2, "final_report_date": "04.05.2026"},
+            ],
+        )
+
+        with patch("proposals_app.variable_resolver._today", return_value=date(2030, 1, 5)):
+            replacements, _, _ = resolve_variables(
+                proposal,
+                [ProposalVariable(key="{{final_report_term_month}}", is_computed=True)],
+            )
+
+        self.assertEqual(replacements["{{final_report_term_month}}"], "3,5 мес.")
+
     def test_resolve_product_name_list_uses_stage_order_and_punctuation(self):
         group_member = GroupMember.objects.create(
             short_name="IMC Montan",
@@ -3786,9 +3900,8 @@ class ProposalRegistrationFormTests(TestCase):
             [ProposalVariable(key="[[product_name]]", is_computed=True)],
         )
 
-        texts = [item["runs"][0]["text"] for item in lists["[[product_name]]"]]
         self.assertEqual(
-            texts,
+            lists["[[product_name]]"],
             [
                 "Этап 1 — Технический аудит;",
                 "Этап 2 — Отчёт JORC;",
@@ -3837,6 +3950,125 @@ class ProposalRegistrationFormTests(TestCase):
                 "Акта №\u00a02 на оставшуюся сумму.",
             ],
         )
+
+    def test_resolve_stage_terms_for_single_product_has_only_bullet_lines(self):
+        product = Product.objects.create(
+            short_name="DD",
+            name_en="Due Diligence",
+            name_ru="ДД",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=1,
+        )
+        proposal = ProposalRegistration(
+            type=product,
+            service_term_months="1.0",
+            preliminary_report_date=date(2026, 2, 19),
+            final_report_term_weeks="2.0",
+            final_report_date=date(2026, 3, 5),
+        )
+
+        _, lists, _ = resolve_variables(
+            proposal,
+            [ProposalVariable(key="[[stage_terms]]", is_computed=True)],
+        )
+        items = lists["[[stage_terms]]"]
+        texts = [item["runs"][0]["text"] for item in items]
+
+        self.assertEqual(
+            texts,
+            [
+                "сдача Предварительного отчёта — в течение 1 мес. до 19.02.2026,",
+                "сдача Итогового отчёта — в течение 2 нед. до 05.03.2026.",
+            ],
+        )
+        self.assertEqual(items[0]["list_type"], "bullet")
+        self.assertEqual(items[1]["list_type"], "bullet")
+
+    def test_resolve_stage_terms_for_multistage_uses_stage_dates(self):
+        group_member = GroupMember.objects.create(
+            short_name="IMC Montan",
+            country_name="Россия",
+            country_code="643",
+            country_alpha2="RU",
+            position=1,
+        )
+        first_product = Product.objects.create(
+            short_name="TDD",
+            name_en="Technical Due Diligence",
+            name_ru="ТДД",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=1,
+        )
+        second_product = Product.objects.create(
+            short_name="JORC",
+            name_en="JORC Report",
+            name_ru="JORC",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Оптимизация",
+            position=2,
+        )
+        proposal = ProposalRegistration.objects.create(
+            number=3333,
+            group_member=group_member,
+            type=second_product,
+            name="Поэтапные сроки",
+            year=2026,
+            stage_payloads_json=[
+                {
+                    "rank": 1,
+                    "product_id": first_product.pk,
+                    "service_term_months": "1.0",
+                    "preliminary_report_date": "19.02.2026",
+                    "final_report_term_weeks": "2.0",
+                    "final_report_date": "05.03.2026",
+                },
+                {
+                    "rank": 2,
+                    "product_id": second_product.pk,
+                    "service_term_months": "2.0",
+                    "preliminary_report_date": "05.05.2026",
+                    "final_report_term_weeks": "3.0",
+                    "final_report_date": "26.05.2026",
+                },
+            ],
+        )
+        ProposalRegistrationProduct.objects.bulk_create(
+            [
+                ProposalRegistrationProduct(proposal=proposal, product=first_product, rank=1),
+                ProposalRegistrationProduct(proposal=proposal, product=second_product, rank=2),
+            ]
+        )
+
+        with patch("proposals_app.variable_resolver._today", return_value=date(2030, 1, 5)):
+            _, lists, _ = resolve_variables(
+                proposal,
+                [ProposalVariable(key="[[stage_terms]]", is_computed=True)],
+            )
+        items = lists["[[stage_terms]]"]
+        texts = [item["runs"][0]["text"] for item in items]
+
+        self.assertEqual(
+            texts,
+            [
+                "Этап 1: 1,5 мес.",
+                "сдача Предварительного отчёта — в течение 1 мес. до 19.02.2026,",
+                "сдача Итогового отчёта — в течение 2 нед. до 05.03.2026.",
+                "Этап 2: 2,7 мес.",
+                "сдача Предварительного отчёта — в течение 2 мес. до 05.05.2026,",
+                "сдача Итогового отчёта — в течение 3 нед. до 26.05.2026.",
+            ],
+        )
+        self.assertNotIn("list_type", items[0])
+        self.assertEqual(items[1]["list_type"], "bullet")
+        self.assertEqual(items[2]["list_type"], "bullet")
+        self.assertNotIn("list_type", items[3])
+        self.assertEqual(items[4]["list_type"], "bullet")
+        self.assertEqual(items[5]["list_type"], "bullet")
 
     def test_resolve_payment_schedule_for_common_multistage_schedule(self):
         group_member = GroupMember.objects.create(
@@ -4086,7 +4318,7 @@ class ProposalRegistrationFormTests(TestCase):
         self.assertEqual(
             lists["[[scope_of_work]]"],
             [
-                {"runs": [{"text": "Состав услуг:", "character_style_id": "Strong"}]},
+                {"runs": [{"text": "Состав услуг:", "character_style_id": "Сильное выделение"}]},
                 {"html": "<p><strong>Текст ТЗ заказчика</strong></p>"},
             ],
         )
@@ -5122,11 +5354,13 @@ class ProposalRegistrationFormTests(TestCase):
             lists["[[scope_of_work]]"],
             [
                 {"runs": [{"text": "ЭТАП 1 — Первый продукт.", "bold": True}]},
-                {"runs": [{"text": "Состав услуг по этапу:", "character_style_id": "Strong"}]},
+                {"runs": [{"text": "Состав услуг по этапу:", "character_style_id": "Сильное выделение"}]},
                 {"html": "<p>Scope 1</p>"},
+                {"runs": [{"text": "Дата оценки: 01.01.2026."}]},
                 {"runs": [{"text": "ЭТАП 2 — Второй продукт.", "bold": True}]},
-                {"runs": [{"text": "Состав услуг по этапу:", "character_style_id": "Strong"}]},
+                {"runs": [{"text": "Состав услуг по этапу:", "character_style_id": "Сильное выделение"}]},
                 {"html": "<p><strong>Scope 2</strong></p>"},
+                {"runs": [{"text": "Дата оценки: 05.02.2026."}]},
             ],
         )
         budget_rows = tables["[[budget_table]]"]["rows"]
@@ -6104,6 +6338,8 @@ class ProposalFormContextTests(TestCase):
         self.assertContains(response, "proposal-stage-delay-add", html=False)
         self.assertContains(response, "proposal-stage-delay-remove", html=False)
         self.assertContains(response, 'name="next_stage_delay_days"', html=False)
+        self.assertContains(response, f'data-product-id="{first_product.pk}"', html=False)
+        self.assertContains(response, f'data-product-id="{second_product.pk}"', html=False)
         self.assertContains(response, "Лаг", html=False)
 
 

--- a/proposals_app/variable_resolver.py
+++ b/proposals_app/variable_resolver.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import sys
+import calendar
 from html import escape
 
-from datetime import date
-from decimal import Decimal, InvalidOperation
+from datetime import date, timedelta
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 
 from policy_app.models import ServiceGoalReport
 
@@ -329,7 +330,13 @@ def _proposal_scope_of_work(proposal) -> list[dict[str, object] | str]:
         return fallback if isinstance(fallback, list) else [fallback]
 
     def strong_line(text):
-        return {"runs": [{"text": text, "character_style_id": "Strong"}]}
+        return {"runs": [{"text": text, "character_style_id": "Сильное выделение"}]}
+
+    def evaluation_date_line(source):
+        value = _format_date(source_value(source, "evaluation_date", ""))
+        if not value:
+            return None
+        return {"runs": [{"text": f"Дата оценки: {value}."}]}
 
     products = list(proposal.ordered_products()) if getattr(proposal, "pk", None) else []
     if not products and getattr(proposal, "type_id", None):
@@ -360,6 +367,9 @@ def _proposal_scope_of_work(proposal) -> list[dict[str, object] | str]:
         result.append({"runs": [{"text": f"ЭТАП {index} — {product_name}.", "bold": True}]})
         result.append(strong_line("Состав услуг по этапу:"))
         result.extend(items_from_source(source))
+        date_line = evaluation_date_line(source)
+        if date_line is not None:
+            result.append(date_line)
     return result
 
 
@@ -631,6 +641,7 @@ def _proposal_multistage_budget_table(proposal) -> dict | None:
                 str(getattr(item, "job_title", "") or "").strip(),
             )
             bucket = grouped_rows.get(key)
+            raw_asset_day_counts = list(getattr(item, "asset_day_counts", []) or [])
             source_rows.append(
                 {
                     "specialist": key[0],
@@ -642,7 +653,11 @@ def _proposal_multistage_budget_table(proposal) -> dict | None:
                         if bucket is not None
                         else [[Decimal("0") for _ in range(asset_count)] for _ in range(stage_count)]
                     ),
-                    "asset_day_counts": normalized_day_values(getattr(item, "asset_day_counts", []) or []),
+                    "asset_day_counts": normalized_day_values(raw_asset_day_counts),
+                    "has_saved_day_count_values": any(
+                        value not in (None, "") and str(value).strip() != ""
+                        for value in raw_asset_day_counts
+                    ),
                     "fallback_total": _proposal_day_decimal(getattr(item, "total_eur_without_vat", None)) or Decimal("0"),
                 }
             )
@@ -662,6 +677,7 @@ def _proposal_multistage_budget_table(proposal) -> dict | None:
                         sum(stage_counts[stage_index][asset_index] for stage_index in range(stage_count))
                         for asset_index in range(asset_count)
                     ],
+                    "has_saved_day_count_values": True,
                     "fallback_total": bucket["fallback_total"],
                 }
             )
@@ -670,13 +686,16 @@ def _proposal_multistage_budget_table(proposal) -> dict | None:
         saved_totals = list(source.get("asset_day_counts") or [])
         while len(saved_totals) < asset_count:
             saved_totals.append(Decimal("0"))
-        if any(value for value in saved_totals):
+        if any(value for value in saved_totals) or source.get("has_saved_day_count_values"):
             return saved_totals[:asset_count]
         stage_counts = source.get("stage_asset_day_counts") or []
-        return [
+        stage_totals = [
             sum(stage_counts[stage_index][asset_index] for stage_index in range(stage_count))
             for asset_index in range(asset_count)
         ]
+        if source.get("fallback_total") != Decimal("0"):
+            return saved_totals[:asset_count]
+        return stage_totals if sum(stage_totals, Decimal("0")) else saved_totals[:asset_count]
 
     for source in source_rows:
         stage_counts = source["stage_asset_day_counts"]
@@ -1027,8 +1046,90 @@ def _proposal_evaluation_date(proposal) -> str:
     return _format_date(proposal.evaluation_date)
 
 
+def _parse_proposal_date(value) -> date | None:
+    if not value:
+        return None
+    if isinstance(value, date):
+        return value
+    text = str(value or "").strip()
+    for fmt in ("%Y-%m-%d", "%d.%m.%Y"):
+        try:
+            return date.fromisoformat(text) if fmt == "%Y-%m-%d" else date(
+                int(text[6:10]),
+                int(text[3:5]),
+                int(text[0:2]),
+            )
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _add_whole_months(value: date, months: int) -> date:
+    month_index = value.month - 1 + months
+    year = value.year + month_index // 12
+    month = month_index % 12 + 1
+    day = min(value.day, calendar.monthrange(year, month)[1])
+    return date(year, month, day)
+
+
+def _add_decimal_months(value: date, months: Decimal) -> date:
+    safe_months = max(months, Decimal("0"))
+    whole_months = int(safe_months)
+    fractional_days = int(((safe_months - whole_months) * Decimal("30")) + Decimal("0.5"))
+    return _add_whole_months(value, whole_months) + timedelta(days=fractional_days)
+
+
+def _subtract_decimal_months(value: date, months: Decimal) -> date:
+    safe_months = max(months, Decimal("0"))
+    whole_months = int(safe_months)
+    fractional_days = int(((safe_months - whole_months) * Decimal("30")) + Decimal("0.5"))
+    base = value - timedelta(days=fractional_days)
+    return _add_whole_months(base, -whole_months)
+
+
+def _subtract_decimal_weeks(value: date, weeks: Decimal) -> date:
+    safe_weeks = max(weeks, Decimal("0"))
+    return value - timedelta(days=int((safe_weeks * Decimal("7")) + Decimal("0.5")))
+
+
+def _add_decimal_weeks(value: date, weeks: Decimal) -> date:
+    safe_weeks = max(weeks, Decimal("0"))
+    return value + timedelta(days=int((safe_weeks * Decimal("7")) + Decimal("0.5")))
+
+
+def _proposal_base_start_date() -> date:
+    current = _today() + timedelta(days=14)
+    previous_monday = current - timedelta(days=current.weekday())
+    next_monday = previous_monday + timedelta(days=7)
+    if (current - previous_monday) <= (next_monday - current):
+        return previous_monday
+    return next_monday
+
+
+def _decimal_months_between(start: date, end: date) -> Decimal:
+    if end <= start:
+        return Decimal("0")
+    whole_months = (end.year - start.year) * 12 + (end.month - start.month)
+    whole_date = _add_whole_months(start, whole_months)
+    while whole_months > 0 and whole_date > end:
+        whole_months -= 1
+        whole_date = _add_whole_months(start, whole_months)
+    remainder_days = max(0, (end - whole_date).days)
+    return Decimal(whole_months) + (Decimal(remainder_days) / Decimal("30"))
+
+
 def _proposal_service_term_months(proposal) -> str:
     return _format_decimal(proposal.service_term_months, precision=1)
+
+
+def _format_month_term_short(months: Decimal) -> str:
+    rounded = months.quantize(Decimal("0.1"), rounding=ROUND_HALF_UP)
+    return f"{_format_decimal(rounded, precision=1, strip_trailing_zeros=True)} мес."
+
+
+def _format_week_term_short(weeks: Decimal) -> str:
+    rounded = weeks.quantize(Decimal("0.1"), rounding=ROUND_HALF_UP)
+    return f"{_format_decimal(rounded, precision=1, strip_trailing_zeros=True)} нед."
 
 
 def _proposal_preliminary_report_term_month(proposal) -> str:
@@ -1045,6 +1146,54 @@ def _proposal_preliminary_report_term_month(proposal) -> str:
     else:
         suffix = "месяцев"
     return f"{_format_decimal(months, precision=1, strip_trailing_zeros=True)} {suffix}"
+
+
+def _proposal_last_stage_final_report_date(proposal) -> date | None:
+    stage_payloads = [
+        item
+        for item in (getattr(proposal, "stage_payloads_json", None) or [])
+        if isinstance(item, dict)
+    ]
+    for payload in reversed(stage_payloads):
+        parsed = _parse_proposal_date(payload.get("final_report_date"))
+        if parsed:
+            return parsed
+    return _parse_proposal_date(getattr(proposal, "final_report_date", None))
+
+
+def _proposal_first_stage_start_date(proposal) -> date | None:
+    stage_payloads = [
+        item
+        for item in (getattr(proposal, "stage_payloads_json", None) or [])
+        if isinstance(item, dict)
+    ]
+    sources = stage_payloads or [proposal]
+    source = sources[0]
+    if isinstance(source, dict):
+        preliminary_report_date = _parse_proposal_date(source.get("preliminary_report_date"))
+        final_report_date = _parse_proposal_date(source.get("final_report_date"))
+        service_term_months = _parse_decimal(source.get("service_term_months"))
+        final_report_term_weeks = _parse_decimal(source.get("final_report_term_weeks"))
+    else:
+        preliminary_report_date = _parse_proposal_date(getattr(source, "preliminary_report_date", None))
+        final_report_date = _parse_proposal_date(getattr(source, "final_report_date", None))
+        service_term_months = _parse_decimal(getattr(source, "service_term_months", None))
+        final_report_term_weeks = _parse_decimal(getattr(source, "final_report_term_weeks", None))
+
+    if not preliminary_report_date and final_report_date and final_report_term_weeks is not None:
+        preliminary_report_date = _subtract_decimal_weeks(final_report_date, final_report_term_weeks)
+    if preliminary_report_date and service_term_months is not None:
+        return _subtract_decimal_months(preliminary_report_date, service_term_months)
+    return None
+
+
+def _proposal_final_report_term_month(proposal) -> str:
+    final_report_date = _proposal_last_stage_final_report_date(proposal)
+    if not final_report_date:
+        return ""
+    start_date = _proposal_first_stage_start_date(proposal) or _proposal_base_start_date()
+    months = _decimal_months_between(start_date, final_report_date)
+    return _format_month_term_short(months)
 
 
 def _proposal_stages(proposal) -> str:
@@ -1078,7 +1227,15 @@ def _proposal_report_languages(proposal) -> str:
 
 
 def _proposal_service_cost(proposal) -> str:
-    return _format_money(proposal.service_cost)
+    service_cost = _parse_decimal(getattr(proposal, "service_cost", None))
+    if service_cost not in (None, Decimal("0")):
+        return _format_money(service_cost)
+    totals_state = getattr(proposal, "commercial_totals_json", {}) or {}
+    contract_total = _parse_decimal(totals_state.get("contract_total"))
+    if contract_total not in (None, Decimal("0")):
+        return _format_money(contract_total)
+    contract_total_auto = _parse_decimal(totals_state.get("contract_total_auto"))
+    return _format_money(contract_total_auto)
 
 
 def _proposal_currency(proposal) -> str:
@@ -1123,6 +1280,135 @@ def _proposal_final_report_term_days(proposal) -> str:
     return str(proposal.final_report_term_days or "")
 
 
+def _source_value(source, key: str, attr: str | None = None):
+    if isinstance(source, dict):
+        return source.get(key)
+    return getattr(source, attr or key, None)
+
+
+def _proposal_stage_term_sources(proposal) -> list[dict[str, object]]:
+    products = list(proposal.ordered_products()) if getattr(proposal, "pk", None) else []
+    if not products and getattr(proposal, "type_id", None):
+        products = [proposal.type]
+    stage_payloads = [
+        item
+        for item in (getattr(proposal, "stage_payloads_json", None) or [])
+        if isinstance(item, dict)
+    ]
+    if not products and stage_payloads:
+        products = [None for _ in stage_payloads]
+    if len(products) <= 1:
+        return [{"product": products[0] if products else getattr(proposal, "type", None), "source": stage_payloads[0] if stage_payloads else proposal}]
+
+    payload_by_product_id = {}
+    for payload in stage_payloads:
+        product_id = str(payload.get("product_id") or "").strip()
+        if product_id and product_id not in payload_by_product_id:
+            payload_by_product_id[product_id] = payload
+
+    result = []
+    for index, product in enumerate(products, start=1):
+        product_id = str(getattr(product, "pk", "") or "")
+        indexed_source = stage_payloads[index - 1] if index - 1 < len(stage_payloads) else {}
+        if indexed_source and (not product_id or str(indexed_source.get("product_id") or "") == product_id):
+            source = indexed_source
+        else:
+            source = payload_by_product_id.get(product_id) or indexed_source or proposal
+        result.append({"product": product, "source": source})
+    return result
+
+
+def _proposal_stage_term_values(source, fallback_start_date: date | None = None) -> dict[str, object]:
+    months = _parse_decimal(_source_value(source, "service_term_months")) or Decimal("0")
+    weeks = _parse_decimal(_source_value(source, "final_report_term_weeks")) or Decimal("0")
+    preliminary_date = _parse_proposal_date(_source_value(source, "preliminary_report_date"))
+    final_date = _parse_proposal_date(_source_value(source, "final_report_date"))
+
+    start_date = None
+    if preliminary_date:
+        start_date = _subtract_decimal_months(preliminary_date, months)
+    elif final_date:
+        preliminary_date = _subtract_decimal_weeks(final_date, weeks)
+        start_date = _subtract_decimal_months(preliminary_date, months)
+    elif fallback_start_date:
+        start_date = fallback_start_date
+
+    if start_date and not preliminary_date:
+        preliminary_date = _add_decimal_months(start_date, months)
+    if preliminary_date and not final_date:
+        final_date = _add_decimal_weeks(preliminary_date, weeks)
+
+    if start_date and preliminary_date:
+        months = _decimal_months_between(start_date, preliminary_date)
+    if preliminary_date and final_date:
+        weeks = Decimal(max(0, (final_date - preliminary_date).days)) / Decimal("7")
+    total_months = _decimal_months_between(start_date, final_date) if start_date and final_date else Decimal("0")
+    return {
+        "start_date": start_date,
+        "preliminary_date": preliminary_date,
+        "final_date": final_date,
+        "preliminary_months": months,
+        "final_weeks": weeks,
+        "total_months": total_months,
+        "next_stage_delay_days": _parse_decimal(_source_value(source, "next_stage_delay_days")) or Decimal("0"),
+    }
+
+
+def _proposal_stage_terms(proposal) -> list[dict[str, object]]:
+    sources = _proposal_stage_term_sources(proposal)
+    result: list[dict[str, object]] = []
+    rolling_start_date = _proposal_first_stage_start_date(proposal) or _proposal_base_start_date()
+    has_multiple_stages = len(sources) > 1
+    bullet_format = {"list_type": "bullet"}
+
+    for index, item in enumerate(sources, start=1):
+        values = _proposal_stage_term_values(item["source"], rolling_start_date)
+        if has_multiple_stages:
+            result.append(
+                {
+                    "runs": [
+                        {
+                            "text": f"Этап {index}: {_format_month_term_short(values['total_months'])}",
+                        }
+                    ]
+                }
+            )
+        result.append(
+            {
+                "runs": [
+                    {
+                        "text": (
+                            "сдача Предварительного отчёта — в течение "
+                            f"{_format_month_term_short(values['preliminary_months'])} до "
+                            f"{_format_date(values['preliminary_date'])},"
+                        )
+                    }
+                ],
+                **bullet_format,
+            }
+        )
+        result.append(
+            {
+                "runs": [
+                    {
+                        "text": (
+                            "сдача Итогового отчёта — в течение "
+                            f"{_format_week_term_short(values['final_weeks'])} до "
+                            f"{_format_date(values['final_date'])}."
+                        )
+                    }
+                ],
+                **bullet_format,
+            }
+        )
+
+        stage_end_date = values["final_date"] or values["preliminary_date"] or values["start_date"]
+        if stage_end_date:
+            rolling_start_date = stage_end_date + timedelta(days=int(values["next_stage_delay_days"]))
+
+    return result
+
+
 def _payment_schedule_decimal(value) -> Decimal:
     try:
         return Decimal(str(value if value not in (None, "") else "0"))
@@ -1146,21 +1432,21 @@ def _payment_schedule_product_name(product) -> str:
     )
 
 
-def _proposal_product_name_list(proposal) -> list[dict[str, object]]:
+def _proposal_product_name_list(proposal) -> list[str]:
     products = list(proposal.ordered_products()) if getattr(proposal, "pk", None) else []
     if not products and getattr(proposal, "type_id", None):
         products = [proposal.type]
 
     total = len(products)
-    result: list[dict[str, object]] = []
+    result: list[str] = []
     for index, product in enumerate(products, start=1):
-        product_name = _service_goal_report_value(getattr(product, "pk", None), "product_name")
+        product_name = _payment_schedule_product_name(product)
         if total == 1:
             text = f"{product_name}."
         else:
             ending = "." if index == total else ";"
             text = f"Этап {index} — {product_name}{ending}"
-        result.append({"runs": [{"text": text}]})
+        result.append(text)
     return result
 
 
@@ -1313,12 +1599,15 @@ FIELD_MAP = {
     ("proposals", "registry", "purpose"): _proposal_purpose,
     ("proposals", "registry", "service_composition"): _proposal_service_composition,
     ("proposals", "registry", "evaluation_date"): _proposal_evaluation_date,
+    ("proposals", "registry", "effective_date"): _proposal_evaluation_date,
     ("proposals", "registry", "term"): _proposal_service_term_months,
     ("proposals", "registry", "preliminary_report_date"): _proposal_preliminary_report_date,
     ("proposals", "registry", "final_report_term_weeks"): _proposal_final_report_term_weeks,
+    ("proposals", "registry", "final_report_term_month"): _proposal_final_report_term_month,
     ("proposals", "registry", "final_report_date"): _proposal_final_report_date,
     ("proposals", "registry", "report_languages"): _proposal_report_languages,
     ("proposals", "registry", "service_cost"): _proposal_service_cost,
+    ("proposals", "registry", "total_price"): _proposal_service_cost,
     ("proposals", "registry", "currency"): _proposal_currency,
     ("proposals", "registry", "advance_percent"): _proposal_advance_percent,
     ("proposals", "registry", "advance_term"): _proposal_advance_term_days,
@@ -1344,9 +1633,12 @@ COMPUTED_MAP = {
     "{{tkp_preliminary}}": _proposal_tkp_preliminary,
     "{{preliminary_payment_percentage_full}}": _proposal_preliminary_payment_percentage_full,
     "{{preliminary_report_term_month}}": _proposal_preliminary_report_term_month,
+    "{{final_report_term_month}}": _proposal_final_report_term_month,
     "{{stages}}": _proposal_stages,
     "{{owner_country_full_name}}": _proposal_asset_owner_country_full_name,
     "{{country_full_name}}": _proposal_country_full_name,
+    "{{effective_date}}": _proposal_evaluation_date,
+    "{{total_price}}": _proposal_service_cost,
 }
 
 COMPUTED_LIST_MAP = {
@@ -1354,6 +1646,7 @@ COMPUTED_LIST_MAP = {
     "[[scope_of_work]]": _proposal_scope_of_work,
     "[[payment_schedule]]": _proposal_payment_schedule,
     "[[product_name]]": _proposal_product_name_list,
+    "[[stage_terms]]": _proposal_stage_terms,
 }
 
 COMPUTED_TABLE_MAP = {
@@ -1363,6 +1656,10 @@ COMPUTED_TABLE_MAP = {
 VARIABLE_ALIASES = {
     "{{client_country_full_name}}": ["{{country_full_name}}"],
     "{{country_full_name}}": ["{{client_country_full_name}}"],
+    "{{evaluation_date}}": ["{{effective_date}}"],
+    "{{effective_date}}": ["{{evaluation_date}}"],
+    "{{service_cost}}": ["{{total_price}}"],
+    "{{total_price}}": ["{{service_cost}}"],
 }
 
 


### PR DESCRIPTION
## Summary
- Align DOCX commercial summary table with multi-stage/multi-asset TKP edit mode.
- Add DOCX variables for final report term in months and per-stage report delivery terms.
- Preserve saved TKP report dates on edit and improve DOCX list/strong style handling.
## Test plan
- python3 -m py_compile contracts_app/docx_processor.py core/static/core/js/proposals-panels.js proposals_app/variable_resolver.py proposals_app/tests.py
- python3 manage.py test proposals_app.tests.ProposalRegistrationFormTests.test_resolve_stage_terms_for_single_product_has_only_bullet_lines proposals_app.tests.ProposalRegistrationFormTests.test_resolve_stage_terms_for_multistage_uses_stage_dates
- node --check core/static/core/js/proposals-panels.js