### PR TITLE
Update proposal panels, specialties, and policy flows

### DIFF
--- a/core/static/core/js/proposals-panels.js
+++ b/core/static/core/js/proposals-panels.js
@@ -2931,6 +2931,72 @@
     }
   }
 
+  function setProposalJsonMapEntry(form, scriptId, productId, value) {
+    const root = form?.closest('#proposals-pane') || pane() || document;
+    const script = root.querySelector('#' + scriptId);
+    if (!script || !productId) return;
+    let data = {};
+    try {
+      data = JSON.parse(script.textContent || '{}') || {};
+    } catch (error) {
+      data = {};
+    }
+    data[String(productId)] = value;
+    script.textContent = JSON.stringify(data);
+  }
+
+  function getProposalProductAutofillUrl(form, productId) {
+    const owningForm = getProposalOwningForm(form) || form;
+    const template = String(owningForm?.dataset?.productAutofillUrlTemplate || '');
+    if (!template || !productId) return '';
+    return template.replace('/0/', '/' + encodeURIComponent(productId) + '/');
+  }
+
+  function applyProposalProductAutofillPayload(form, productId, payload) {
+    if (!payload || payload.ok === false) return;
+    const key = String(payload.product_id || productId || '').trim();
+    if (!key) return;
+    setProposalJsonMapEntry(form, 'proposal-typical-sections-data', key, Array.isArray(payload.typical_sections) ? payload.typical_sections : []);
+    setProposalJsonMapEntry(form, 'proposal-service-goal-reports-data', key, payload.service_goal_report || {});
+    setProposalJsonMapEntry(
+      form,
+      'proposal-typical-service-compositions-data',
+      key,
+      Array.isArray(payload.typical_service_compositions) ? payload.typical_service_compositions : []
+    );
+    setProposalJsonMapEntry(form, 'proposal-typical-service-terms-data', key, payload.typical_service_term || {});
+  }
+
+  function refreshProposalProductAutofillData(form, productId) {
+    const key = String(productId || '').trim();
+    const url = getProposalProductAutofillUrl(form, key);
+    if (!url) return Promise.resolve();
+    const owningForm = getProposalOwningForm(form) || form;
+    owningForm.__proposalProductAutofillRequests = owningForm.__proposalProductAutofillRequests || {};
+    if (owningForm.__proposalProductAutofillRequests[key]) {
+      return owningForm.__proposalProductAutofillRequests[key];
+    }
+    const request = fetch(url, {
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      credentials: 'same-origin',
+    })
+      .then(function (response) {
+        if (!response.ok) throw new Error('product-autofill-failed');
+        return response.json();
+      })
+      .then(function (payload) {
+        applyProposalProductAutofillPayload(owningForm, key, payload);
+      })
+      .catch(function (error) {
+        console.warn('Не удалось обновить справочник продукта для ТКП.', error);
+      })
+      .finally(function () {
+        delete owningForm.__proposalProductAutofillRequests[key];
+      });
+    owningForm.__proposalProductAutofillRequests[key] = request;
+    return request;
+  }
+
   function getProposalOwningForm(node) {
     if (!node) return null;
     if (node.matches?.('form[data-proposal-form]')) return node;
@@ -4438,6 +4504,7 @@
       commitServiceRows: function (nextRows, meta) {
         const currentRows = api.getRows();
         const currentTravelRow = currentRows.find(isProposalTravelExpensesRow) || normalizeProposalTravelExpensesRow({});
+        const forceAutofill = meta?.forceAutofill === true;
         rows = ensureSystemDscServiceRows(nextRows).map(function (row, index) {
           const currentRow = currentRows[index] || {};
           const nextServiceName = String(row?.service_name || '').trim();
@@ -4448,7 +4515,7 @@
             code: row?.code || '',
             merge_without_code: normalizeProposalMergeWithoutCode(row?.merge_without_code),
           }, {
-            forceAutofill: nextServiceName !== currentServiceName,
+            forceAutofill: forceAutofill || nextServiceName !== currentServiceName,
           });
         });
         rows.push(normalizeProposalTravelExpensesRow(currentTravelRow));
@@ -4473,7 +4540,7 @@
               merge_without_code: false,
             };
           }),
-          meta
+          { ...(meta || {}), forceAutofill: true }
         );
       },
       subscribe: function (listener) {
@@ -8284,6 +8351,7 @@
         const categorySelect = row.querySelector('.proposal-service-category-select');
         const subtypeSelect = row.querySelector('.proposal-service-subtype-select');
         const productSelect = row.querySelector('.proposal-product-select');
+        let productAutofillRefreshSeq = 0;
 
         function syncRow(state) {
           const selectedProduct = productById.get(String(state?.productId ?? productSelect?.value ?? ''));
@@ -8343,20 +8411,29 @@
         }
 
         consultingSelect?.addEventListener('change', function () {
+          productAutofillRefreshSeq += 1;
           syncRow({ consultingType: consultingSelect.value, serviceCategory: '', serviceSubtype: '', productId: '' });
           syncStageContent();
         });
         categorySelect?.addEventListener('change', function () {
+          productAutofillRefreshSeq += 1;
           syncRow({ consultingType: consultingSelect?.value || '', serviceCategory: categorySelect.value, serviceSubtype: '', productId: '' });
           syncStageContent();
         });
         subtypeSelect?.addEventListener('change', function () {
+          productAutofillRefreshSeq += 1;
           syncRow({ consultingType: consultingSelect?.value || '', serviceCategory: categorySelect?.value || '', serviceSubtype: subtypeSelect.value, productId: '' });
           syncStageContent();
         });
         productSelect?.addEventListener('change', function () {
-          syncRow({ productId: productSelect.value });
-          syncStageContent();
+          const selectedProductId = String(productSelect.value || '').trim();
+          const refreshSeq = productAutofillRefreshSeq + 1;
+          productAutofillRefreshSeq = refreshSeq;
+          syncRow({ productId: selectedProductId });
+          refreshProposalProductAutofillData(form, selectedProductId).finally(function () {
+            if (refreshSeq !== productAutofillRefreshSeq) return;
+            syncStageContent();
+          });
         });
 
         syncRow({

--- a/policy_app/tests.py
+++ b/policy_app/tests.py
@@ -1067,6 +1067,42 @@ class TypicalSectionViewsTests(TestCase):
             [first_specialty.pk, second_specialty.pk],
         )
 
+    def test_section_csv_upload_updates_existing_section_by_product_and_code(self):
+        section = TypicalSection.objects.create(
+            product=self.product,
+            code="SEC-UPD",
+            short_name="old-en",
+            short_name_ru="old-ru",
+            name_en="Old EN",
+            name_ru="Старый раздел",
+            accounting_type="Раздел",
+            exclude_from_tkp_autofill=False,
+            position=1,
+        )
+        csv_file = SimpleUploadedFile(
+            "sections.csv",
+            (
+                "Продукт;Код;Краткое имя EN;Краткое имя RU;"
+                "Наименование раздела (услуги) EN;Наименование раздела (услуги) RU;"
+                "Тип учета;Исполнитель;Экспертиза;Подразделение;ТКП\n"
+                "SEC;SEC-UPD;new-en;new-ru;New EN;Новый раздел;Услуги;;;;Да\n"
+            ).encode("utf-8"),
+            content_type="text/csv",
+        )
+
+        response = self.client.post(reverse("section_csv_upload"), {"csv_file": csv_file})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["created"], 0)
+        self.assertEqual(response.json()["updated"], 1)
+        section.refresh_from_db()
+        self.assertEqual(section.short_name, "new-en")
+        self.assertEqual(section.short_name_ru, "new-ru")
+        self.assertEqual(section.name_en, "New EN")
+        self.assertEqual(section.name_ru, "Новый раздел")
+        self.assertEqual(section.accounting_type, "Услуги")
+        self.assertTrue(section.exclude_from_tkp_autofill)
+
     def test_section_csv_upload_rolls_back_row_when_specialty_insert_fails(self):
         owner = GroupMember.objects.create(
             short_name="IMC",
@@ -1428,6 +1464,36 @@ class ServiceGoalReportViewsTests(TestCase):
         self.assertEqual(item.report_title, "Отчет по документам")
         self.assertEqual(item.product_name, "Документарная проверка")
         self.assertEqual(item.position, 1)
+
+    def test_service_goal_report_csv_upload_updates_existing_product_row(self):
+        item = ServiceGoalReport.objects.create(
+            product=self.product,
+            service_goal="Старая цель",
+            service_goal_genitive="Старой цели",
+            report_title="Старый титул",
+            product_name="Старый продукт",
+            position=1,
+        )
+        csv_file = SimpleUploadedFile(
+            "service_goal_reports.csv",
+            (
+                "Продукт;Цели оказания услуг;Цели оказания услуг в родительном падеже;Титул отчета/ТКП;Название продукта\n"
+                "TAX;Новая цель;Новой цели;Новый титул;Новый продукт\n"
+            ).encode("utf-8"),
+            content_type="text/csv",
+        )
+
+        response = self.client.post(reverse("service_goal_report_csv_upload"), {"csv_file": csv_file})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["created"], 0)
+        self.assertEqual(response.json()["updated"], 1)
+        self.assertEqual(ServiceGoalReport.objects.count(), 1)
+        item.refresh_from_db()
+        self.assertEqual(item.service_goal, "Новая цель")
+        self.assertEqual(item.service_goal_genitive, "Новой цели")
+        self.assertEqual(item.report_title, "Новый титул")
+        self.assertEqual(item.product_name, "Новый продукт")
 
     def test_move_up_reorders_globally_across_table(self):
         other_product = Product.objects.create(
@@ -3664,6 +3730,34 @@ class TypicalServiceTermViewsTests(TestCase):
         self.assertEqual(item.preliminary_report_months, Decimal("2.5"))
         self.assertEqual(item.final_report_weeks, 4)
 
+    def test_typical_service_term_csv_upload_updates_existing_product_row(self):
+        item = TypicalServiceTerm.objects.create(
+            product=self.product,
+            source_data_weeks=1,
+            preliminary_report_months=Decimal("1.0"),
+            final_report_weeks=2,
+            position=1,
+        )
+        csv_file = SimpleUploadedFile(
+            "typical_service_terms.csv",
+            (
+                "Продукт;Сроки предоставления исходных данных, нед.;Срок подготовки Предварительного отчёта, мес.;Срок подготовки Итогового отчёта, нед.\n"
+                "TERM;4;3,5;7\n"
+            ).encode("utf-8"),
+            content_type="text/csv",
+        )
+
+        response = self.client.post(reverse("typical_service_term_csv_upload"), {"csv_file": csv_file})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["created"], 0)
+        self.assertEqual(response.json()["updated"], 1)
+        self.assertEqual(TypicalServiceTerm.objects.count(), 1)
+        item.refresh_from_db()
+        self.assertEqual(item.source_data_weeks, 4)
+        self.assertEqual(item.preliminary_report_months, Decimal("3.5"))
+        self.assertEqual(item.final_report_weeks, 7)
+
     def test_non_staff_user_cannot_reorder_typical_service_terms(self):
         first = TypicalServiceTerm.objects.create(
             product=self.product,
@@ -3997,6 +4091,37 @@ class TariffViewsTests(TestCase):
         self.assertEqual(tariff.service_hours, 16)
         self.assertEqual(tariff.service_days_tkp, 6)
         self.assertEqual(tariff.created_by, self.user)
+        self.assertEqual(tariff.position, 1)
+
+    def test_tariff_csv_upload_updates_existing_product_section_owner_row(self):
+        tariff = Tariff.objects.create(
+            product=self.product,
+            section=self.section,
+            base_rate_vpm=Decimal("10.00"),
+            service_hours=8,
+            service_days_tkp=5,
+            created_by=self.user,
+            position=1,
+        )
+        csv_file = SimpleUploadedFile(
+            "section_tariffs.csv",
+            (
+                "Продукт;Раздел (услуга);Базовая ставка в ВПМ;Объем услуг в часах;Объем услуг в днях для ТКП\n"
+                "TAR;Тарифный раздел;22,50;18;9\n"
+            ).encode("utf-8"),
+            content_type="text/csv",
+        )
+
+        response = self.client.post(reverse("tariff_csv_upload"), {"csv_file": csv_file})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["created"], 0)
+        self.assertEqual(response.json()["updated"], 1)
+        self.assertEqual(Tariff.objects.count(), 1)
+        tariff.refresh_from_db()
+        self.assertEqual(tariff.base_rate_vpm, Decimal("22.50"))
+        self.assertEqual(tariff.service_hours, 18)
+        self.assertEqual(tariff.service_days_tkp, 9)
         self.assertEqual(tariff.position, 1)
 
     def test_move_up_normalizes_positions_before_reorder(self):

--- a/policy_app/views.py
+++ b/policy_app/views.py
@@ -1004,6 +1004,7 @@ def section_csv_upload(request):
     }
     data_rows = rows[1:]
     created = 0
+    updated = 0
     warnings = []
 
     for i, row in enumerate(data_rows, start=2):
@@ -1077,23 +1078,48 @@ def section_csv_upload(request):
             if not expertise_direction:
                 warnings.append(f"Строка {i}: подразделение «{expertise_name}» не найдено. Поле оставлено пустым.")
 
-        position = _next_position(TypicalSection, {"product": product})
         try:
             with transaction.atomic():
                 ensure_system_dsc_section(product)
-                section = TypicalSection.objects.create(
-                    product=product,
-                    code=code,
-                    short_name=short_name,
-                    short_name_ru=short_name_ru,
-                    name_en=name_en,
-                    name_ru=name_ru,
-                    accounting_type=accounting_type,
-                    expertise_dir=expertise_dir,
-                    expertise_direction=expertise_direction,
-                    exclude_from_tkp_autofill=_csv_truthy(tkp_raw),
-                    position=position,
-                )
+                section = TypicalSection.objects.filter(product=product, code=code).first()
+                was_created = section is None
+                if was_created:
+                    section = TypicalSection.objects.create(
+                        product=product,
+                        code=code,
+                        short_name=short_name,
+                        short_name_ru=short_name_ru,
+                        name_en=name_en,
+                        name_ru=name_ru,
+                        accounting_type=accounting_type,
+                        expertise_dir=expertise_dir,
+                        expertise_direction=expertise_direction,
+                        exclude_from_tkp_autofill=_csv_truthy(tkp_raw),
+                        position=_next_position(TypicalSection, {"product": product}),
+                    )
+                else:
+                    section.short_name = short_name
+                    section.short_name_ru = short_name_ru
+                    section.name_en = name_en
+                    section.name_ru = name_ru
+                    section.accounting_type = accounting_type
+                    section.expertise_dir = expertise_dir
+                    section.expertise_direction = expertise_direction
+                    section.exclude_from_tkp_autofill = _csv_truthy(tkp_raw)
+                    section.save(
+                        update_fields=[
+                            "short_name",
+                            "short_name_ru",
+                            "name_en",
+                            "name_ru",
+                            "accounting_type",
+                            "expertise_dir",
+                            "expertise_direction",
+                            "exclude_from_tkp_autofill",
+                            "updated_at",
+                        ]
+                    )
+                    TypicalSectionSpecialty.objects.filter(section=section).delete()
                 missing_specialties = []
                 for rank, specialty_name in enumerate(_split_csv_list_value(executor_raw, specialties_by_name), start=1):
                     specialty = specialties_by_name.get(_csv_lookup_key(specialty_name))
@@ -1103,12 +1129,15 @@ def section_csv_upload(request):
                     TypicalSectionSpecialty.objects.create(section=section, specialty=specialty, rank=rank)
             if missing_specialties:
                 warnings.append(f"Строка {i}: исполнители не найдены: {', '.join(missing_specialties)}.")
-            created += 1
+            if was_created:
+                created += 1
+            else:
+                updated += 1
             ensure_system_dsc_section(product)
         except Exception as exc:
             warnings.append(f"Строка {i}: ошибка сохранения — {exc}")
 
-    return JsonResponse({"ok": True, "created": created, "warnings": warnings})
+    return JsonResponse({"ok": True, "created": created, "updated": updated, "warnings": warnings})
 
 
 @login_required
@@ -1446,6 +1475,7 @@ def service_goal_report_csv_upload(request):
 
     products_by_name = {_csv_lookup_key(p.short_name): p for p in Product.objects.all()}
     created = 0
+    updated = 0
     warnings = []
 
     for i, row in enumerate(rows[1:], start=2):
@@ -1466,19 +1496,23 @@ def service_goal_report_csv_upload(request):
             continue
 
         try:
-            ServiceGoalReport.objects.create(
-                product=product,
-                service_goal=row[1].strip(),
-                service_goal_genitive=row[2].strip(),
-                report_title=row[3].strip(),
-                product_name=row[4].strip(),
-                position=_next_position(ServiceGoalReport),
-            )
-            created += 1
+            item = ServiceGoalReport.objects.filter(product=product).order_by("position", "id").first()
+            was_created = item is None
+            if was_created:
+                item = ServiceGoalReport(product=product, position=_next_position(ServiceGoalReport))
+            item.service_goal = row[1].strip()
+            item.service_goal_genitive = row[2].strip()
+            item.report_title = row[3].strip()
+            item.product_name = row[4].strip()
+            item.save()
+            if was_created:
+                created += 1
+            else:
+                updated += 1
         except Exception as exc:
             warnings.append(f"Строка {i}: ошибка сохранения — {exc}")
 
-    return JsonResponse({"ok": True, "created": created, "warnings": warnings})
+    return JsonResponse({"ok": True, "created": created, "updated": updated, "warnings": warnings})
 
 
 @login_required
@@ -3088,6 +3122,7 @@ def typical_service_term_csv_upload(request):
 
     products_by_name = {_csv_lookup_key(p.short_name): p for p in Product.objects.all()}
     created = 0
+    updated = 0
     warnings = []
 
     for i, row in enumerate(rows[1:], start=2):
@@ -3140,18 +3175,22 @@ def typical_service_term_csv_upload(request):
             continue
 
         try:
-            TypicalServiceTerm.objects.create(
-                product=product,
-                source_data_weeks=source_data_weeks,
-                preliminary_report_months=preliminary_report_months,
-                final_report_weeks=final_report_weeks,
-                position=_next_position(TypicalServiceTerm),
-            )
-            created += 1
+            item = TypicalServiceTerm.objects.filter(product=product).order_by("position", "id").first()
+            was_created = item is None
+            if was_created:
+                item = TypicalServiceTerm(product=product, position=_next_position(TypicalServiceTerm))
+            item.source_data_weeks = source_data_weeks
+            item.preliminary_report_months = preliminary_report_months
+            item.final_report_weeks = final_report_weeks
+            item.save()
+            if was_created:
+                created += 1
+            else:
+                updated += 1
         except Exception as exc:
             warnings.append(f"Строка {i}: ошибка сохранения — {exc}")
 
-    return JsonResponse({"ok": True, "created": created, "warnings": warnings})
+    return JsonResponse({"ok": True, "created": created, "updated": updated, "warnings": warnings})
 
 
 @login_required
@@ -3811,6 +3850,7 @@ def tariff_csv_upload(request):
                     owners_by_label.setdefault(key, user)
 
     created = 0
+    updated = 0
     warnings = []
 
     for i, row in enumerate(rows[1:], start=2):
@@ -3872,20 +3912,32 @@ def tariff_csv_upload(request):
                 continue
 
         try:
-            Tariff.objects.create(
-                product=product,
-                section=section,
-                base_rate_vpm=base_rate_vpm,
-                service_hours=service_hours,
-                service_days_tkp=service_days_tkp,
-                created_by=owner,
-                position=_next_position(Tariff, {"created_by": owner}),
+            tariff = (
+                Tariff.objects
+                .filter(product=product, section=section, created_by=owner)
+                .order_by("position", "id")
+                .first()
             )
-            created += 1
+            was_created = tariff is None
+            if was_created:
+                tariff = Tariff(
+                    product=product,
+                    section=section,
+                    created_by=owner,
+                    position=_next_position(Tariff, {"created_by": owner}),
+                )
+            tariff.base_rate_vpm = base_rate_vpm
+            tariff.service_hours = service_hours
+            tariff.service_days_tkp = service_days_tkp
+            tariff.save()
+            if was_created:
+                created += 1
+            else:
+                updated += 1
         except Exception as exc:
             warnings.append(f"Строка {i}: ошибка сохранения — {exc}")
 
-    return JsonResponse({"ok": True, "created": created, "warnings": warnings})
+    return JsonResponse({"ok": True, "created": created, "updated": updated, "warnings": warnings})
 
 
 @login_required

--- a/proposals_app/templates/proposals_app/proposal_form_page.html
+++ b/proposals_app/templates/proposals_app/proposal_form_page.html
@@ -16,6 +16,7 @@
         data-region-autofill-url="{% url 'ler_region_autofill' %}"
         data-ler-search-url="{% url 'ler_search' %}"
         data-cbr-rate-refresh-url="{% url 'proposal_cbr_eur_rate' %}"
+        data-product-autofill-url-template="{% url 'proposal_product_autofill' 0 %}"
         {% if action == "create" %}
           hx-post="{% url 'proposal_form_create' %}"
         {% else %}

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -7190,6 +7190,281 @@ class ProposalFormContextTests(TestCase):
             ],
         )
 
+    def test_product_autofill_endpoint_returns_fresh_product_defaults(self):
+        product = Product.objects.create(
+            short_name="FRESH",
+            name_en="Fresh Product",
+            name_ru="Актуальный продукт",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=4,
+        )
+        section = TypicalSection.objects.create(
+            product=product,
+            code="OLD",
+            short_name="old",
+            short_name_ru="Старый",
+            name_en="Old section",
+            name_ru="Старый раздел",
+            accounting_type="Раздел",
+            position=1,
+        )
+        composition = TypicalServiceComposition.objects.create(
+            product=product,
+            section=section,
+            service_composition="Старый состав",
+            service_composition_editor_state={"html": "<p>Старый состав</p>", "plain_text": "Старый состав"},
+            position=1,
+        )
+        TypicalServiceTerm.objects.create(
+            product=product,
+            preliminary_report_months=Decimal("1.0"),
+            final_report_weeks=2,
+            position=1,
+        )
+
+        section.code = "NEW"
+        section.short_name = "new"
+        section.name_en = "New section"
+        section.name_ru = "Актуальный раздел"
+        section.save()
+        composition.service_composition = "Актуальный состав"
+        composition.service_composition_editor_state = {
+            "html": "<p>Актуальный состав</p>",
+            "plain_text": "Актуальный состав",
+        }
+        composition.save()
+
+        response = self.client.get(reverse("proposal_product_autofill", args=[product.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["product_id"], str(product.pk))
+        section_entry = next(item for item in payload["typical_sections"] if item["code"] == "NEW")
+        self.assertEqual(section_entry["name"], "Актуальный раздел")
+        self.assertEqual(
+            payload["typical_service_compositions"],
+            [
+                {
+                    "code": "NEW",
+                    "service_name": "Актуальный раздел",
+                    "service_composition": "Актуальный состав",
+                    "service_composition_editor_state": {
+                        "html": "<p>Актуальный состав</p>",
+                        "plain_text": "Актуальный состав",
+                    },
+                }
+            ],
+        )
+        self.assertEqual(
+            payload["typical_service_term"],
+            {"preliminary_report_months": "1.0", "final_report_weeks": "2.0"},
+        )
+        self.assertEqual(response["Cache-Control"], "no-store")
+
+    def test_product_autofill_endpoint_includes_fresh_goal_terms_rates_grades_and_tariffs(self):
+        product = Product.objects.create(
+            short_name="FULL",
+            name_en="Full Product",
+            name_ru="Полный продукт",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=4,
+        )
+        section = TypicalSection.objects.create(
+            product=product,
+            code="FULL-1",
+            short_name="full-one",
+            short_name_ru="full-one-ru",
+            name_en="Full section",
+            name_ru="Полный раздел",
+            accounting_type="Раздел",
+            position=1,
+        )
+        specialty = ExpertSpecialty.objects.create(specialty="Финансовый эксперт", position=1)
+        TypicalSectionSpecialty.objects.create(section=section, specialty=specialty, rank=1)
+        grade = Grade.objects.create(
+            grade_en="Senior",
+            grade_ru="Старший",
+            qualification=4,
+            qualification_levels=5,
+            base_rate_share=30,
+            created_by=self.user,
+            position=1,
+        )
+        _, employee = self._create_staff_employee(
+            username="full-autofill-expert",
+            first_name="Ирина",
+            last_name="Тарифова",
+        )
+        profile = ExpertProfile.objects.create(
+            employee=employee,
+            professional_status="Certified Public Accountant",
+            professional_status_short="CPA",
+            grade=grade,
+            position=1,
+        )
+        ExpertProfileSpecialty.objects.create(profile=profile, specialty=specialty, rank=1)
+        SpecialtyTariff.objects.create(
+            specialty_group="Финансы",
+            daily_rate_tkp_eur="1200.00",
+            position=1,
+        ).specialties.set([specialty])
+        Tariff.objects.create(
+            product=product,
+            section=section,
+            base_rate_vpm="1.00",
+            service_hours=8,
+            service_days_tkp=11,
+            created_by=self.user,
+            position=1,
+        )
+        ServiceGoalReport.objects.create(
+            product=product,
+            service_goal="Проверить актуальные цели",
+            service_goal_genitive="Проверки актуальных целей",
+            report_title="Актуальный титул ТКП",
+            product_name="Актуальное имя продукта",
+            position=1,
+        )
+        TypicalServiceTerm.objects.create(
+            product=product,
+            preliminary_report_months=Decimal("2.5"),
+            final_report_weeks=6,
+            position=1,
+        )
+
+        response = self.client.get(reverse("proposal_product_autofill", args=[product.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(
+            payload["service_goal_report"],
+            {
+                "report_title": "Актуальный титул ТКП",
+                "service_goal": "Проверить актуальные цели",
+                "service_goal_genitive": "Проверки актуальных целей",
+            },
+        )
+        self.assertEqual(
+            payload["typical_service_term"],
+            {"preliminary_report_months": "2.5", "final_report_weeks": "6.0"},
+        )
+        section_entry = next(item for item in payload["typical_sections"] if item["code"] == "FULL-1")
+        self.assertEqual(section_entry["specialty_tariff_rate_eur"], "1200.00")
+        self.assertEqual(section_entry["service_days_tkp"], 11)
+        self.assertEqual(section_entry["default_specialist"], "Ирина Тарифова")
+        self.assertEqual(section_entry["default_professional_status"], "CPA")
+        self.assertEqual(section_entry["default_base_rate_share"], 30)
+        self.assertEqual(section_entry["specialist_options"][0]["base_rate_share"], 30)
+
+    def test_product_autofill_endpoint_reflects_sections_created_by_csv_upload(self):
+        product = Product.objects.create(
+            short_name="CSV",
+            name_en="CSV Product",
+            name_ru="CSV продукт",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=4,
+        )
+        TypicalSection.objects.create(
+            product=product,
+            code="CSV-1",
+            short_name="old-csv",
+            short_name_ru="old-csv-ru",
+            name_en="Old CSV",
+            name_ru="Старый CSV раздел",
+            accounting_type="Раздел",
+            position=1,
+        )
+        initial_response = self.client.get(reverse("proposal_product_autofill", args=[product.pk]))
+        initial_entry = next(
+            item for item in initial_response.json()["typical_sections"] if item["code"] == "CSV-1"
+        )
+        self.assertEqual(initial_entry["name"], "Старый CSV раздел")
+        csv_file = SimpleUploadedFile(
+            "sections.csv",
+            (
+                "Продукт;Код;Краткое имя EN;Краткое имя RU;Наименование EN;Наименование RU;Тип учета;Направление экспертизы\n"
+                "CSV;CSV-1;csv-one;csv-one-ru;CSV One;CSV раздел;Раздел;\n"
+            ).encode("utf-8"),
+            content_type="text/csv",
+        )
+
+        upload_response = self.client.post(reverse("section_csv_upload"), {"csv_file": csv_file})
+        response = self.client.get(reverse("proposal_product_autofill", args=[product.pk]))
+
+        self.assertEqual(upload_response.status_code, 200)
+        self.assertEqual(upload_response.json()["created"], 0)
+        self.assertEqual(upload_response.json()["updated"], 1)
+        payload = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("CSV-1", [item["code"] for item in payload["typical_sections"]])
+        section_entry = next(item for item in payload["typical_sections"] if item["code"] == "CSV-1")
+        self.assertEqual(section_entry["name"], "CSV раздел")
+
+    def test_product_autofill_endpoint_keeps_edit_snapshot_but_exposes_fresh_defaults(self):
+        product = Product.objects.create(
+            short_name="EDIT",
+            name_en="Edit Product",
+            name_ru="Edit продукт",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+            position=4,
+        )
+        section = TypicalSection.objects.create(
+            product=product,
+            code="EDIT-NEW",
+            short_name="edit-new",
+            name_en="Edit New",
+            name_ru="Актуальный edit раздел",
+            accounting_type="Раздел",
+            position=1,
+        )
+        TypicalServiceComposition.objects.create(
+            product=product,
+            section=section,
+            service_composition="Актуальный edit состав",
+            service_composition_editor_state={
+                "html": "<p>Актуальный edit состав</p>",
+                "plain_text": "Актуальный edit состав",
+            },
+            position=1,
+        )
+        proposal = ProposalRegistration.objects.create(
+            number=3333,
+            group_member=self.group_member,
+            type=product,
+            name="ТКП со старым снимком",
+            year=2026,
+            stage_payloads_json=[
+                {
+                    "rank": 1,
+                    "product_id": product.pk,
+                    "service_sections_json": [{"service_name": "Старый раздел", "code": "EDIT-OLD"}],
+                    "service_sections_editor_state": [
+                        {"code": "EDIT-OLD", "service_name": "Старый раздел", "html": "", "plain_text": "Старый состав"}
+                    ],
+                    "commercial_offer_payload": [{"service_name": "Старый раздел", "code": "EDIT-OLD"}],
+                }
+            ],
+        )
+        ProposalRegistrationProduct.objects.create(proposal=proposal, product=product, rank=1)
+
+        edit_response = self.client.get(reverse("proposal_form_edit", args=[proposal.pk]))
+        endpoint_response = self.client.get(reverse("proposal_product_autofill", args=[product.pk]))
+
+        self.assertEqual(edit_response.status_code, 200)
+        self.assertContains(edit_response, "EDIT-OLD", html=False)
+        payload = endpoint_response.json()
+        self.assertIn("EDIT-NEW", [item["code"] for item in payload["typical_sections"]])
+        self.assertEqual(payload["typical_service_compositions"][0]["service_composition"], "Актуальный edit состав")
+
     def test_typical_service_terms_json_exposes_first_product_default(self):
         product = Product.objects.create(
             short_name="TERM",

--- a/proposals_app/urls.py
+++ b/proposals_app/urls.py
@@ -11,6 +11,7 @@ sys.modules.setdefault("ai_app.proposals_app.urls", sys.modules[__name__])
 urlpatterns = [
     path("proposals/partial/", views.proposals_partial, name="proposals_partial"),
     path("proposals/cbr-eur-rate/", views.proposal_cbr_eur_rate, name="proposal_cbr_eur_rate"),
+    path("proposals/products/<int:product_id>/autofill/", views.proposal_product_autofill, name="proposal_product_autofill"),
     path("proposals/row-order/", views.proposal_row_order, name="proposal_row_order"),
     path("proposals/create/", views.proposal_form_create, name="proposal_form_create"),
     path("proposals/<int:pk>/edit/", views.proposal_form_edit, name="proposal_form_edit"),

--- a/proposals_app/views.py
+++ b/proposals_app/views.py
@@ -1448,7 +1448,7 @@ def _proposal_product_catalog():
     }
 
 
-def _render_proposal_form(request, *, form, action, proposal=None):
+def _proposal_product_autofill_data(product_ids=None):
     def _section_specialty_names(section):
         names = []
         seen = set()
@@ -1498,6 +1498,14 @@ def _render_proposal_form(request, *, form, action, proposal=None):
             "service_days_tkp": section_tariff_days,
             "specialty_is_director": True,
             "specialist_options": [],
+        }
+
+    product_filter = None
+    if product_ids is not None:
+        product_filter = {
+            int(product_id)
+            for product_id in product_ids
+            if str(product_id or "").strip().isdigit() and int(product_id) > 0
         }
 
     specialty_candidates = {}
@@ -1583,11 +1591,12 @@ def _render_proposal_form(request, *, form, action, proposal=None):
             )
         specialty_candidates[specialty_name] = ordered_candidates
 
-    product_ids = [
-        str(product_id)
-        for product_id in Product.objects.order_by("position", "id").values_list("id", flat=True)
-    ]
-    sections = list(
+    products_qs = Product.objects.order_by("position", "id")
+    if product_filter is not None:
+        products_qs = products_qs.filter(pk__in=product_filter)
+    product_ids = [str(product_id) for product_id in products_qs.values_list("id", flat=True)]
+
+    sections_qs = (
         TypicalSection.objects
         .select_related("product", "expertise_dir", "expertise_direction")
         .prefetch_related(
@@ -1602,31 +1611,33 @@ def _render_proposal_form(request, *, form, action, proposal=None):
         )
         .order_by("product_id", "position", "id")
     )
-    service_goal_reports = list(
-        ServiceGoalReport.objects
-        .select_related("product")
-        .order_by("product_id", "position", "id")
+    service_goal_reports_qs = ServiceGoalReport.objects.select_related("product").order_by("product_id", "position", "id")
+    typical_service_compositions_qs = (
+        TypicalServiceComposition.objects.select_related("product", "section").order_by("product_id", "position", "id")
     )
-    typical_service_compositions = list(
-        TypicalServiceComposition.objects
-        .select_related("product", "section")
-        .order_by("product_id", "position", "id")
-    )
-    typical_service_terms = list(
-        TypicalServiceTerm.objects
-        .select_related("product")
-        .order_by("product_id", "position", "id")
-    )
+    typical_service_terms_qs = TypicalServiceTerm.objects.select_related("product").order_by("product_id", "position", "id")
+    if product_filter is not None:
+        sections_qs = sections_qs.filter(product_id__in=product_filter)
+        service_goal_reports_qs = service_goal_reports_qs.filter(product_id__in=product_filter)
+        typical_service_compositions_qs = typical_service_compositions_qs.filter(product_id__in=product_filter)
+        typical_service_terms_qs = typical_service_terms_qs.filter(product_id__in=product_filter)
+    sections = list(sections_qs)
+    service_goal_reports = list(service_goal_reports_qs)
+    typical_service_compositions = list(typical_service_compositions_qs)
+    typical_service_terms = list(typical_service_terms_qs)
     specialty_tariffs = list(
         SpecialtyTariff.objects
         .prefetch_related("specialties")
         .order_by("position", "id")
     )
-    section_tariffs = list(
+    section_tariffs_qs = (
         Tariff.objects
         .select_related("product", "section")
         .order_by("product_id", "position", "id")
     )
+    if product_filter is not None:
+        section_tariffs_qs = section_tariffs_qs.filter(product_id__in=product_filter)
+    section_tariffs = list(section_tariffs_qs)
     direction_ids = {
         section.expertise_direction_id
         for section in sections
@@ -1774,6 +1785,15 @@ def _render_proposal_form(request, *, form, action, proposal=None):
             "preliminary_report_months": format(item.preliminary_report_months, ".1f"),
             "final_report_weeks": format(item.final_report_weeks, ".1f"),
         }
+    return {
+        "typical_sections_json": sections_map,
+        "service_goal_reports_json": service_goal_reports_map,
+        "typical_service_compositions_json": typical_service_compositions_map,
+        "typical_service_terms_json": typical_service_terms_map,
+    }
+
+
+def _render_proposal_form(request, *, form, action, proposal=None):
     return render(
         request,
         PROPOSAL_FORM_TEMPLATE,
@@ -1782,10 +1802,7 @@ def _render_proposal_form(request, *, form, action, proposal=None):
             "action": action,
             "proposal": proposal,
             "proposal_type_meta_json": json.dumps(_proposal_product_catalog(), ensure_ascii=False),
-            "typical_sections_json": sections_map,
-            "service_goal_reports_json": service_goal_reports_map,
-            "typical_service_compositions_json": typical_service_compositions_map,
-            "typical_service_terms_json": typical_service_terms_map,
+            **_proposal_product_autofill_data(),
         },
     )
 
@@ -2027,6 +2044,27 @@ def proposal_cbr_eur_rate(request):
             "rub_total_service_text": get_cbr_eur_rate_text(),
         }
     )
+
+
+@login_required
+@user_passes_test(staff_required)
+@require_GET
+def proposal_product_autofill(request, product_id: int):
+    product = get_object_or_404(Product, pk=product_id)
+    product_key = str(product.pk)
+    data = _proposal_product_autofill_data(product_ids=[product.pk])
+    response = JsonResponse(
+        {
+            "ok": True,
+            "product_id": product_key,
+            "typical_sections": data["typical_sections_json"].get(product_key, []),
+            "service_goal_report": data["service_goal_reports_json"].get(product_key, {}),
+            "typical_service_compositions": data["typical_service_compositions_json"].get(product_key, []),
+            "typical_service_term": data["typical_service_terms_json"].get(product_key, {}),
+        }
+    )
+    response["Cache-Control"] = "no-store"
+    return response
 
 
 @login_required

--- a/staticfiles/core/js/proposals-panels.js
+++ b/staticfiles/core/js/proposals-panels.js
@@ -2870,6 +2870,72 @@
     }
   }
 
+  function setProposalJsonMapEntry(form, scriptId, productId, value) {
+    const root = form?.closest('#proposals-pane') || pane() || document;
+    const script = root.querySelector('#' + scriptId);
+    if (!script || !productId) return;
+    let data = {};
+    try {
+      data = JSON.parse(script.textContent || '{}') || {};
+    } catch (error) {
+      data = {};
+    }
+    data[String(productId)] = value;
+    script.textContent = JSON.stringify(data);
+  }
+
+  function getProposalProductAutofillUrl(form, productId) {
+    const owningForm = getProposalOwningForm(form) || form;
+    const template = String(owningForm?.dataset?.productAutofillUrlTemplate || '');
+    if (!template || !productId) return '';
+    return template.replace('/0/', '/' + encodeURIComponent(productId) + '/');
+  }
+
+  function applyProposalProductAutofillPayload(form, productId, payload) {
+    if (!payload || payload.ok === false) return;
+    const key = String(payload.product_id || productId || '').trim();
+    if (!key) return;
+    setProposalJsonMapEntry(form, 'proposal-typical-sections-data', key, Array.isArray(payload.typical_sections) ? payload.typical_sections : []);
+    setProposalJsonMapEntry(form, 'proposal-service-goal-reports-data', key, payload.service_goal_report || {});
+    setProposalJsonMapEntry(
+      form,
+      'proposal-typical-service-compositions-data',
+      key,
+      Array.isArray(payload.typical_service_compositions) ? payload.typical_service_compositions : []
+    );
+    setProposalJsonMapEntry(form, 'proposal-typical-service-terms-data', key, payload.typical_service_term || {});
+  }
+
+  function refreshProposalProductAutofillData(form, productId) {
+    const key = String(productId || '').trim();
+    const url = getProposalProductAutofillUrl(form, key);
+    if (!url) return Promise.resolve();
+    const owningForm = getProposalOwningForm(form) || form;
+    owningForm.__proposalProductAutofillRequests = owningForm.__proposalProductAutofillRequests || {};
+    if (owningForm.__proposalProductAutofillRequests[key]) {
+      return owningForm.__proposalProductAutofillRequests[key];
+    }
+    const request = fetch(url, {
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      credentials: 'same-origin',
+    })
+      .then(function (response) {
+        if (!response.ok) throw new Error('product-autofill-failed');
+        return response.json();
+      })
+      .then(function (payload) {
+        applyProposalProductAutofillPayload(owningForm, key, payload);
+      })
+      .catch(function (error) {
+        console.warn('Не удалось обновить справочник продукта для ТКП.', error);
+      })
+      .finally(function () {
+        delete owningForm.__proposalProductAutofillRequests[key];
+      });
+    owningForm.__proposalProductAutofillRequests[key] = request;
+    return request;
+  }
+
   function getProposalOwningForm(node) {
     if (!node) return null;
     if (node.matches?.('form[data-proposal-form]')) return node;
@@ -4377,6 +4443,7 @@
       commitServiceRows: function (nextRows, meta) {
         const currentRows = api.getRows();
         const currentTravelRow = currentRows.find(isProposalTravelExpensesRow) || normalizeProposalTravelExpensesRow({});
+        const forceAutofill = meta?.forceAutofill === true;
         rows = ensureSystemDscServiceRows(nextRows).map(function (row, index) {
           const currentRow = currentRows[index] || {};
           const nextServiceName = String(row?.service_name || '').trim();
@@ -4387,7 +4454,7 @@
             code: row?.code || '',
             merge_without_code: normalizeProposalMergeWithoutCode(row?.merge_without_code),
           }, {
-            forceAutofill: nextServiceName !== currentServiceName,
+            forceAutofill: forceAutofill || nextServiceName !== currentServiceName,
           });
         });
         rows.push(normalizeProposalTravelExpensesRow(currentTravelRow));
@@ -4412,7 +4479,7 @@
               merge_without_code: false,
             };
           }),
-          meta
+          { ...(meta || {}), forceAutofill: true }
         );
       },
       subscribe: function (listener) {
@@ -8224,6 +8291,7 @@
         const categorySelect = row.querySelector('.proposal-service-category-select');
         const subtypeSelect = row.querySelector('.proposal-service-subtype-select');
         const productSelect = row.querySelector('.proposal-product-select');
+        let productAutofillRefreshSeq = 0;
 
         function syncRow(state) {
           const selectedProduct = productById.get(String(state?.productId ?? productSelect?.value ?? ''));
@@ -8283,20 +8351,29 @@
         }
 
         consultingSelect?.addEventListener('change', function () {
+          productAutofillRefreshSeq += 1;
           syncRow({ consultingType: consultingSelect.value, serviceCategory: '', serviceSubtype: '', productId: '' });
           syncStageContent();
         });
         categorySelect?.addEventListener('change', function () {
+          productAutofillRefreshSeq += 1;
           syncRow({ consultingType: consultingSelect?.value || '', serviceCategory: categorySelect.value, serviceSubtype: '', productId: '' });
           syncStageContent();
         });
         subtypeSelect?.addEventListener('change', function () {
+          productAutofillRefreshSeq += 1;
           syncRow({ consultingType: consultingSelect?.value || '', serviceCategory: categorySelect?.value || '', serviceSubtype: subtypeSelect.value, productId: '' });
           syncStageContent();
         });
         productSelect?.addEventListener('change', function () {
-          syncRow({ productId: productSelect.value });
-          syncStageContent();
+          const selectedProductId = String(productSelect.value || '').trim();
+          const refreshSeq = productAutofillRefreshSeq + 1;
+          productAutofillRefreshSeq = refreshSeq;
+          syncRow({ productId: selectedProductId });
+          refreshProposalProductAutofillData(form, selectedProductId).finally(function () {
+            if (refreshSeq !== productAutofillRefreshSeq) return;
+            syncStageContent();
+          });
         });
 
         syncRow({


### PR DESCRIPTION
## Summary
- Updated proposal panels frontend behavior and static assets.
- Adjusted proposal form, routes, and view logic.
- Updated policy/proposal tests to cover the latest behavior.
## Test plan
- CI/CD should run from this pull request.
- Relevant Django tests were updated in `policy_app` and `proposals_app`.