### PR TITLE
Update checklist and performer approval flows for CI

### DIFF
--- a/projects_app/tests.py
+++ b/projects_app/tests.py
@@ -4446,6 +4446,8 @@ class InfoRequestApprovalRevokeTests(TestCase):
             name="Asset A",
             asset_name="Asset A",
         )
+        self.info_request_sent_at = timezone.now() - timedelta(hours=2)
+        self.info_request_deadline_at = timezone.now() + timedelta(hours=46)
         self.performer = Performer.objects.create(
             work_item=self.work,
             registration=self.project,
@@ -4454,8 +4456,8 @@ class InfoRequestApprovalRevokeTests(TestCase):
             employee=self.expert_employee,
             typical_section=self.section,
             participation_response=Performer.ParticipationResponse.CONFIRMED,
-            info_request_sent_at=timezone.now() - timedelta(hours=2),
-            info_request_deadline_at=timezone.now() + timedelta(hours=46),
+            info_request_sent_at=self.info_request_sent_at,
+            info_request_deadline_at=self.info_request_deadline_at,
             info_approval_status=Performer.InfoApprovalStatus.APPROVED,
             info_approval_at=timezone.now() - timedelta(hours=1),
         )
@@ -4473,6 +4475,8 @@ class InfoRequestApprovalRevokeTests(TestCase):
             recipient=self.expert_user,
             project=self.project,
             title_text="Согласуйте запрос",
+            sent_at=self.info_request_sent_at,
+            deadline_at=self.info_request_deadline_at,
             is_read=True,
             is_processed=True,
             action_at=timezone.now() - timedelta(hours=1),
@@ -4552,6 +4556,69 @@ class InfoRequestApprovalRevokeTests(TestCase):
         self.assertIn(self.section.pk, payload["ui"]["pendingSectionIds"])
         self.assertIn(self.section.pk, payload["ui"]["editableSectionIds"])
         self.assertIn(reverse("checklists_app:item_form_create"), payload["ui"]["createUrl"])
+
+    def test_admin_revoke_removes_manager_section_approval(self):
+        InfoRequestSectionApproval.objects.filter(
+            project=self.project,
+            section=self.section,
+            approved_by=self.expert_user,
+        ).delete()
+        InfoRequestSectionApproval.objects.create(
+            project=self.project,
+            section=self.section,
+            approved_by=self.staff_user,
+            approved_at=timezone.now() - timedelta(hours=1),
+        )
+        self.notification.action_by = self.staff_user
+        self.notification.save(update_fields=["action_by"])
+        self.client.force_login(self.admin_user)
+
+        response = self.client.post(
+            reverse("revoke_info_request_approval"),
+            {"performer_id": self.performer.pk},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(
+            InfoRequestSectionApproval.objects.filter(
+                project=self.project,
+                section=self.section,
+                approved_by=self.staff_user,
+            ).exists()
+        )
+
+    def test_admin_revoke_does_not_reopen_historical_notifications(self):
+        old_notification = Notification.objects.create(
+            notification_type=Notification.NotificationType.PROJECT_INFO_REQUEST_APPROVAL,
+            related_section=Notification.RelatedSection.CHECKLISTS,
+            recipient=self.expert_user,
+            project=self.project,
+            title_text="Старый запрос",
+            sent_at=self.info_request_sent_at - timedelta(days=10),
+            deadline_at=self.info_request_deadline_at - timedelta(days=10),
+            is_read=True,
+            is_processed=True,
+            action_at=timezone.now() - timedelta(days=9),
+            action_by=self.expert_user,
+            action_choice=Notification.ActionChoice.APPROVED,
+        )
+        NotificationPerformerLink.objects.create(
+            notification=old_notification,
+            performer=self.performer,
+        )
+        self.client.force_login(self.admin_user)
+
+        response = self.client.post(
+            reverse("revoke_info_request_approval"),
+            {"performer_id": self.performer.pk},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.notification.refresh_from_db()
+        old_notification.refresh_from_db()
+        self.assertFalse(self.notification.is_processed)
+        self.assertTrue(old_notification.is_processed)
+        self.assertEqual(old_notification.action_choice, Notification.ActionChoice.APPROVED)
 
 
 class ExpertProjectVisibilityTests(TestCase):

--- a/projects_app/views.py
+++ b/projects_app/views.py
@@ -3278,35 +3278,54 @@ def revoke_info_request_approval(request):
         project = performer.registration
         section = performer.typical_section
 
+        current_notification_ids = list(
+            Notification.objects
+            .filter(
+                notification_type=Notification.NotificationType.PROJECT_INFO_REQUEST_APPROVAL,
+                project=project,
+                recipient=expert_user,
+                sent_at=performer.info_request_sent_at,
+                deadline_at=performer.info_request_deadline_at,
+                performer_links__performer=performer,
+            )
+            .values_list("pk", flat=True)
+            .distinct()
+        )
+        if not current_notification_ids:
+            return JsonResponse({"ok": False, "error": "Не найден связанный запрос согласования."}, status=400)
+
+        current_notifications = list(
+            Notification.objects
+            .select_for_update()
+            .filter(pk__in=current_notification_ids)
+        )
+        notification_ids = [notification.pk for notification in current_notifications]
+        affected_ids = list(
+            NotificationPerformerLink.objects
+            .filter(
+                notification_id__in=notification_ids,
+                performer__registration=project,
+                performer__employee=performer.employee,
+                performer__typical_section=section,
+            )
+            .values_list("performer_id", flat=True)
+            .distinct()
+        )
         affected_performers = (
             Performer.objects
             .select_for_update()
-            .filter(
-                registration=project,
-                employee=performer.employee,
-                typical_section=section,
-                info_request_sent_at__isnull=False,
-            )
+            .filter(pk__in=affected_ids)
         )
-        affected_ids = list(affected_performers.values_list("pk", flat=True))
-        notification_ids = list(
-            NotificationPerformerLink.objects
-            .filter(
-                performer_id__in=affected_ids,
-                notification__notification_type=Notification.NotificationType.PROJECT_INFO_REQUEST_APPROVAL,
-                notification__project=project,
-                notification__recipient=expert_user,
-            )
-            .values_list("notification_id", flat=True)
-            .distinct()
+        approver_ids = {expert_user.pk}
+        approver_ids.update(
+            notification.action_by_id
+            for notification in current_notifications
+            if notification.action_by_id
         )
-        if not notification_ids:
-            return JsonResponse({"ok": False, "error": "Не найден связанный запрос согласования."}, status=400)
-
         InfoRequestSectionApproval.objects.filter(
             project=project,
             section=section,
-            approved_by=expert_user,
+            approved_by_id__in=approver_ids,
         ).delete()
         performers_updated = affected_performers.update(
             info_approval_status="",


### PR DESCRIPTION
## Summary
- Updates checklist and performer approval flows around project info request approvals.
- Fixes approval revoke logic so it targets the current approval notification and does not reopen historical notifications.
- Expands regression coverage for admin revoke behavior and section approval cleanup.
## Test plan
- Not run locally; CI/CD should run from this pull request.