### PR TITLE
Disambiguate duplicate proposal sections

### DIFF
--- a/core/static/core/js/proposals-panels.js
+++ b/core/static/core/js/proposals-panels.js
@@ -3193,7 +3193,7 @@
     if (label) return label;
     const name = String(entry?.name || '').trim();
     const code = String(entry?.code || '').trim();
-    return code && name ? (code + ' - ' + name) : name;
+    return code && name ? (code + ' ' + name) : name;
   }
 
   function getProposalSectionSelectKeyForEntries(entries, serviceName, code) {
@@ -3237,15 +3237,55 @@
       if (!key || !name) return;
       const option = document.createElement('option');
       option.value = key;
-      option.textContent = getProposalSectionDisplayName(entry);
+      const displayName = getProposalSectionDisplayName(entry);
+      option.textContent = displayName;
       option.dataset.sectionName = name;
       option.dataset.sectionCode = String(entry?.code || '').trim();
+      option.dataset.sectionDisplayName = displayName;
       optionKeys.push(key);
       select.appendChild(option);
     });
 
     select.value = optionKeys.includes(previousKey) ? previousKey : '';
+    bindProposalSectionSelectDisplay(select);
+    collapseProposalSectionSelectDisplay(select);
     return select.value !== previousKey;
+  }
+
+  function expandProposalSectionSelectDisplay(select) {
+    if (!(select instanceof HTMLSelectElement)) return;
+    Array.from(select.options).forEach(function (option) {
+      const displayName = String(option.dataset.sectionDisplayName || '').trim();
+      if (displayName) option.textContent = displayName;
+    });
+  }
+
+  function collapseProposalSectionSelectDisplay(select) {
+    if (!(select instanceof HTMLSelectElement)) return;
+    const selectedOption = select.options[select.selectedIndex];
+    const sectionName = String(selectedOption?.dataset?.sectionName || '').trim();
+    if (selectedOption && selectedOption.value && sectionName) {
+      selectedOption.textContent = sectionName;
+    }
+  }
+
+  function bindProposalSectionSelectDisplay(select) {
+    if (!(select instanceof HTMLSelectElement) || select.dataset.sectionDisplayBound === '1') return;
+    select.dataset.sectionDisplayBound = '1';
+    select.addEventListener('pointerdown', function () {
+      expandProposalSectionSelectDisplay(select);
+    });
+    select.addEventListener('keydown', function (event) {
+      if (['ArrowDown', 'ArrowUp', 'Enter', ' ', 'Home', 'End'].includes(event.key)) {
+        expandProposalSectionSelectDisplay(select);
+      }
+    });
+    select.addEventListener('change', function () {
+      window.setTimeout(function () { collapseProposalSectionSelectDisplay(select); }, 0);
+    });
+    select.addEventListener('blur', function () {
+      collapseProposalSectionSelectDisplay(select);
+    });
   }
 
   function getProposalSelectedSection(select, form, fallbackCode) {
@@ -4624,13 +4664,15 @@
           const currentRow = currentRows[index] || {};
           const nextServiceName = String(row?.service_name || '').trim();
           const currentServiceName = String(currentRow?.service_name || '').trim();
+          const nextCode = String(row?.code || '').trim();
+          const currentCode = String(currentRow?.code || '').trim();
           return normalizeRow({
             ...currentRow,
             service_name: nextServiceName,
-            code: row?.code || '',
+            code: nextCode,
             merge_without_code: normalizeProposalMergeWithoutCode(row?.merge_without_code),
           }, {
-            forceAutofill: forceAutofill || nextServiceName !== currentServiceName,
+            forceAutofill: forceAutofill || nextServiceName !== currentServiceName || nextCode !== currentCode,
           });
         });
         rows.push(normalizeProposalTravelExpensesRow(currentTravelRow));
@@ -5416,7 +5458,12 @@
         };
       }
       const serviceControl = row.querySelector('.proposal-commercial-service');
-      const selectedSection = getProposalSelectedSection(serviceControl, form, row.dataset.commercialCode || '');
+      const selectedSection = serviceControl instanceof HTMLSelectElement
+        ? getProposalSelectedSection(serviceControl, form, row.dataset.commercialCode || '')
+        : {
+          serviceName: String(serviceControl?.value || '').trim(),
+          code: String(row.dataset.commercialCode || '').trim(),
+        };
       return {
         specialist: (row.querySelector('.proposal-commercial-specialist')?.value || '').trim(),
         job_title: (row.querySelector('.proposal-commercial-job-title')?.value || '').trim(),

--- a/proposals_app/tests.py
+++ b/proposals_app/tests.py
@@ -7405,7 +7405,7 @@ class ProposalFormContextTests(TestCase):
         self.assertEqual([item["select_key"] for item in water_sections], ["PRW", "INW"])
         self.assertEqual(
             [item["display_name"] for item in water_sections],
-            ["PRW - Водоснабжение", "INW - Водоснабжение"],
+            ["PRW Водоснабжение", "INW Водоснабжение"],
         )
 
     def test_product_autofill_endpoint_reflects_sections_created_by_csv_upload(self):

--- a/proposals_app/views.py
+++ b/proposals_app/views.py
@@ -1509,7 +1509,7 @@ def _proposal_product_autofill_data(product_ids=None):
     def _section_display_name(section_name, section_code):
         name = (section_name or "").strip()
         code = (section_code or "").strip()
-        return f"{code} - {name}" if code and name else name
+        return f"{code} {name}" if code and name else name
 
     product_filter = None
     if product_ids is not None:

--- a/staticfiles/core/js/proposals-panels.js
+++ b/staticfiles/core/js/proposals-panels.js
@@ -3132,7 +3132,7 @@
     if (label) return label;
     const name = String(entry?.name || '').trim();
     const code = String(entry?.code || '').trim();
-    return code && name ? (code + ' - ' + name) : name;
+    return code && name ? (code + ' ' + name) : name;
   }
 
   function getProposalSectionSelectKeyForEntries(entries, serviceName, code) {
@@ -3176,15 +3176,55 @@
       if (!key || !name) return;
       const option = document.createElement('option');
       option.value = key;
-      option.textContent = getProposalSectionDisplayName(entry);
+      const displayName = getProposalSectionDisplayName(entry);
+      option.textContent = displayName;
       option.dataset.sectionName = name;
       option.dataset.sectionCode = String(entry?.code || '').trim();
+      option.dataset.sectionDisplayName = displayName;
       optionKeys.push(key);
       select.appendChild(option);
     });
 
     select.value = optionKeys.includes(previousKey) ? previousKey : '';
+    bindProposalSectionSelectDisplay(select);
+    collapseProposalSectionSelectDisplay(select);
     return select.value !== previousKey;
+  }
+
+  function expandProposalSectionSelectDisplay(select) {
+    if (!(select instanceof HTMLSelectElement)) return;
+    Array.from(select.options).forEach(function (option) {
+      const displayName = String(option.dataset.sectionDisplayName || '').trim();
+      if (displayName) option.textContent = displayName;
+    });
+  }
+
+  function collapseProposalSectionSelectDisplay(select) {
+    if (!(select instanceof HTMLSelectElement)) return;
+    const selectedOption = select.options[select.selectedIndex];
+    const sectionName = String(selectedOption?.dataset?.sectionName || '').trim();
+    if (selectedOption && selectedOption.value && sectionName) {
+      selectedOption.textContent = sectionName;
+    }
+  }
+
+  function bindProposalSectionSelectDisplay(select) {
+    if (!(select instanceof HTMLSelectElement) || select.dataset.sectionDisplayBound === '1') return;
+    select.dataset.sectionDisplayBound = '1';
+    select.addEventListener('pointerdown', function () {
+      expandProposalSectionSelectDisplay(select);
+    });
+    select.addEventListener('keydown', function (event) {
+      if (['ArrowDown', 'ArrowUp', 'Enter', ' ', 'Home', 'End'].includes(event.key)) {
+        expandProposalSectionSelectDisplay(select);
+      }
+    });
+    select.addEventListener('change', function () {
+      window.setTimeout(function () { collapseProposalSectionSelectDisplay(select); }, 0);
+    });
+    select.addEventListener('blur', function () {
+      collapseProposalSectionSelectDisplay(select);
+    });
   }
 
   function getProposalSelectedSection(select, form, fallbackCode) {
@@ -4563,13 +4603,15 @@
           const currentRow = currentRows[index] || {};
           const nextServiceName = String(row?.service_name || '').trim();
           const currentServiceName = String(currentRow?.service_name || '').trim();
+          const nextCode = String(row?.code || '').trim();
+          const currentCode = String(currentRow?.code || '').trim();
           return normalizeRow({
             ...currentRow,
             service_name: nextServiceName,
-            code: row?.code || '',
+            code: nextCode,
             merge_without_code: normalizeProposalMergeWithoutCode(row?.merge_without_code),
           }, {
-            forceAutofill: forceAutofill || nextServiceName !== currentServiceName,
+            forceAutofill: forceAutofill || nextServiceName !== currentServiceName || nextCode !== currentCode,
           });
         });
         rows.push(normalizeProposalTravelExpensesRow(currentTravelRow));
@@ -5355,7 +5397,12 @@
         };
       }
       const serviceControl = row.querySelector('.proposal-commercial-service');
-      const selectedSection = getProposalSelectedSection(serviceControl, form, row.dataset.commercialCode || '');
+      const selectedSection = serviceControl instanceof HTMLSelectElement
+        ? getProposalSelectedSection(serviceControl, form, row.dataset.commercialCode || '')
+        : {
+          serviceName: String(serviceControl?.value || '').trim(),
+          code: String(row.dataset.commercialCode || '').trim(),
+        };
       return {
         specialist: (row.querySelector('.proposal-commercial-specialist')?.value || '').trim(),
         job_title: (row.querySelector('.proposal-commercial-job-title')?.value || '').trim(),


### PR DESCRIPTION
## Summary
- Use section codes as stable selection keys so duplicate section names remain unambiguous.
- Show section codes in proposal service dropdown options, while keeping the selected field display as the section name.
- Preserve free-text summary commercial service edits and re-autofill commercial rows when a duplicate-name section code changes.
- Added/updated regression coverage for duplicate TypicalSection names and refreshed collected static JS.
## Test plan
- Run CI/CD checks for this pull request.
- Locally verified duplicate section-name regression test and JS syntax checks.