### PR TITLE
Update checklist and performer approval flows

### DIFF
--- a/checklists_app/templates/checklists_app/includes/checklists_grid_js.html
+++ b/checklists_app/templates/checklists_app/includes/checklists_grid_js.html
@@ -239,6 +239,24 @@
       return rows.slice(start, end);
     }
 
+    function renumberRowsInPayload() {
+      const rows = state.payload?.rows || [];
+      const counters = new Map();
+      let currentSectionId = null;
+      rows.forEach((row) => {
+        if (row.kind === "section_header") {
+          currentSectionId = row.sectionId;
+          if (!counters.has(currentSectionId)) counters.set(currentSectionId, 0);
+          return;
+        }
+        if (row.kind !== "item") return;
+        const sectionId = row.sectionId || currentSectionId || "";
+        const nextNumber = (counters.get(sectionId) || 0) + 1;
+        counters.set(sectionId, nextNumber);
+        row.number = String(nextNumber).padStart(2, "0");
+      });
+    }
+
     function renderActions() {
       const ui = state.payload?.ui || {};
       if (!ui.createUrl && !ui.xlsxUrl && !ui.showActions && !ui.approveInfoRequestUrl && !ui.infoRequestApprovedAt) return "";
@@ -2144,6 +2162,7 @@
           (row) => row.kind !== "item" || !deleteSet.has(String(row.id))
         );
         deleteSet.forEach((id) => state.selectedItems.delete(id));
+        renumberRowsInPayload();
         reindexRows();
         render();
         return;
@@ -2183,6 +2202,7 @@
           [sectionItems[posInSection], sectionItems[swapPos]] = [sectionItems[swapPos], sectionItems[posInSection]];
         }
 
+        renumberRowsInPayload();
         reindexRows();
         render();
         restoreSelection(saved);

--- a/checklists_app/tests.py
+++ b/checklists_app/tests.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from policy_app.models import EXPERT_GROUP, Product, TypicalSection
 from projects_app.models import LegalEntity, Performer, ProjectRegistration, WorkVolume
 from users_app.models import Employee
+from notifications_app.models import Notification, NotificationPerformerLink
 
 from checklists_app.models import ChecklistCustomerStatus, ChecklistItem, ChecklistStatus, SharedChecklistLink
 from checklists_app.views import _project_options
@@ -222,7 +223,7 @@ class ChecklistStatusPermissionTests(TestCase):
             patronymic="Иванович",
             role=EXPERT_GROUP,
         )
-        Performer.objects.create(
+        self.performer_allowed = Performer.objects.create(
             work_item=self.work_allowed,
             registration=self.project,
             asset_name="Asset A",
@@ -275,6 +276,67 @@ class ChecklistStatusPermissionTests(TestCase):
         self.assertFalse(wrong_asset_cell["editable"])
         self.assertFalse(other_section_cell["editable"])
         self.assertFalse(allowed_customer_cell["editable"])
+
+    def test_expert_section_filter_keeps_create_url_for_pending_own_section(self):
+        notification = Notification.objects.create(
+            notification_type=Notification.NotificationType.PROJECT_INFO_REQUEST_APPROVAL,
+            recipient=self.expert_user,
+            project=self.project,
+            title_text="Согласуйте запрос",
+        )
+        NotificationPerformerLink.objects.create(
+            notification=notification,
+            performer=self.performer_allowed,
+        )
+        self.client.force_login(self.expert_user)
+
+        response = self.client.get(reverse("checklists_app:grid_data"), {
+            "project_uid": self.project.short_uid,
+            "asset": "all",
+            "section": str(self.section_allowed.id),
+        })
+
+        self.assertEqual(response.status_code, 200)
+        create_url = response.json()["ui"]["createUrl"]
+        self.assertIn(reverse("checklists_app:item_form_create"), create_url)
+        self.assertIn(f"section={self.section_allowed.id}", create_url)
+
+    def test_batch_edit_renumbers_items_after_reorder(self):
+        second = ChecklistItem.objects.create(
+            project=self.project,
+            section=self.section_allowed,
+            code="ALW",
+            number=2,
+            position=2,
+            short_name="Second item",
+            name="Second item",
+        )
+        third = ChecklistItem.objects.create(
+            project=self.project,
+            section=self.section_allowed,
+            code="ALW",
+            number=3,
+            position=3,
+            short_name="Third item",
+            name="Third item",
+        )
+        self.client.force_login(self.expert_user)
+
+        response = self._post_json(reverse("checklists_app:item_batch_edit"), {
+            "order": [
+                {"id": third.id, "position": 0},
+                {"id": self.item_allowed.id, "position": 1},
+                {"id": second.id, "position": 2},
+            ],
+        })
+
+        self.assertEqual(response.status_code, 204)
+        self.item_allowed.refresh_from_db()
+        second.refresh_from_db()
+        third.refresh_from_db()
+        self.assertEqual(third.number, 1)
+        self.assertEqual(self.item_allowed.number, 2)
+        self.assertEqual(second.number, 3)
 
     def test_expert_can_update_only_confirmed_imcm_status_and_not_customer_status(self):
         self.client.force_login(self.expert_user)

--- a/checklists_app/views.py
+++ b/checklists_app/views.py
@@ -1818,7 +1818,8 @@ def grid_data(request):
                     .values_list("typical_section_id", flat=True).distinct()
                 )
                 user_approved_sections = user_approved_sections | processed_section_ids
-            if _current_section and _current_section.id not in user_approved_sections:
+            user_create_sections = user_approved_sections | set(pending_section_ids)
+            if _current_section and _current_section.id not in user_create_sections:
                 payload["ui"]["createUrl"] = ""
 
         any_sent = _Notif.objects.filter(
@@ -2604,40 +2605,63 @@ def item_check_number(request):
 @login_required
 @require_POST
 def item_delete(request, pk):
-    ci = get_object_or_404(ChecklistItem, pk=pk)
-    ci.delete()
+    with transaction.atomic():
+        ci = get_object_or_404(ChecklistItem.objects.select_for_update(), pk=pk)
+        project_id = ci.project_id
+        section_id = ci.section_id
+        ci.delete()
+        _renumber_checklist_items(project_id, [section_id])
     resp = HttpResponse(status=204)
     resp["HX-Trigger"] = "checklists:saved"
     return resp
 
 
+def _renumber_checklist_items(project_id: int, section_ids) -> None:
+    for section_id in {sid for sid in section_ids if sid}:
+        items = list(
+            ChecklistItem.objects
+            .select_for_update()
+            .filter(project_id=project_id, section_id=section_id)
+            .order_by("position", "id")
+        )
+        changed = []
+        for idx, item in enumerate(items, start=1):
+            if item.number != idx:
+                item.number = idx
+                changed.append(item)
+        if changed:
+            ChecklistItem.objects.bulk_update(changed, ["number"])
+
+
 @login_required
 @require_POST
 def item_move(request, pk, direction):
-    ci = get_object_or_404(ChecklistItem, pk=pk)
+    with transaction.atomic():
+        ci = get_object_or_404(ChecklistItem.objects.select_for_update(), pk=pk)
 
-    group_filter = Q(project=ci.project, section=ci.section)
-    if ci.item_type == ChecklistItem.ItemType.ADDITIONAL and ci.additional_number is not None:
-        group_filter &= Q(item_type=ChecklistItem.ItemType.ADDITIONAL, additional_number=ci.additional_number)
-    else:
-        group_filter &= Q(item_type=ChecklistItem.ItemType.BASIC)
+        group_filter = Q(project=ci.project, section=ci.section)
+        if ci.item_type == ChecklistItem.ItemType.ADDITIONAL and ci.additional_number is not None:
+            group_filter &= Q(item_type=ChecklistItem.ItemType.ADDITIONAL, additional_number=ci.additional_number)
+        else:
+            group_filter &= Q(item_type=ChecklistItem.ItemType.BASIC)
 
-    siblings = ChecklistItem.objects.filter(group_filter).order_by("position", "id")
-    items = list(siblings)
-    idx = next((i for i, x in enumerate(items) if x.pk == ci.pk), None)
-    if idx is None:
-        return HttpResponse(status=204)
+        siblings = ChecklistItem.objects.select_for_update().filter(group_filter).order_by("position", "id")
+        items = list(siblings)
+        idx = next((i for i, x in enumerate(items) if x.pk == ci.pk), None)
+        if idx is None:
+            return HttpResponse(status=204)
 
-    if direction == "up" and idx > 0:
-        swap = items[idx - 1]
-    elif direction == "down" and idx < len(items) - 1:
-        swap = items[idx + 1]
-    else:
-        return HttpResponse(status=204)
+        if direction == "up" and idx > 0:
+            swap = items[idx - 1]
+        elif direction == "down" and idx < len(items) - 1:
+            swap = items[idx + 1]
+        else:
+            return HttpResponse(status=204)
 
-    ci.position, swap.position = swap.position, ci.position
-    ci.save(update_fields=["position"])
-    swap.save(update_fields=["position"])
+        ci.position, swap.position = swap.position, ci.position
+        ci.save(update_fields=["position"])
+        swap.save(update_fields=["position"])
+        _renumber_checklist_items(ci.project_id, [ci.section_id])
     resp = HttpResponse(status=204)
     resp["HX-Trigger"] = "checklists:saved"
     return resp
@@ -2656,6 +2680,19 @@ def item_batch_edit(request):
     text_updates = data.get("text_updates") or []
 
     with transaction.atomic():
+        affected_sections_by_project: dict[int, set[int]] = {}
+        order_item_ids = [
+            entry.get("id") for entry in order_list
+            if entry.get("id") is not None
+        ]
+        affected_item_ids = list(deleted_ids) + order_item_ids
+        if affected_item_ids:
+            affected_rows = ChecklistItem.objects.filter(pk__in=affected_item_ids).values_list(
+                "project_id", "section_id",
+            )
+            for project_id, section_id in affected_rows:
+                affected_sections_by_project.setdefault(project_id, set()).add(section_id)
+
         if deleted_ids:
             ChecklistItem.objects.filter(pk__in=deleted_ids).delete()
 
@@ -2674,6 +2711,9 @@ def item_batch_edit(request):
             if field == "name" and not value:
                 continue
             ChecklistItem.objects.filter(pk=item_id).update(**{field: value})
+
+        for project_id, section_ids in affected_sections_by_project.items():
+            _renumber_checklist_items(project_id, section_ids)
 
     resp = HttpResponse(status=204)
     resp["HX-Trigger"] = "checklists:saved"

--- a/core/static/core/js/performers-panels.js
+++ b/core/static/core/js/performers-panels.js
@@ -599,16 +599,30 @@
   function getCreateSourceDataBtn() {
     return pane()?.querySelector('#create-source-data-btn');
   }
+  function getRevokeInfoApprovalBtn() {
+    return pane()?.querySelector('#revoke-info-approval-btn');
+  }
 
   function getSelectedInfoRequestProjectId() {
     const filter = window.__infoRequestProjectFilter;
     if (filter && filter.length === 1 && filter[0] !== '__all__') return filter[0];
     return null;
   }
+  function getInfoRequestRowForCheck(checkbox) {
+    return checkbox?.closest('tr[data-project-id]') || null;
+  }
+  function isInfoRequestRowSent(row) {
+    return row?.dataset?.infoRequestSent === '1';
+  }
+  function isInfoRequestRowApproved(row) {
+    return row?.dataset?.infoApprovalStatus === 'approved';
+  }
 
   function updateInfoRequestState() {
     const boxes = getVisibleInfoRequestChecks();
-    const checkedCount = boxes.filter(b => b.checked).length;
+    const checked = boxes.filter(b => b.checked);
+    const checkedCount = checked.length;
+    const checkedRows = checked.map(getInfoRequestRowForCheck).filter(Boolean);
     const master = getInfoRequestMaster();
     if (master) {
       master.checked = boxes.length > 0 && checkedCount === boxes.length;
@@ -617,11 +631,22 @@
     updateRowHighlight('info-request-select');
 
     const requestBtn = getInfoRequestBtn();
-    if (requestBtn) requestBtn.disabled = checkedCount === 0;
+    if (requestBtn) {
+      const canRequestApproval = checkedCount > 0 && checkedRows.every((row) => !isInfoRequestRowSent(row));
+      requestBtn.disabled = !canRequestApproval;
+    }
+
+    const revokeBtn = getRevokeInfoApprovalBtn();
+    if (revokeBtn) {
+      const hasApprovedSelection = checkedRows.some(isInfoRequestRowApproved);
+      const canRevoke = checkedCount === 1 && checkedRows.length === 1 && isInfoRequestRowApproved(checkedRows[0]);
+      revokeBtn.classList.toggle('d-none', !hasApprovedSelection);
+      revokeBtn.disabled = !canRevoke;
+    }
 
     const controls = getInfoRequestDeadlineControls();
     if (controls) {
-      const show = checkedCount > 0;
+      const show = checkedCount > 0 && checkedRows.every((row) => !isInfoRequestRowSent(row));
       controls.classList.toggle('invisible', !show);
       controls.classList.toggle('pe-none', !show);
     }
@@ -2367,6 +2392,41 @@
       ensurePerformerActionsVisibility();
 
       await htmx.ajax('GET', url, { target: '#performers-modal .modal-content', swap: 'innerHTML' });
+      return;
+    }
+
+    const revokeInfoApprovalBtn = e.target.closest('#revoke-info-approval-btn');
+    if (revokeInfoApprovalBtn && root.contains(revokeInfoApprovalBtn)) {
+      const checked = getVisibleInfoRequestChecks().filter((cb) => cb.checked);
+      if (checked.length !== 1 || revokeInfoApprovalBtn.disabled) return;
+
+      const requestPanel = getInfoRequestPanel();
+      const revokeUrl = requestPanel?.dataset?.revokeInfoApprovalUrl;
+      if (!revokeUrl) return;
+
+      const formData = new FormData();
+      formData.append('performer_id', checked[0].value);
+
+      revokeInfoApprovalBtn.disabled = true;
+      try {
+        const response = await fetch(revokeUrl, {
+          method: 'POST',
+          headers: { 'X-CSRFToken': csrftoken },
+          body: formData,
+        });
+        const data = await response.json();
+        if (!response.ok || !data.ok) {
+          throw new Error(data?.error || 'Не удалось отменить согласование.');
+        }
+
+        window.__tableSel['info-request-select'] = [];
+        window.__tableSelLast = null;
+        document.body.dispatchEvent(new Event('performers-updated'));
+        document.body.dispatchEvent(new Event('notifications-updated'));
+      } catch (err) {
+        alert(err.message || 'Не удалось отменить согласование.');
+        updateInfoRequestState();
+      }
       return;
     }
 

--- a/projects_app/templates/projects_app/performers_partial.html
+++ b/projects_app/templates/projects_app/performers_partial.html
@@ -618,6 +618,11 @@
       <tbody>
       {% for p in info_request_performers %}
         <tr data-project-id="{{ p.registration_id }}"
+            data-performer-id="{{ p.id }}"
+            data-section-id="{{ p.typical_section_id|default:'' }}"
+            data-employee-user-id="{% if p.employee and p.employee.user_id %}{{ p.employee.user_id }}{% endif %}"
+            data-info-request-sent="{% if p.info_request_sent_at %}1{% else %}0{% endif %}"
+            data-info-approval-status="{{ p.info_approval_status|default:'' }}"
             data-executor="{{ p.executor }}"
             data-asset-name="{{ p.asset_name }}">
           <td class="text-nowrap cell-group-val">
@@ -631,7 +636,7 @@
                        {% if is_expert %}
                          disabled
                        {% endif %}
-                       {% if p.info_request_sent_at %}
+                       {% if p.info_request_sent_at and not is_admin %}
                          disabled
                          title="Строка недоступна: запрос уже отправлен"
                        {% endif %}
@@ -667,6 +672,7 @@
       <div id="info-request-actions"
            class="d-flex align-items-stretch gap-2 products-actions-row"
            data-request-url="{% url 'info_request_approval' %}"
+           data-revoke-info-approval-url="{% url 'revoke_info_request_approval' %}"
            data-create-source-data-url="{% url 'create_source_data_workspace' %}"
            data-source-data-target-url="{% url 'source_data_target_folder_load' %}"
            data-source-data-target-save-url="{% url 'source_data_target_folder_save' %}">
@@ -704,6 +710,14 @@
             <i class="bi bi-gear"></i>
           </button>
         </div>
+        {% if is_admin %}
+          <button type="button"
+                  id="revoke-info-approval-btn"
+                  class="btn btn-outline-danger btn-sm d-none d-flex align-items-center"
+                  disabled>
+            <i class="bi bi-arrow-counterclockwise me-2"></i>Отменить согласование
+          </button>
+        {% endif %}
       </div>
 
       <div class="modal fade" id="info-request-modal" tabindex="-1" aria-hidden="true">

--- a/projects_app/tests.py
+++ b/projects_app/tests.py
@@ -17,7 +17,14 @@ from django.utils import timezone
 from docx import Document
 from docx.enum.text import WD_COLOR_INDEX
 
-from checklists_app.models import ChecklistItem, ChecklistStatus, SourceDataItemFolder, SourceDataSectionFolder, SourceDataWorkspace
+from checklists_app.models import (
+    ChecklistItem,
+    ChecklistStatus,
+    InfoRequestSectionApproval,
+    SourceDataItemFolder,
+    SourceDataSectionFolder,
+    SourceDataWorkspace,
+)
 from classifiers_app.models import BusinessEntityIdentifierRecord, BusinessEntityRecord, LegalEntityRecord, OKSMCountry
 from contacts_app.models import CitizenshipRecord, PersonRecord
 from core.models import CloudStorageSettings
@@ -26,6 +33,7 @@ from letters_app.models import LetterTemplate
 from nextcloud_app.models import NextcloudUserLink
 from notifications_app.models import Notification, NotificationPerformerLink
 from policy_app.models import (
+    ADMIN_GROUP,
     DIRECTOR_GROUP,
     DIRECTION_DIRECTOR_GROUP,
     EXPERT_GROUP,
@@ -4382,6 +4390,168 @@ class ProjectProductLinkSyncTests(TestCase):
         self.assertEqual(edited["text"], "Обновлённая задача")
         self.assertEqual(edited["executor"], "Архивный Исполнитель")
         self.assertEqual(int(edited["progress"]), 75)
+
+
+class InfoRequestApprovalRevokeTests(TestCase):
+    def setUp(self):
+        self.admin_user = get_user_model().objects.create_user(
+            username="info-revoke-admin",
+            password="secret",
+            is_staff=True,
+        )
+        Employee.objects.create(user=self.admin_user, role=ADMIN_GROUP)
+        self.staff_user = get_user_model().objects.create_user(
+            username="info-revoke-staff",
+            password="secret",
+            is_staff=True,
+        )
+        Employee.objects.create(user=self.staff_user, role=PROJECTS_HEAD_GROUP)
+        self.expert_user = get_user_model().objects.create_user(
+            username="info-revoke-expert",
+            password="secret",
+            is_staff=True,
+            first_name="Иван",
+            last_name="Эксперт",
+        )
+        self.expert_employee = Employee.objects.create(
+            user=self.expert_user,
+            patronymic="Иванович",
+            role=EXPERT_GROUP,
+        )
+        self.product = Product.objects.create(
+            short_name="DD",
+            name_en="Due Diligence",
+            name_ru="ДД",
+            consulting_type="Горный",
+            service_category="Аудит",
+            service_subtype="Аудит соответствия стандартам",
+        )
+        self.section = self.product.sections.create(
+            code="FIN",
+            short_name="Finance",
+            short_name_ru="Финансы",
+            name_en="Finance",
+            name_ru="Финансы",
+            accounting_type="Раздел",
+            position=1,
+        )
+        self.project = ProjectRegistration.objects.create(
+            number=6101,
+            type=self.product,
+            name="Откат согласования",
+            year=2026,
+        )
+        self.work = WorkVolume.objects.create(
+            project=self.project,
+            name="Asset A",
+            asset_name="Asset A",
+        )
+        self.performer = Performer.objects.create(
+            work_item=self.work,
+            registration=self.project,
+            asset_name="Asset A",
+            executor=Performer.employee_full_name(self.expert_employee),
+            employee=self.expert_employee,
+            typical_section=self.section,
+            participation_response=Performer.ParticipationResponse.CONFIRMED,
+            info_request_sent_at=timezone.now() - timedelta(hours=2),
+            info_request_deadline_at=timezone.now() + timedelta(hours=46),
+            info_approval_status=Performer.InfoApprovalStatus.APPROVED,
+            info_approval_at=timezone.now() - timedelta(hours=1),
+        )
+        self.checklist_item = ChecklistItem.objects.create(
+            project=self.project,
+            section=self.section,
+            code="FIN",
+            number=1,
+            short_name="ОСВ",
+            name="Оборотно-сальдовая ведомость",
+        )
+        self.notification = Notification.objects.create(
+            notification_type=Notification.NotificationType.PROJECT_INFO_REQUEST_APPROVAL,
+            related_section=Notification.RelatedSection.CHECKLISTS,
+            recipient=self.expert_user,
+            project=self.project,
+            title_text="Согласуйте запрос",
+            is_read=True,
+            is_processed=True,
+            action_at=timezone.now() - timedelta(hours=1),
+            action_by=self.expert_user,
+            action_choice=Notification.ActionChoice.APPROVED,
+        )
+        NotificationPerformerLink.objects.create(
+            notification=self.notification,
+            performer=self.performer,
+        )
+        InfoRequestSectionApproval.objects.create(
+            project=self.project,
+            section=self.section,
+            approved_by=self.expert_user,
+            approved_at=timezone.now() - timedelta(hours=1),
+        )
+
+    def test_admin_can_select_approved_info_request_row(self):
+        self.client.force_login(self.admin_user)
+
+        response = self.client.get(reverse("performers_partial"))
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode("utf-8")
+        checkbox_start = content.index(f'id="info-request-sel-{self.performer.pk}"')
+        checkbox_html = content[checkbox_start:content.index("aria-label", checkbox_start)]
+        self.assertNotIn("disabled", checkbox_html)
+        self.assertIn('data-info-approval-status="approved"', content)
+        self.assertIn('id="revoke-info-approval-btn"', content)
+
+    def test_revoke_info_request_approval_requires_admin_role(self):
+        self.client.force_login(self.staff_user)
+
+        response = self.client.post(
+            reverse("revoke_info_request_approval"),
+            {"performer_id": self.performer.pk},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.performer.refresh_from_db()
+        self.assertEqual(self.performer.info_approval_status, Performer.InfoApprovalStatus.APPROVED)
+
+    def test_admin_revoke_restores_expert_pending_checklist_editing(self):
+        self.client.force_login(self.admin_user)
+
+        response = self.client.post(
+            reverse("revoke_info_request_approval"),
+            {"performer_id": self.performer.pk},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["ok"])
+        self.performer.refresh_from_db()
+        self.notification.refresh_from_db()
+        self.assertEqual(self.performer.info_approval_status, "")
+        self.assertIsNone(self.performer.info_approval_at)
+        self.assertFalse(self.notification.is_processed)
+        self.assertIsNone(self.notification.action_at)
+        self.assertIsNone(self.notification.action_by)
+        self.assertEqual(self.notification.action_choice, "")
+        self.assertFalse(
+            InfoRequestSectionApproval.objects.filter(
+                project=self.project,
+                section=self.section,
+                approved_by=self.expert_user,
+            ).exists()
+        )
+
+        self.client.force_login(self.expert_user)
+        grid_response = self.client.get(reverse("checklists_app:grid_data"), {
+            "project_uid": self.project.short_uid,
+            "asset": "all",
+            "section": str(self.section.pk),
+        })
+        self.assertEqual(grid_response.status_code, 200)
+        payload = grid_response.json()
+        self.assertIn(self.section.pk, payload["ui"]["pendingSectionIds"])
+        self.assertIn(self.section.pk, payload["ui"]["editableSectionIds"])
+        self.assertIn(reverse("checklists_app:item_form_create"), payload["ui"]["createUrl"])
 
 
 class ExpertProjectVisibilityTests(TestCase):

--- a/projects_app/urls.py
+++ b/projects_app/urls.py
@@ -46,6 +46,7 @@ urlpatterns = [
     path("projects/performers/request-confirmation/", views.participation_request, name="participation_request"),
     path("projects/performers/send-contract/", views.contract_request, name="contract_request"),
     path("projects/performers/request-info-approval/", views.info_request_approval, name="info_request_approval"),
+    path("projects/performers/revoke-info-approval/", views.revoke_info_request_approval, name="revoke_info_request_approval"),
     path("projects/performers/payment-request/", views.payment_request, name="payment_request"),
     path(
         "projects/performers/payment-paid-toggle/",

--- a/projects_app/views.py
+++ b/projects_app/views.py
@@ -144,6 +144,16 @@ def staff_required(user):
     return user.is_authenticated and user.is_staff
 
 
+def _is_admin_user(user):
+    if not staff_required(user):
+        return False
+    employee = getattr(user, "employee_profile", None)
+    return (
+        getattr(employee, "role", "") == ADMIN_GROUP
+        or user.groups.filter(name=ADMIN_GROUP).exists()
+    )
+
+
 def _normalize_contract_person_name(value):
     return " ".join(str(value or "").split()).strip()
 
@@ -1788,6 +1798,7 @@ def _payment_request_context(user=None, *, payment_request_performers_qs=None, p
 def _performers_context(user=None):
     expert_project_ids = _confirmed_project_ids_for_expert(user)
     is_expert = expert_project_ids is not None
+    is_admin = _is_admin_user(user)
     active_participation_statuses = ["Не начат", "В работе"]
     registration_products_prefetch = models.Prefetch(
         "registration__product_links",
@@ -2058,6 +2069,7 @@ def _performers_context(user=None):
         "primary_cloud_storage_label": get_primary_cloud_storage_label(),
         "user_is_direction_head": user_is_direction_head,
         "is_expert": is_expert,
+        "is_admin": is_admin,
         "has_active_smtp_connection": has_active_smtp_connection,
     }
 
@@ -3234,6 +3246,85 @@ def info_request_approval(request):
             "deadline_at": timezone.localtime(deadline_at).strftime("%d.%m.%Y %H:%M"),
         }
     )
+
+
+@login_required
+@user_passes_test(staff_required)
+@require_POST
+def revoke_info_request_approval(request):
+    if not _is_admin_user(request.user):
+        return JsonResponse({"ok": False, "error": "Действие доступно только администратору."}, status=403)
+
+    performer_id = (request.POST.get("performer_id") or "").strip()
+    if not performer_id:
+        return JsonResponse({"ok": False, "error": "Не выбрана строка для отката."}, status=400)
+
+    from checklists_app.models import InfoRequestSectionApproval
+    from notifications_app.models import Notification, NotificationPerformerLink
+
+    with transaction.atomic():
+        performer = get_object_or_404(
+            Performer.objects.select_for_update(),
+            pk=performer_id,
+        )
+        if performer.info_approval_status != Performer.InfoApprovalStatus.APPROVED:
+            return JsonResponse({"ok": False, "error": "По выбранной строке нет согласования для отмены."}, status=400)
+        if not performer.employee_id or not getattr(performer.employee, "user_id", None):
+            return JsonResponse({"ok": False, "error": "У выбранной строки не найден эксперт."}, status=400)
+        if not performer.typical_section_id:
+            return JsonResponse({"ok": False, "error": "У выбранной строки не указан типовой раздел."}, status=400)
+
+        expert_user = performer.employee.user
+        project = performer.registration
+        section = performer.typical_section
+
+        affected_performers = (
+            Performer.objects
+            .select_for_update()
+            .filter(
+                registration=project,
+                employee=performer.employee,
+                typical_section=section,
+                info_request_sent_at__isnull=False,
+            )
+        )
+        affected_ids = list(affected_performers.values_list("pk", flat=True))
+        notification_ids = list(
+            NotificationPerformerLink.objects
+            .filter(
+                performer_id__in=affected_ids,
+                notification__notification_type=Notification.NotificationType.PROJECT_INFO_REQUEST_APPROVAL,
+                notification__project=project,
+                notification__recipient=expert_user,
+            )
+            .values_list("notification_id", flat=True)
+            .distinct()
+        )
+        if not notification_ids:
+            return JsonResponse({"ok": False, "error": "Не найден связанный запрос согласования."}, status=400)
+
+        InfoRequestSectionApproval.objects.filter(
+            project=project,
+            section=section,
+            approved_by=expert_user,
+        ).delete()
+        performers_updated = affected_performers.update(
+            info_approval_status="",
+            info_approval_at=None,
+        )
+        notifications_updated = Notification.objects.filter(pk__in=notification_ids).update(
+            is_processed=False,
+            action_at=None,
+            action_by=None,
+            action_choice="",
+            updated_at=timezone.now(),
+        )
+
+    return JsonResponse({
+        "ok": True,
+        "performers_updated": performers_updated,
+        "notifications_updated": notifications_updated,
+    })
 
 
 @login_required

--- a/staticfiles/core/js/performers-panels.js
+++ b/staticfiles/core/js/performers-panels.js
@@ -599,16 +599,30 @@
   function getCreateSourceDataBtn() {
     return pane()?.querySelector('#create-source-data-btn');
   }
+  function getRevokeInfoApprovalBtn() {
+    return pane()?.querySelector('#revoke-info-approval-btn');
+  }
 
   function getSelectedInfoRequestProjectId() {
     const filter = window.__infoRequestProjectFilter;
     if (filter && filter.length === 1 && filter[0] !== '__all__') return filter[0];
     return null;
   }
+  function getInfoRequestRowForCheck(checkbox) {
+    return checkbox?.closest('tr[data-project-id]') || null;
+  }
+  function isInfoRequestRowSent(row) {
+    return row?.dataset?.infoRequestSent === '1';
+  }
+  function isInfoRequestRowApproved(row) {
+    return row?.dataset?.infoApprovalStatus === 'approved';
+  }
 
   function updateInfoRequestState() {
     const boxes = getVisibleInfoRequestChecks();
-    const checkedCount = boxes.filter(b => b.checked).length;
+    const checked = boxes.filter(b => b.checked);
+    const checkedCount = checked.length;
+    const checkedRows = checked.map(getInfoRequestRowForCheck).filter(Boolean);
     const master = getInfoRequestMaster();
     if (master) {
       master.checked = boxes.length > 0 && checkedCount === boxes.length;
@@ -617,11 +631,22 @@
     updateRowHighlight('info-request-select');
 
     const requestBtn = getInfoRequestBtn();
-    if (requestBtn) requestBtn.disabled = checkedCount === 0;
+    if (requestBtn) {
+      const canRequestApproval = checkedCount > 0 && checkedRows.every((row) => !isInfoRequestRowSent(row));
+      requestBtn.disabled = !canRequestApproval;
+    }
+
+    const revokeBtn = getRevokeInfoApprovalBtn();
+    if (revokeBtn) {
+      const hasApprovedSelection = checkedRows.some(isInfoRequestRowApproved);
+      const canRevoke = checkedCount === 1 && checkedRows.length === 1 && isInfoRequestRowApproved(checkedRows[0]);
+      revokeBtn.classList.toggle('d-none', !hasApprovedSelection);
+      revokeBtn.disabled = !canRevoke;
+    }
 
     const controls = getInfoRequestDeadlineControls();
     if (controls) {
-      const show = checkedCount > 0;
+      const show = checkedCount > 0 && checkedRows.every((row) => !isInfoRequestRowSent(row));
       controls.classList.toggle('invisible', !show);
       controls.classList.toggle('pe-none', !show);
     }
@@ -2367,6 +2392,41 @@
       ensurePerformerActionsVisibility();
 
       await htmx.ajax('GET', url, { target: '#performers-modal .modal-content', swap: 'innerHTML' });
+      return;
+    }
+
+    const revokeInfoApprovalBtn = e.target.closest('#revoke-info-approval-btn');
+    if (revokeInfoApprovalBtn && root.contains(revokeInfoApprovalBtn)) {
+      const checked = getVisibleInfoRequestChecks().filter((cb) => cb.checked);
+      if (checked.length !== 1 || revokeInfoApprovalBtn.disabled) return;
+
+      const requestPanel = getInfoRequestPanel();
+      const revokeUrl = requestPanel?.dataset?.revokeInfoApprovalUrl;
+      if (!revokeUrl) return;
+
+      const formData = new FormData();
+      formData.append('performer_id', checked[0].value);
+
+      revokeInfoApprovalBtn.disabled = true;
+      try {
+        const response = await fetch(revokeUrl, {
+          method: 'POST',
+          headers: { 'X-CSRFToken': csrftoken },
+          body: formData,
+        });
+        const data = await response.json();
+        if (!response.ok || !data.ok) {
+          throw new Error(data?.error || 'Не удалось отменить согласование.');
+        }
+
+        window.__tableSel['info-request-select'] = [];
+        window.__tableSelLast = null;
+        document.body.dispatchEvent(new Event('performers-updated'));
+        document.body.dispatchEvent(new Event('notifications-updated'));
+      } catch (err) {
+        alert(err.message || 'Не удалось отменить согласование.');
+        updateInfoRequestState();
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- Updates checklist grid behavior: keeps create actions for pending expert sections and renumbers checklist items after delete/reorder/batch edits.
- Adds admin flow to revoke approved performer info requests, with UI wiring, endpoint handling, and regression tests.
- Includes latest branch changes for report structure management, Nextcloud contract share cleanup/signal fixes, notifications, and dev PostgreSQL preflight updates.
## Test plan
- CI/CD checks should run on this pull request.