### PR TITLE
Fix info request approval revoke flow

### DIFF
--- a/contracts_app/templates/contracts_app/execution_panel.html
+++ b/contracts_app/templates/contracts_app/execution_panel.html
@@ -16,4 +16,4 @@
 
   </div>
 </div>
-<script src="{% static 'core/js/performers-panels.js' %}?v=20260604-1" defer></script>
+<script src="{% static 'core/js/performers-panels.js' %}?v=20260703-2" defer></script>

--- a/core/static/core/js/performers-panels.js
+++ b/core/static/core/js/performers-panels.js
@@ -617,6 +617,19 @@
   function isInfoRequestRowApproved(row) {
     return row?.dataset?.infoApprovalStatus === 'approved';
   }
+  function infoRequestRevokeSelectionState(checkedRows) {
+    const approvedRows = checkedRows.filter(isInfoRequestRowApproved);
+    const hasApprovedSelection = approvedRows.length > 0;
+    if (!checkedRows.length || approvedRows.length !== checkedRows.length) {
+      return { hasApprovedSelection, canRevoke: false };
+    }
+    const executorSet = new Set(checkedRows.map((row) => row.dataset.employeeUserId || row.dataset.executor || ''));
+    const projectSet = new Set(checkedRows.map((row) => row.dataset.projectId || ''));
+    return {
+      hasApprovedSelection,
+      canRevoke: executorSet.size === 1 && projectSet.size === 1,
+    };
+  }
 
   function updateInfoRequestState() {
     const boxes = getVisibleInfoRequestChecks();
@@ -638,10 +651,9 @@
 
     const revokeBtn = getRevokeInfoApprovalBtn();
     if (revokeBtn) {
-      const hasApprovedSelection = checkedRows.some(isInfoRequestRowApproved);
-      const canRevoke = checkedCount === 1 && checkedRows.length === 1 && isInfoRequestRowApproved(checkedRows[0]);
-      revokeBtn.classList.toggle('d-none', !hasApprovedSelection);
-      revokeBtn.disabled = !canRevoke;
+      const revokeState = infoRequestRevokeSelectionState(checkedRows);
+      revokeBtn.classList.toggle('d-none', !revokeState.hasApprovedSelection);
+      revokeBtn.disabled = !revokeState.canRevoke;
     }
 
     const controls = getInfoRequestDeadlineControls();
@@ -2398,14 +2410,14 @@
     const revokeInfoApprovalBtn = e.target.closest('#revoke-info-approval-btn');
     if (revokeInfoApprovalBtn && root.contains(revokeInfoApprovalBtn)) {
       const checked = getVisibleInfoRequestChecks().filter((cb) => cb.checked);
-      if (checked.length !== 1 || revokeInfoApprovalBtn.disabled) return;
+      if (!checked.length || revokeInfoApprovalBtn.disabled) return;
 
       const requestPanel = getInfoRequestPanel();
       const revokeUrl = requestPanel?.dataset?.revokeInfoApprovalUrl;
       if (!revokeUrl) return;
 
       const formData = new FormData();
-      formData.append('performer_id', checked[0].value);
+      checked.forEach((cb) => formData.append('performer_ids[]', cb.value));
 
       revokeInfoApprovalBtn.disabled = true;
       try {

--- a/projects_app/templates/projects_app/panel.html
+++ b/projects_app/templates/projects_app/panel.html
@@ -124,7 +124,7 @@
     </div>
   </div>
 
-  <script src="{% static 'core/js/performers-panels.js' %}?v=20260604-1" defer></script>
+  <script src="{% static 'core/js/performers-panels.js' %}?v=20260703-2" defer></script>
   <script>
     function showProjectsModal() {
       const modalEl = document.getElementById('projects-modal');

--- a/projects_app/tests.py
+++ b/projects_app/tests.py
@@ -4494,6 +4494,48 @@ class InfoRequestApprovalRevokeTests(TestCase):
             approved_at=timezone.now() - timedelta(hours=1),
         )
 
+    def _create_approved_info_request_row(self, employee, section, suffix):
+        sent_at = timezone.now() - timedelta(hours=2)
+        deadline_at = timezone.now() + timedelta(hours=46)
+        performer = Performer.objects.create(
+            work_item=self.work,
+            registration=self.project,
+            asset_name=f"Asset {suffix}",
+            executor=Performer.employee_full_name(employee),
+            employee=employee,
+            typical_section=section,
+            participation_response=Performer.ParticipationResponse.CONFIRMED,
+            info_request_sent_at=sent_at,
+            info_request_deadline_at=deadline_at,
+            info_approval_status=Performer.InfoApprovalStatus.APPROVED,
+            info_approval_at=timezone.now() - timedelta(hours=1),
+        )
+        notification = Notification.objects.create(
+            notification_type=Notification.NotificationType.PROJECT_INFO_REQUEST_APPROVAL,
+            related_section=Notification.RelatedSection.CHECKLISTS,
+            recipient=employee.user,
+            project=self.project,
+            title_text="Согласуйте запрос",
+            sent_at=sent_at,
+            deadline_at=deadline_at,
+            is_read=True,
+            is_processed=True,
+            action_at=timezone.now() - timedelta(hours=1),
+            action_by=employee.user,
+            action_choice=Notification.ActionChoice.APPROVED,
+        )
+        NotificationPerformerLink.objects.create(
+            notification=notification,
+            performer=performer,
+        )
+        InfoRequestSectionApproval.objects.create(
+            project=self.project,
+            section=section,
+            approved_by=employee.user,
+            approved_at=timezone.now() - timedelta(hours=1),
+        )
+        return performer, notification
+
     def test_admin_can_select_approved_info_request_row(self):
         self.client.force_login(self.admin_user)
 
@@ -4556,6 +4598,77 @@ class InfoRequestApprovalRevokeTests(TestCase):
         self.assertIn(self.section.pk, payload["ui"]["pendingSectionIds"])
         self.assertIn(self.section.pk, payload["ui"]["editableSectionIds"])
         self.assertIn(reverse("checklists_app:item_form_create"), payload["ui"]["createUrl"])
+
+    def test_admin_revoke_single_executor_row_revokes_all_executor_sections(self):
+        second_section = self.product.sections.create(
+            code="LEG",
+            short_name="Legal",
+            short_name_ru="Право",
+            name_en="Legal",
+            name_ru="Право",
+            accounting_type="Раздел",
+            position=2,
+        )
+        second_performer, second_notification = self._create_approved_info_request_row(
+            self.expert_employee,
+            second_section,
+            "B",
+        )
+        self.client.force_login(self.admin_user)
+
+        response = self.client.post(
+            reverse("revoke_info_request_approval"),
+            {"performer_ids[]": [self.performer.pk]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["performers_updated"], 2)
+        self.performer.refresh_from_db()
+        second_performer.refresh_from_db()
+        self.notification.refresh_from_db()
+        second_notification.refresh_from_db()
+        self.assertEqual(self.performer.info_approval_status, "")
+        self.assertEqual(second_performer.info_approval_status, "")
+        self.assertFalse(self.notification.is_processed)
+        self.assertFalse(second_notification.is_processed)
+        self.assertFalse(
+            InfoRequestSectionApproval.objects.filter(
+                project=self.project,
+                section__in=[self.section, second_section],
+                approved_by=self.expert_user,
+            ).exists()
+        )
+
+    def test_admin_revoke_rejects_rows_from_different_executors(self):
+        other_user = get_user_model().objects.create_user(
+            username="info-revoke-other-expert",
+            password="secret",
+            is_staff=True,
+            first_name="Петр",
+            last_name="Другой",
+        )
+        other_employee = Employee.objects.create(
+            user=other_user,
+            patronymic="Петрович",
+            role=EXPERT_GROUP,
+        )
+        other_performer, _ = self._create_approved_info_request_row(
+            other_employee,
+            self.section,
+            "C",
+        )
+        self.client.force_login(self.admin_user)
+
+        response = self.client.post(
+            reverse("revoke_info_request_approval"),
+            {"performer_ids[]": [self.performer.pk, other_performer.pk]},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.performer.refresh_from_db()
+        other_performer.refresh_from_db()
+        self.assertEqual(self.performer.info_approval_status, Performer.InfoApprovalStatus.APPROVED)
+        self.assertEqual(other_performer.info_approval_status, Performer.InfoApprovalStatus.APPROVED)
 
     def test_admin_revoke_removes_manager_section_approval(self):
         InfoRequestSectionApproval.objects.filter(

--- a/projects_app/views.py
+++ b/projects_app/views.py
@@ -3255,42 +3255,74 @@ def revoke_info_request_approval(request):
     if not _is_admin_user(request.user):
         return JsonResponse({"ok": False, "error": "Действие доступно только администратору."}, status=403)
 
-    performer_id = (request.POST.get("performer_id") or "").strip()
-    if not performer_id:
-        return JsonResponse({"ok": False, "error": "Не выбрана строка для отката."}, status=400)
+    raw_ids = (
+        request.POST.getlist("performer_ids[]")
+        or request.POST.getlist("performer_ids")
+        or [request.POST.get("performer_id")]
+    )
+    try:
+        performer_ids = sorted({int(value) for value in raw_ids if str(value or "").strip()})
+    except (TypeError, ValueError):
+        return JsonResponse({"ok": False, "error": "Передан некорректный список строк."}, status=400)
+    if not performer_ids:
+        return JsonResponse({"ok": False, "error": "Не выбраны строки для отката."}, status=400)
 
     from checklists_app.models import InfoRequestSectionApproval
-    from notifications_app.models import Notification, NotificationPerformerLink
+    from notifications_app.models import Notification
 
     with transaction.atomic():
-        performer = get_object_or_404(
-            Performer.objects.select_for_update(),
-            pk=performer_id,
+        selected_performers = list(
+            Performer.objects
+            .select_for_update()
+            .filter(pk__in=performer_ids)
         )
-        if performer.info_approval_status != Performer.InfoApprovalStatus.APPROVED:
-            return JsonResponse({"ok": False, "error": "По выбранной строке нет согласования для отмены."}, status=400)
+        if len(selected_performers) != len(performer_ids):
+            return JsonResponse({"ok": False, "error": "Одна или несколько выбранных строк не найдены."}, status=404)
+        if any(p.info_approval_status != Performer.InfoApprovalStatus.APPROVED for p in selected_performers):
+            return JsonResponse({"ok": False, "error": "Откат доступен только для согласованных строк."}, status=400)
+
+        project_ids = {p.registration_id for p in selected_performers}
+        employee_ids = {p.employee_id for p in selected_performers}
+        if len(project_ids) != 1:
+            return JsonResponse({"ok": False, "error": "Выберите строки в рамках одного проекта."}, status=400)
+        if len(employee_ids) != 1:
+            return JsonResponse({"ok": False, "error": "Выберите строки одного исполнителя."}, status=400)
+
+        performer = selected_performers[0]
         if not performer.employee_id or not getattr(performer.employee, "user_id", None):
-            return JsonResponse({"ok": False, "error": "У выбранной строки не найден эксперт."}, status=400)
-        if not performer.typical_section_id:
-            return JsonResponse({"ok": False, "error": "У выбранной строки не указан типовой раздел."}, status=400)
+            return JsonResponse({"ok": False, "error": "У выбранных строк не найден эксперт."}, status=400)
 
         expert_user = performer.employee.user
         project = performer.registration
-        section = performer.typical_section
-
-        current_notification_ids = list(
-            Notification.objects
+        target_performers = list(
+            Performer.objects
+            .select_for_update()
             .filter(
-                notification_type=Notification.NotificationType.PROJECT_INFO_REQUEST_APPROVAL,
-                project=project,
-                recipient=expert_user,
-                sent_at=performer.info_request_sent_at,
-                deadline_at=performer.info_request_deadline_at,
-                performer_links__performer=performer,
+                registration=project,
+                employee=performer.employee,
+                info_approval_status=Performer.InfoApprovalStatus.APPROVED,
             )
-            .values_list("pk", flat=True)
-            .distinct()
         )
+        section_ids = {p.typical_section_id for p in target_performers if p.typical_section_id}
+        if not section_ids:
+            return JsonResponse({"ok": False, "error": "У выбранных строк не указаны типовые разделы."}, status=400)
+
+        current_notification_ids = set()
+        for target in target_performers:
+            ids = (
+                Notification.objects
+                .filter(
+                    notification_type=Notification.NotificationType.PROJECT_INFO_REQUEST_APPROVAL,
+                    project=project,
+                    recipient=expert_user,
+                    sent_at=target.info_request_sent_at,
+                    deadline_at=target.info_request_deadline_at,
+                    performer_links__performer=target,
+                )
+                .values_list("pk", flat=True)
+                .distinct()
+            )
+            current_notification_ids.update(ids)
         if not current_notification_ids:
             return JsonResponse({"ok": False, "error": "Не найден связанный запрос согласования."}, status=400)
 
@@ -3300,22 +3332,6 @@ def revoke_info_request_approval(request):
             .filter(pk__in=current_notification_ids)
         )
         notification_ids = [notification.pk for notification in current_notifications]
-        affected_ids = list(
-            NotificationPerformerLink.objects
-            .filter(
-                notification_id__in=notification_ids,
-                performer__registration=project,
-                performer__employee=performer.employee,
-                performer__typical_section=section,
-            )
-            .values_list("performer_id", flat=True)
-            .distinct()
-        )
-        affected_performers = (
-            Performer.objects
-            .select_for_update()
-            .filter(pk__in=affected_ids)
-        )
         approver_ids = {expert_user.pk}
         approver_ids.update(
             notification.action_by_id
@@ -3324,12 +3340,17 @@ def revoke_info_request_approval(request):
         )
         InfoRequestSectionApproval.objects.filter(
             project=project,
-            section=section,
+            section_id__in=section_ids,
             approved_by_id__in=approver_ids,
         ).delete()
-        performers_updated = affected_performers.update(
-            info_approval_status="",
-            info_approval_at=None,
+        performers_updated = (
+            Performer.objects
+            .select_for_update()
+            .filter(pk__in=[p.pk for p in target_performers])
+            .update(
+                info_approval_status="",
+                info_approval_at=None,
+            )
         )
         notifications_updated = Notification.objects.filter(pk__in=notification_ids).update(
             is_processed=False,

--- a/staticfiles/core/js/performers-panels.js
+++ b/staticfiles/core/js/performers-panels.js
@@ -617,6 +617,19 @@
   function isInfoRequestRowApproved(row) {
     return row?.dataset?.infoApprovalStatus === 'approved';
   }
+  function infoRequestRevokeSelectionState(checkedRows) {
+    const approvedRows = checkedRows.filter(isInfoRequestRowApproved);
+    const hasApprovedSelection = approvedRows.length > 0;
+    if (!checkedRows.length || approvedRows.length !== checkedRows.length) {
+      return { hasApprovedSelection, canRevoke: false };
+    }
+    const executorSet = new Set(checkedRows.map((row) => row.dataset.employeeUserId || row.dataset.executor || ''));
+    const projectSet = new Set(checkedRows.map((row) => row.dataset.projectId || ''));
+    return {
+      hasApprovedSelection,
+      canRevoke: executorSet.size === 1 && projectSet.size === 1,
+    };
+  }
 
   function updateInfoRequestState() {
     const boxes = getVisibleInfoRequestChecks();
@@ -638,10 +651,9 @@
 
     const revokeBtn = getRevokeInfoApprovalBtn();
     if (revokeBtn) {
-      const hasApprovedSelection = checkedRows.some(isInfoRequestRowApproved);
-      const canRevoke = checkedCount === 1 && checkedRows.length === 1 && isInfoRequestRowApproved(checkedRows[0]);
-      revokeBtn.classList.toggle('d-none', !hasApprovedSelection);
-      revokeBtn.disabled = !canRevoke;
+      const revokeState = infoRequestRevokeSelectionState(checkedRows);
+      revokeBtn.classList.toggle('d-none', !revokeState.hasApprovedSelection);
+      revokeBtn.disabled = !revokeState.canRevoke;
     }
 
     const controls = getInfoRequestDeadlineControls();
@@ -2398,14 +2410,14 @@
     const revokeInfoApprovalBtn = e.target.closest('#revoke-info-approval-btn');
     if (revokeInfoApprovalBtn && root.contains(revokeInfoApprovalBtn)) {
       const checked = getVisibleInfoRequestChecks().filter((cb) => cb.checked);
-      if (checked.length !== 1 || revokeInfoApprovalBtn.disabled) return;
+      if (!checked.length || revokeInfoApprovalBtn.disabled) return;
 
       const requestPanel = getInfoRequestPanel();
       const revokeUrl = requestPanel?.dataset?.revokeInfoApprovalUrl;
       if (!revokeUrl) return;
 
       const formData = new FormData();
-      formData.append('performer_id', checked[0].value);
+      checked.forEach((cb) => formData.append('performer_ids[]', cb.value));
 
       revokeInfoApprovalBtn.disabled = true;
       try {


### PR DESCRIPTION
## Summary
- Исправлена логика кнопки «Отменить согласование»: она активна для нескольких согласованных строк одного исполнителя и неактивна для разных исполнителей.
- Backend теперь проверяет выбранные строки и откатывает все согласованные разделы выбранного исполнителя в проекте.
- Добавлены регрессионные тесты и обновлен cache-busting для `performers-panels.js`.
## Test plan
- `python3 manage.py test projects_app.tests.InfoRequestApprovalRevokeTests --keepdb`
- CI/CD checks should run on this pull request.